### PR TITLE
Account for minted VAI in borrow limit computation

### DIFF
--- a/src/containers/App.js
+++ b/src/containers/App.js
@@ -49,8 +49,8 @@ class App extends React.Component {
         <IntlProvider locale={lang} messages={message}>
           <Provider store={store}>
             <RefreshContextProvider>
-              <MarketContextProvider>
-                <VaiContextProvider>
+              <VaiContextProvider>
+                <MarketContextProvider>
                   <BrowserRouter>
                     <ToastContainer
                       autoClose={8000}
@@ -101,8 +101,8 @@ class App extends React.Component {
                       <Redirect from="/" to="/dashboard" />
                     </Switch>
                   </BrowserRouter>
-                </VaiContextProvider>
-              </MarketContextProvider>
+                </MarketContextProvider>
+              </VaiContextProvider>
             </RefreshContextProvider>
           </Provider>
         </IntlProvider>


### PR DESCRIPTION
Problem: MarketContext uses VaiContext to get user's minted VAIs. However, MarketContext does not have VaiContext provider above in the components hierarchy, so it receives zero instead of an actual value.

Solution: Swap VaiContext and MarketContext in the components hierarchy.