### PR TITLE
Add jsconfig.json with configuration for absolute paths

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+  }
+}


### PR DESCRIPTION
Problem: Absolute paths weren't getting resolved correctly

Solution: Add support for absolute paths per [docs](https://create-react-app.dev/docs/importing-a-component/#absolute-imports)