### PR TITLE
Use the correct param for exitMarket call

### DIFF
--- a/src/components/Dashboard/Market/SupplyMarket.js
+++ b/src/components/Dashboard/Market/SupplyMarket.js
@@ -53,7 +53,7 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }) {
         setIsCollateralEnable(true);
         setIsCollateralConfirm(true);
         await comptrollerContract.methods
-          .exitMarket([r.vtokenAddress])
+          .exitMarket(r.vtokenAddress)
           .send({ from: account });
         setIsCollateralConfirm(false);
       } else {


### PR DESCRIPTION
**Problem:** The call to comptroller.methods.exitMarket in the supply dashboard uses an array of addresses as an argument. In reality, the contract ABI accepts a single address. As a result, it is impossible to exit a market via app.venus.io.

**Solution:** Replace the array with a single address.