### PR TITLE
Add node engine to package.json as requiring >=12.19.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "venus",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=12.19.x"
+  },
   "scripts": {
     "start": "react-scripts --max_old_space_size=4096 start",
     "build": "react-scripts --max_old_space_size=4096 build",


### PR DESCRIPTION
The project requires at least node 12.19.x which is used in the docker file and set in the readme. 

Adding it as a node engine will give the user a nice message about the required version if their node version doesn't match