### PR TITLE
Adapt vault page for mobile

### DIFF
--- a/src/components/Vault/CardContent.js
+++ b/src/components/Vault/CardContent.js
@@ -155,13 +155,15 @@ function CardContent({
         <Col lg={{ span: 6 }} xs={{ span: 24 }}>
           <CardItemWrapper>
             <div className="card-item claim-rewards">
-              <div className="card-title">Available Rewards</div>
-              <div className="center-amount">
-                {pendingReward
-                  .div(rewardTokenDecimal)
-                  .dp(6, 1)
-                  .toString(10)}{' '}
-                {rewardToken.toUpperCase()}
+              <div>
+                <div className="card-title">Available Rewards</div>
+                <div className="center-amount">
+                  {pendingReward
+                    .div(rewardTokenDecimal)
+                    .dp(6, 1)
+                    .toString(10)}{' '}
+                  {rewardToken.toUpperCase()}
+                </div>
               </div>
               <button
                 type="button"
@@ -237,44 +239,44 @@ function CardContent({
                     MAX
                   </span>
                 </div>
-                <button
-                  type="button"
-                  className="button stake-button"
-                  disabled={!account || !stakeAmount.gt(0) || stakeLoading}
-                  onClick={async () => {
-                    setStakeLoading(true);
-                    try {
-                      if (!userStakedTokenAllowance.gt(0)) {
-                        await stakedTokenContract.methods
-                          .approve(
-                            xvsVaultContract.options.address,
-                            new BigNumber(2)
-                              .pow(256)
-                              .minus(1)
-                              .toString(10)
-                          )
-                          .send({
-                            from: account
-                          });
-                      } else {
-                        await xvsVaultContract.methods
-                          .deposit(
-                            rewardTokenAddress,
-                            poolId.toNumber(),
-                            stakeAmount.multipliedBy(1e18).toString(10)
-                          )
-                          .send({ from: account });
-                      }
-                    } catch (e) {
-                      console.log('>> stake error:', e);
-                    }
-                    setStakeLoading(false);
-                  }}
-                >
-                  {stakeLoading && <Icon type="loading" />}{' '}
-                  {userStakedTokenAllowance.gt(0) ? 'Stake' : 'Enable'}
-                </button>
               </div>
+              <button
+                type="button"
+                className="button stake-button"
+                disabled={!account || !stakeAmount.gt(0) || stakeLoading}
+                onClick={async () => {
+                  setStakeLoading(true);
+                  try {
+                    if (!userStakedTokenAllowance.gt(0)) {
+                      await stakedTokenContract.methods
+                        .approve(
+                          xvsVaultContract.options.address,
+                          new BigNumber(2)
+                            .pow(256)
+                            .minus(1)
+                            .toString(10)
+                        )
+                        .send({
+                          from: account
+                        });
+                    } else {
+                      await xvsVaultContract.methods
+                        .deposit(
+                          rewardTokenAddress,
+                          poolId.toNumber(),
+                          stakeAmount.multipliedBy(1e18).toString(10)
+                        )
+                        .send({ from: account });
+                    }
+                  } catch (e) {
+                    console.log('>> stake error:', e);
+                  }
+                  setStakeLoading(false);
+                }}
+              >
+                {stakeLoading && <Icon type="loading" />}{' '}
+                {userStakedTokenAllowance.gt(0) ? 'Stake' : 'Enable'}
+              </button>
             </div>
           </CardItemWrapper>
         </Col>

--- a/src/components/Vault/VaiCardContent.js
+++ b/src/components/Vault/VaiCardContent.js
@@ -109,13 +109,15 @@ function VaiCardContent({
         <Col lg={{ span: 6 }} xs={{ span: 24 }}>
           <CardItemWrapper>
             <div className="card-item claim-rewards">
-              <div className="card-title">Available Rewards</div>
-              <div className="center-amount">
-                {userPendingReward
-                  .div(1e18)
-                  .dp(6, 1)
-                  .toString(10)}{' '}
-                XVS
+              <div>
+                <div className="card-title">Available Rewards</div>
+                <div className="center-amount">
+                  {userPendingReward
+                    .div(1e18)
+                    .dp(6, 1)
+                    .toString(10)}{' '}
+                  XVS
+                </div>
               </div>
               <button
                 type="button"
@@ -175,21 +177,21 @@ function VaiCardContent({
                     </span>
                   </div>
                 </div>
-                <button
-                  type="button"
-                  className="button claim-button"
-                  disabled={
-                    !withdrawAmount.gt(0) ||
-                    !userVaiStakedAmount.gt(0) ||
-                    !account
-                  }
-                  onClick={() => {
-                    handleWithdrawVAI();
-                  }}
-                >
-                  {isWithdrawLoading && <Icon type="loading" />} Withdraw
-                </button>
               </div>
+              <button
+                type="button"
+                className="button claim-button"
+                disabled={
+                  !withdrawAmount.gt(0) ||
+                  !userVaiStakedAmount.gt(0) ||
+                  !account
+                }
+                onClick={() => {
+                  handleWithdrawVAI();
+                }}
+              >
+                {isWithdrawLoading && <Icon type="loading" />} Withdraw
+              </button>
             </div>
           </CardItemWrapper>
         </Col>
@@ -230,22 +232,22 @@ function VaiCardContent({
                     MAX
                   </span>
                 </div>
-                <button
-                  type="button"
-                  disabled={!stakeAmount.gt(0) || !account}
-                  className="button stake-button"
-                  onClick={() => {
-                    if (userVaiAllowance.gt(0)) {
-                      handleStakeVAI();
-                    } else {
-                      handleApprove();
-                    }
-                  }}
-                >
-                  {isStakeLoading && <Icon type="loading" />}
-                  {userVaiAllowance.gt(0) ? 'Stake' : 'Enable'}
-                </button>
               </div>
+              <button
+                type="button"
+                disabled={!stakeAmount.gt(0) || !account}
+                className="button stake-button"
+                onClick={() => {
+                  if (userVaiAllowance.gt(0)) {
+                    handleStakeVAI();
+                  } else {
+                    handleApprove();
+                  }
+                }}
+              >
+                {isStakeLoading && <Icon type="loading" />}
+                {userVaiAllowance.gt(0) ? 'Stake' : 'Enable'}
+              </button>
             </div>
           </CardItemWrapper>
         </Col>

--- a/src/components/Vault/WithdrawCard.js
+++ b/src/components/Vault/WithdrawCard.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import { Row, Icon } from 'antd';
+import { Row, Col, Icon } from 'antd';
 import BigNumber from 'bignumber.js';
 import PropTypes from 'prop-types';
 import { useWeb3React } from '@web3-react/core';
@@ -14,18 +14,23 @@ const WithdrawCardWrapper = styled.div`
   .card-item {
     padding: 0;
   }
+
   .request-withdraw {
-    display: flex;
     .left {
-      flex: 1;
       position: relative;
-      border-right: 1px solid #262b48;
+      border-right: none;
+      border-bottom: 1px solid #262b48;
       padding: 16px;
     }
     .right {
       position: relative;
       padding: 16px;
-      width: 40%;
+    }
+    .column {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      min-height: 165px;
     }
   }
 
@@ -33,8 +38,14 @@ const WithdrawCardWrapper = styled.div`
     font-size: 12px;
     line-height: 16px;
   }
-  .inner-row {
-    width: 100%;
+
+  @media only screen and (min-width: 992px) {
+    .request-withdraw {
+      .left {
+        border-right: 1px solid #262b48;
+        border-bottom: none;
+      }
+    }
   }
 `;
 
@@ -79,53 +90,55 @@ function WithdrawCard({
       <CardItemWrapper>
         {/* withdraw area */}
         <div className="card-item request-withdraw">
-          <Row className="inner-row" justify="end" type="flex">
-            <div className="left">
-              <div className="card-title">
-                <span>
-                  {stakedToken.toUpperCase()} Staked:{' '}
-                  {userEligibleStakedAmount.div(stakedTokenDecimal).toFixed(4)}
-                </span>
-                <Icon
-                  type="history"
-                  className="icon"
-                  onClick={() => setHistoryModalVisible(!historyModalVisible)}
-                />
-              </div>
-              <div className="card-body">
-                <div className="input-wrapper">
-                  <NumberFormat
-                    autoFocus
-                    value={
-                      withdrawAmount.isZero()
-                        ? '0'
-                        : withdrawAmount.toString(10)
-                    }
-                    onValueChange={values => {
-                      const value = new BigNumber(values.value || 0);
-                      const maxValue = userEligibleStakedAmount
-                        .div(stakedTokenDecimal)
-                        .dp(4, 1);
-                      setWithdrawAmount(value.gt(maxValue) ? maxValue : value);
-                    }}
-                    thousandSeparator
-                    allowNegative={false}
-                    placeholder="0"
-                  />
-                  <span
-                    className="pointer max"
-                    onClick={() => {
-                      setWithdrawAmount(
-                        userEligibleStakedAmount.div(stakedTokenDecimal)
-                      );
-                    }}
-                  >
-                    MAX
+          <Row type="flex">
+            <Col xs={{ span: 24 }} lg={{ span: 15 }} className="left column">
+              <div className="card-content">
+                <div className="card-title">
+                  <span>
+                    {stakedToken.toUpperCase()} Staked:{' '}
+                    {userEligibleStakedAmount.div(stakedTokenDecimal).toFixed(4)}
                   </span>
+                  <Icon
+                    type="history"
+                    className="icon"
+                    onClick={() => setHistoryModalVisible(!historyModalVisible)}
+                  />
                 </div>
-                <div className="lock-period">
-                  Locking period:{' '}
-                  {formatTimeToLockPeriodString(lockPeriodSecond)}
+                <div className="card-body">
+                  <div className="input-wrapper">
+                    <NumberFormat
+                      autoFocus
+                      value={
+                        withdrawAmount.isZero()
+                          ? '0'
+                          : withdrawAmount.toString(10)
+                      }
+                      onValueChange={values => {
+                        const value = new BigNumber(values.value || 0);
+                        const maxValue = userEligibleStakedAmount
+                          .div(stakedTokenDecimal)
+                          .dp(4, 1);
+                        setWithdrawAmount(value.gt(maxValue) ? maxValue : value);
+                      }}
+                      thousandSeparator
+                      allowNegative={false}
+                      placeholder="0"
+                    />
+                    <span
+                      className="pointer max"
+                      onClick={() => {
+                        setWithdrawAmount(
+                          userEligibleStakedAmount.div(stakedTokenDecimal)
+                        );
+                      }}
+                    >
+                      MAX
+                    </span>
+                  </div>
+                  <div className="lock-period">
+                    Locking period:{' '}
+                    {formatTimeToLockPeriodString(lockPeriodSecond)}
+                  </div>
                 </div>
               </div>
               <button
@@ -160,13 +173,15 @@ function WithdrawCard({
                 {requestWithdrawLoading && <Icon type="loading" />} Request
                 Withdraw
               </button>
-            </div>
+            </Col>
             {/* !left */}
-            <div className="right">
-              <div className="card-title">Withdrawable amount</div>
-              <div className="center-amount">
-                {withdrawableAmount.div(stakedTokenDecimal).toFixed(4)}{' '}
-                {stakedToken.toUpperCase()}
+            <Col xs={{ span: 24 }} lg={{ span: 9 }} className="right column">
+              <div className="card-content">
+                <div className="card-title">Withdrawable amount</div>
+                <div className="center-amount">
+                  {withdrawableAmount.div(stakedTokenDecimal).toFixed(4)}{' '}
+                  {stakedToken.toUpperCase()}
+                </div>
               </div>
               <button
                 type="button"
@@ -190,7 +205,7 @@ function WithdrawCard({
               >
                 {executeWithdrawLoading && <Icon type="loading" />} Withdraw
               </button>
-            </div>
+            </Col>
           </Row>
         </div>
         <WithdrawHistoryModal

--- a/src/components/Vault/styles.js
+++ b/src/components/Vault/styles.js
@@ -80,21 +80,21 @@ export const CardItemWrapper = styled.div`
     position: relative;
     background: #090e25;
     border-radius: 8px;
-    height: 165px;
     margin-left: 16px;
     margin-bottom: 16px;
     padding: 16px;
+    min-height: 165px;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
   }
 
   .button {
-    position: absolute;
-    width: calc(100% - 32px);
+    width: 100%;
     color: #fff;
-    bottom: 16px;
-    left: 16px;
-    right: 16px;
     border-radius: 8px;
     border: none;
+    box-sizing: border-box;
     font-size: 14px;
     line-height: 36px;
     background: #ebbf6e;


### PR DESCRIPTION
Problem: Due to absolute positioning, the buttons on the vault page sometimes hide the text and inputs above.

Solution: Make a flexbox out of cards on the page. Put contents in one block, and the button would then be another block. Use space-between to align the card contents and the button. Allow cards to stretch beyond 165px.