### PR TITLE
Move scripts to the top of package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,14 @@
   "name": "venus",
   "version": "0.1.0",
   "private": true,
+  "scripts": {
+    "start": "react-scripts --max_old_space_size=4096 start",
+    "build": "react-scripts --max_old_space_size=4096 build",
+    "test": "react-scripts test",
+    "eject": "react-scripts eject",
+    "lint": "export NODE_OPTIONS=\"--max-old-space-size=4096\" && eslint .",
+    "lint:fix": "eslint . --fix"
+  },
   "dependencies": {
     "@binance-chain/bsc-connector": "^1.0.0",
     "@material-ui/core": "^4.6.0",
@@ -45,14 +53,6 @@
     "redux-thunk": "^2.2.0",
     "styled-components": "^4.4.1",
     "web3": "^1.3.1"
-  },
-  "scripts": {
-    "start": "react-scripts --max_old_space_size=4096 start",
-    "build": "react-scripts --max_old_space_size=4096 build",
-    "test": "react-scripts test",
-    "eject": "react-scripts eject",
-    "lint": "export NODE_OPTIONS=\"--max-old-space-size=4096\" && eslint .",
-    "lint:fix": "eslint . --fix"
   },
   "devDependencies": {
     "eslint": "^5.16.0",


### PR DESCRIPTION
Problem: The scripts are located between dependencies and devDependcies. This reduces their visibility and leaves the two dependency keys disorganized

Solution: Move scripts to the top of the file so that they can be referenced easily. This is convienent because developers on the project will easily be reference what scripts are available to them while working on the project.
It also has a side effect of organizing dependencies and devDependencies next to each other