### PR TITLE
Remove stray semi colon

### DIFF
--- a/src/components/Vault/CardContent.tsx
+++ b/src/components/Vault/CardContent.tsx
@@ -153,7 +153,6 @@ function CardContent({
       <CardContentWrapper>
         {/* @ts-expect-error ts-migrate(2322) FIXME: Type '{ className: string; }' is not assignable to... Remove this comment to see the full error message */}
         <LoadingSpinner className="loading-spinner" />
-        ;
       </CardContentWrapper>
     );
   }


### PR DESCRIPTION
Remove stray semi-colon that was rending on the page while the vault card loads