### PR TITLE
Remove jsconfig.json because we are using typescript

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,0 @@
-{
-  "compilerOptions": {
-    "baseUrl": "./src",
-  }
-}


### PR DESCRIPTION
Problem:
Typescript uses tsconfig.json so the jsconfig.json isn't needed

Solution:
Remove jsconfig.json to keep project uncluttered