### PR TITLE
fix withdraw error with over 1000 XVS

### DIFF
--- a/src/components/Vault/Card.js
+++ b/src/components/Vault/Card.js
@@ -89,7 +89,7 @@ function VaultCard({
                 apr
                   .multipliedBy(100)
                   .dp(6, 1)
-                  .toString()
+                  .toString(10)
               )}
               %
             </div>

--- a/src/components/Vault/WithdrawCard.js
+++ b/src/components/Vault/WithdrawCard.js
@@ -146,7 +146,7 @@ function WithdrawCard({
                         poolId.toNumber(),
                         withdrawAmount
                           .multipliedBy(stakedTokenDecimal)
-                          .toString()
+                          .toString(10)
                       )
                       .send({
                         from: account


### PR DESCRIPTION
the `toString()` method in BigNumber library should be called with parameter of 10, otherwise the result it produces is scientific notation like `1e+21`