### PR TITLE
Add git and openssh to lock Dockerfile

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -4,7 +4,7 @@ FROM node:12.19.0-alpine3.12
 ENV NODE_ENV development
 ENV NODE_PATH=src/
 
-RUN apk add --update --no-cache python3
+RUN apk add --update --no-cache python3 git openssh
 
 WORKDIR /usr/app
 


### PR DESCRIPTION
Problem: There are subdepedencies that need to be installed via git. Without these dependencies they won't install correctly

Solution: Similar to the production container, install git and ssh in the local development container