### PR TITLE
Remove proptypes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "lodash": "^4.17.21",
     "markdown-it": "^12.0.0",
     "moment": "^2.24.0",
-    "prop-types": "^15.7.2",
     "react": "^16.9.6",
     "react-copy-to-clipboard": "^5.0.2",
     "react-dom": "npm:@hot-loader/react-dom@^17.0.1",

--- a/src/components/Basic/BorrowTabs/BorrowTab.tsx
+++ b/src/components/Basic/BorrowTabs/BorrowTab.tsx
@@ -27,6 +27,7 @@ interface Props {
   asset: Asset;
   changeTab: (tab: 'borrow' | 'repayBorrow') => void;
   onCancel: () => void;
+  setSetting: () => void;
 }
 
 function BorrowTab({ asset, changeTab, onCancel, setSetting }: Props & DispatchProps) {
@@ -182,10 +183,7 @@ function BorrowTab({ asset, changeTab, onCancel, setSetting }: Props & DispatchP
               <img className="asset-img" src={asset.img} alt="asset" />
               <span>Borrow APY</span>
             </div>
-            <span>
-              {asset.borrowApy.dp(2, 1).toString(10)}
-              %
-            </span>
+            <span>{asset.borrowApy.dp(2, 1).toString(10)}%</span>
           </div>
           <div className="description">
             <div className="flex align-center">
@@ -217,11 +215,7 @@ function BorrowTab({ asset, changeTab, onCancel, setSetting }: Props & DispatchP
               />
               <span>Repay VAI Balance</span>
             </div>
-            <span>
-              {userVaiMinted.dp(2, 1).toString(10)}
-              {' '}
-              VAI
-            </span>
+            <span>{userVaiMinted.dp(2, 1).toString(10)} VAI</span>
           </div>
           {!new BigNumber(asset.borrowCaps || 0).isZero() && (
             <div className="description borrow-caps">
@@ -246,42 +240,24 @@ function BorrowTab({ asset, changeTab, onCancel, setSetting }: Props & DispatchP
           <div className="borrow-balance">
             <span>Borrow Balance</span>
             {amount.isZero() || amount.isNaN() ? (
-              <span>
-                $
-                {borrowBalance.dp(2, 1).toString(10)}
-              </span>
+              <span>${borrowBalance.dp(2, 1).toString(10)}</span>
             ) : (
               <div className="flex align-center just-between">
-                <span>
-                  $
-                  {borrowBalance.dp(2, 1).toString(10)}
-                </span>
+                <span>${borrowBalance.dp(2, 1).toString(10)}</span>
                 <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                <span>
-                  $
-                  {newBorrowBalance.dp(2, 1).toString(10)}
-                </span>
+                <span>${newBorrowBalance.dp(2, 1).toString(10)}</span>
               </div>
             )}
           </div>
           <div className="borrow-limit">
             <span>Borrow Limit Used</span>
             {amount.isZero() || amount.isNaN() ? (
-              <span>
-                {borrowPercent.dp(2, 1).toString(10)}
-                %
-              </span>
+              <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
             ) : (
               <div className="flex align-center just-between">
-                <span>
-                  {borrowPercent.dp(2, 1).toString(10)}
-                  %
-                </span>
+                <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
                 <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                <span>
-                  {newBorrowPercent.dp(2, 1).toString(10)}
-                  %
-                </span>
+                <span>{newBorrowPercent.dp(2, 1).toString(10)}%</span>
               </div>
             )}
           </div>
@@ -305,15 +281,12 @@ function BorrowTab({ asset, changeTab, onCancel, setSetting }: Props & DispatchP
           }
           onClick={handleBorrow}
         >
-          {isLoading && <Icon type="loading" />}
-          {' '}
-          Borrow
+          {isLoading && <Icon type="loading" />} Borrow
         </Button>
         <div className="description">
           <span>Protocol Balance</span>
           <span>
-            {asset.borrowBalance && format(asset.borrowBalance.dp(2, 1).toString(10))}
-            {' '}
+            {asset.borrowBalance && format(asset.borrowBalance.dp(2, 1).toString(10))}{' '}
             {asset.symbol}
           </span>
         </div>

--- a/src/components/Basic/CircleProgressBar.tsx
+++ b/src/components/Basic/CircleProgressBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Progress } from 'antd';
 
@@ -46,7 +45,13 @@ const CircleProgressBarWrapper = styled.div`
   }
 `;
 
-function CircleProgressBar({ label, percent, width }: $TSFixMe) {
+interface CircleProgressBarProps {
+  label: string;
+  percent: number;
+  width?: number;
+}
+
+function CircleProgressBar({ label, percent, width }: CircleProgressBarProps) {
   return (
     <CircleProgressBarWrapper>
       <Progress
@@ -63,21 +68,12 @@ function CircleProgressBar({ label, percent, width }: $TSFixMe) {
         showInfo={false}
       />
       <div className="circle-label">
-        <p className={percent < 0 ? 'percent-red' : 'percent'}>
-          {percent}
-          %
-        </p>
+        <p className={percent < 0 ? 'percent-red' : 'percent'}>{percent}%</p>
         <p className="label">{label}</p>
       </div>
     </CircleProgressBarWrapper>
   );
 }
-
-CircleProgressBar.propTypes = {
-  label: PropTypes.string,
-  percent: PropTypes.number,
-  width: PropTypes.number,
-};
 
 CircleProgressBar.defaultProps = {
   label: 'Default Label',

--- a/src/components/Basic/CollateralConfirmModal.tsx
+++ b/src/components/Basic/CollateralConfirmModal.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 import { Modal, Spin, Icon } from 'antd';
 import closeImg from 'assets/img/close.png';
 import logoImg from 'assets/img/logo.png';
@@ -39,11 +38,18 @@ const ModalContent = styled.div`
 `;
 
 const antIcon = <Icon type="loading" style={{ fontSize: 64 }} spin />;
+
+interface CollateralConfirmModalProps {
+  visible: boolean;
+  isCollateralEnalbe?: boolean;
+  onCancel: () => void;
+}
+
 function CollateralConfirmModal({
   visible,
   isCollateralEnalbe,
   onCancel,
-}: $TSFixMe) {
+}: CollateralConfirmModalProps) {
   return (
     <Modal
       className="collateral-confirm-modal"
@@ -56,33 +62,14 @@ function CollateralConfirmModal({
       centered
     >
       <ModalContent className="flex flex-column align-center just-center">
-        <img
-          className="close-btn pointer"
-          src={closeImg}
-          alt="close"
-          onClick={onCancel}
-        />
+        <img className="close-btn pointer" src={closeImg} alt="close" onClick={onCancel} />
         <img src={logoImg} alt="logo" className="logo-text" />
-        <p className="title">
-          {`${isCollateralEnalbe ? 'Disable' : 'Enable'} as collateral`}
-        </p>
+        <p className="title">{`${isCollateralEnalbe ? 'Disable' : 'Enable'} as collateral`}</p>
         <Spin className="voting-spinner" indicator={antIcon} />
         <p className="confirm-text">Confirm the transaction</p>
       </ModalContent>
     </Modal>
   );
 }
-
-CollateralConfirmModal.propTypes = {
-  visible: PropTypes.bool,
-  isCollateralEnalbe: PropTypes.bool,
-  onCancel: PropTypes.func,
-};
-
-CollateralConfirmModal.defaultProps = {
-  visible: false,
-  isCollateralEnalbe: true,
-  onCancel: () => {},
-};
 
 export default CollateralConfirmModal;

--- a/src/components/Basic/DelegationTypeModal.tsx
+++ b/src/components/Basic/DelegationTypeModal.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import styled from 'styled-components';
-import PropTypes from 'prop-types';
 import { Modal } from 'antd';
 import greenCheckImg from 'assets/img/green-check.png';
 import arrowRightImg from 'assets/img/arrow-right.png';
@@ -72,13 +71,21 @@ const ModalContent = styled.div`
   }
 `;
 
+interface DelegationTypeModalProps {
+  address: string;
+  balance: string;
+  visible: boolean;
+  delegateStatus: string;
+  onCancel: () => void;
+}
+
 function DelegationTypeModal({
   address,
   balance,
   delegateStatus,
   visible,
   onCancel,
-}: $TSFixMe) {
+}: DelegationTypeModalProps) {
   const [child, setChild] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const xvsVaultProxyContract = useXvsVaultProxy();
@@ -86,9 +93,7 @@ function DelegationTypeModal({
   const handleDelegateVoting = async (dAddress: $TSFixMe) => {
     setIsLoading(true);
     try {
-      await xvsVaultProxyContract.methods
-        .delegate(dAddress || address)
-        .send({ from: address });
+      await xvsVaultProxyContract.methods.delegate(dAddress || address).send({ from: address });
       onCancel();
     } catch (error) {
       console.log('delegate error :>> ', error);
@@ -115,19 +120,14 @@ function DelegationTypeModal({
           alt="left arrow"
           onClick={() => setChild('')}
         />
-        <img
-          className="close-btn pointer"
-          src={closeImg}
-          alt="close"
-          onClick={onCancel}
-        />
+        <img className="close-btn pointer" src={closeImg} alt="close" onClick={onCancel} />
         <div className={`${child ? 'hidden' : ''}`}>
           <div className="flex align-center just-center header-content">
             <p>Choose Delegation Type</p>
           </div>
           <div
             className="flex flex-column section"
-            onClick={(e) => {
+            onClick={e => {
               if (delegateStatus === 'self') {
                 e.preventDefault();
                 return;
@@ -148,8 +148,7 @@ function DelegationTypeModal({
               )}
             </div>
             <div className="description">
-              This option allows you to vote on proposals directly from your
-              connected wallet.
+              This option allows you to vote on proposals directly from your connected wallet.
             </div>
           </div>
           <div
@@ -170,44 +169,21 @@ function DelegationTypeModal({
               )}
             </div>
             <div className="description">
-              This Option allows you to delegate your votes to another trusted
-              BSC address. You are not sending your XVS Tokens, you are only
-              passing your voting power and you can undelegate at any time.
+              This Option allows you to delegate your votes to another trusted BSC address. You are
+              not sending your XVS Tokens, you are only passing your voting power and you can
+              undelegate at any time.
             </div>
           </div>
         </div>
         {child === 'delegate' && (
-          <DelegationVoting
-            isLoading={isLoading}
-            onDelegate={handleDelegateVoting}
-          />
+          <DelegationVoting isLoading={isLoading} onDelegate={handleDelegateVoting} />
         )}
         {child === 'manual' && (
-          <ManualVoting
-            isLoading={isLoading}
-            balance={balance}
-            address={address}
-          />
+          <ManualVoting isLoading={isLoading} balance={balance} address={address} />
         )}
       </ModalContent>
     </Modal>
   );
 }
-
-DelegationTypeModal.propTypes = {
-  address: PropTypes.string,
-  balance: PropTypes.string,
-  visible: PropTypes.bool,
-  delegateStatus: PropTypes.string,
-  onCancel: PropTypes.func,
-};
-
-DelegationTypeModal.defaultProps = {
-  address: '',
-  balance: PropTypes.string,
-  visible: false,
-  delegateStatus: '',
-  onCancel: () => {},
-};
 
 export default DelegationTypeModal;

--- a/src/components/Basic/LineProgressBar.tsx
+++ b/src/components/Basic/LineProgressBar.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Progress } from 'antd';
 
@@ -25,30 +24,22 @@ const LineProgressBarWrapper = styled.div`
   }
 `;
 
-function LineProgressBar({ label, percent }: $TSFixMe) {
+interface LineProgressBarProps {
+  label?: string;
+  percent?: number;
+}
+
+function LineProgressBar({ label, percent }: LineProgressBarProps) {
   return (
     <LineProgressBarWrapper>
       <div className="flex align-center just-between">
         <p className="label">{label}</p>
-        <p className="percent">
-          {percent}
-          %
-        </p>
+        <p className="percent">{percent}%</p>
       </div>
-      <Progress
-        percent={percent}
-        strokeColor="#ffffff"
-        strokeWidth={7}
-        showInfo={false}
-      />
+      <Progress percent={percent} strokeColor="#ffffff" strokeWidth={7} showInfo={false} />
     </LineProgressBarWrapper>
   );
 }
-
-LineProgressBar.propTypes = {
-  label: PropTypes.string,
-  percent: PropTypes.number,
-};
 
 LineProgressBar.defaultProps = {
   label: 'Borrow Limit',

--- a/src/components/Basic/LoadingSpinner.tsx
+++ b/src/components/Basic/LoadingSpinner.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Spin, Icon } from 'antd';
-import PropTypes from 'prop-types';
 
 const LoadingSpinnerWrapper = styled.div`
   width: 100%;
@@ -12,7 +11,11 @@ const LoadingSpinnerWrapper = styled.div`
   }
 `;
 
-function LoadingSpinner({ size }: $TSFixMe) {
+interface LoadingSpinnerProps {
+  size?: number;
+}
+
+function LoadingSpinner({ size }: LoadingSpinnerProps) {
   const antIcon = <Icon type="loading" style={{ fontSize: size }} spin />;
   return (
     <LoadingSpinnerWrapper className="flex align-center just-center">
@@ -20,10 +23,6 @@ function LoadingSpinner({ size }: $TSFixMe) {
     </LoadingSpinnerWrapper>
   );
 }
-
-LoadingSpinner.propTypes = {
-  size: PropTypes.number,
-};
 
 LoadingSpinner.defaultProps = {
   size: 64,

--- a/src/components/Basic/ManualVoting.tsx
+++ b/src/components/Basic/ManualVoting.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Spin, Icon } from 'antd';
 import styled from 'styled-components';
 
@@ -45,7 +44,13 @@ const ManualVotingWrapper = styled.div`
   }
 `;
 
-function ManualVoting({ address, balance, isLoading }: $TSFixMe) {
+interface ManualVotingProps {
+  address: string;
+  balance: string;
+  isLoading: boolean;
+}
+
+function ManualVoting({ address, balance, isLoading }: ManualVotingProps) {
   const antIcon = <Icon type="loading" style={{ fontSize: 64 }} spin />;
 
   return (
@@ -54,15 +59,9 @@ function ManualVoting({ address, balance, isLoading }: $TSFixMe) {
         <p>Confirm Transaction</p>
       </div>
       <div className="flex flex-column align-center just-center manual-voting-section">
-        <p className="voting-count">
-          {balance}
-          {' '}
-          Votes
-        </p>
+        <p className="voting-count">{balance} Votes</p>
         <span className="voting-address">
-          Manual Voting from
-          {' '}
-          {`${address.substr(0, 4)}...${address.substr(address.length - 4, 4)}`}
+          Manual Voting from {`${address.substr(0, 4)}...${address.substr(address.length - 4, 4)}`}
         </span>
         {isLoading && <Spin className="voting-spinner" indicator={antIcon} />}
         <span className="voting-confirm">Confirm the transaction.</span>
@@ -70,11 +69,5 @@ function ManualVoting({ address, balance, isLoading }: $TSFixMe) {
     </ManualVotingWrapper>
   );
 }
-
-ManualVoting.propTypes = {
-  address: PropTypes.bool.isRequired,
-  balance: PropTypes.bool.isRequired,
-  isLoading: PropTypes.bool.isRequired,
-};
 
 export default ManualVoting;

--- a/src/components/Basic/OverviewChart.tsx
+++ b/src/components/Basic/OverviewChart.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import BigNumber from 'bignumber.js';
 import styled from 'styled-components';
 import {
@@ -51,6 +50,11 @@ interface Props {
   data: Array<Record<string, { name: string; apy: number }>>;
 }
 
+interface CustomChart2TooltipProps {
+  active: boolean;
+  payload: Array<{ value: BigNumber.Value }>;
+}
+
 function OverviewChart({ marketType, graphType, data }: Props) {
   const [activeIndex, setActiveIndex] = useState(-1);
 
@@ -84,7 +88,7 @@ function OverviewChart({ marketType, graphType, data }: Props) {
     return null;
   };
 
-  const CustomChart2Tooltip = ({ active, payload }: $TSFixMe) => {
+  const CustomChart2Tooltip = ({ active, payload }: CustomChart2TooltipProps) => {
     if (active && payload && payload.length !== 0) {
       return (
         <div className="custom-tooltip">
@@ -97,10 +101,6 @@ function OverviewChart({ marketType, graphType, data }: Props) {
       );
     }
     return null;
-  };
-  CustomChart2Tooltip.propTypes = {
-    active: PropTypes.bool.isRequired,
-    payload: PropTypes.array.isRequired,
   };
 
   const handleMouseMove = (index: $TSFixMe) => {

--- a/src/components/Basic/PendingTransaction.tsx
+++ b/src/components/Basic/PendingTransaction.tsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import LoadingSpinner from 'components/Basic/LoadingSpinner';
-import { connectAccount } from 'core';
+import { connect } from 'react-redux';
 import moment from 'moment';
+import LoadingSpinner from 'components/Basic/LoadingSpinner';
+import { Setting } from 'types';
 import { Label } from './Label';
 
 const PendingTransactionWrapper = styled.div`
@@ -38,7 +39,11 @@ const PendingTransactionWrapper = styled.div`
   }
 `;
 
-function PendingTransaction({ settings }: $TSFixMe) {
+interface PendingTransactionProps {
+  settings: Setting;
+}
+
+function PendingTransaction({ settings }: PendingTransactionProps) {
   const [curTime, setCurTime] = useState('');
   useEffect(() => {
     const dateTime = new Date();
@@ -73,4 +78,4 @@ const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(PendingTransaction);
+export default connect(mapStateToProps)(PendingTransaction);

--- a/src/components/Basic/SupplyModal.tsx
+++ b/src/components/Basic/SupplyModal.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import { Modal } from 'antd';
 import SupplyTab from 'components/Basic/SupplyTabs/SupplyTab';
 import WithdrawTab from 'components/Basic/SupplyTabs/WithdrawTab';
 import closeImg from 'assets/img/close.png';
+import { Asset } from 'types';
 import styled from 'styled-components';
 
 const ModalContent = styled.div`
@@ -199,7 +199,13 @@ export const TabContent = styled.div`
   }
 `;
 
-function SupplyModal({ visible, asset, onCancel }: $TSFixMe) {
+interface SupplyModalProps {
+  visible: boolean;
+  asset: Asset;
+  onCancel: () => void;
+}
+
+function SupplyModal({ visible, asset, onCancel }: SupplyModalProps) {
   const [currentTab, setCurrentTab] = useState('supply');
 
   useEffect(() => {
@@ -236,17 +242,5 @@ function SupplyModal({ visible, asset, onCancel }: $TSFixMe) {
     </Modal>
   );
 }
-
-SupplyModal.propTypes = {
-  visible: PropTypes.bool,
-  asset: PropTypes.object,
-  onCancel: PropTypes.func,
-};
-
-SupplyModal.defaultProps = {
-  visible: false,
-  asset: {},
-  onCancel: () => {},
-};
 
 export default SupplyModal;

--- a/src/components/Basic/SupplyTabs/SupplyTab.tsx
+++ b/src/components/Basic/SupplyTabs/SupplyTab.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import PropTypes from 'prop-types';
 import BigNumber from 'bignumber.js';
 import { Icon, Progress } from 'antd';
 import { Button } from 'components/v2/Button';
@@ -13,6 +12,7 @@ import arrowRightImg from 'assets/img/arrow-right.png';
 import vaiImg from 'assets/img/coins/vai.svg';
 import { TabSection, Tabs, TabContent } from 'components/Basic/SupplyModal';
 import { getBigNumber } from 'utilities/common';
+import { Asset, Setting } from 'types';
 import { useToken, useVbep } from '../../../hooks/useContract';
 import { useMarketsUser } from '../../../hooks/useMarketsUser';
 import { useVaiUser } from '../../../hooks/useVaiUser';
@@ -20,7 +20,14 @@ import useWeb3 from '../../../hooks/useWeb3';
 
 const format = commaNumber.bindWith(',', '.');
 
-function SupplyTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
+interface SupplyTabProps {
+  asset: Asset;
+  changeTab: (tab: 'supply' | 'withdraw') => void;
+  onCancel: () => void;
+  setSetting: (setting: Partial<Setting> | undefined) => void;
+}
+
+function SupplyTab({ asset, changeTab, onCancel, setSetting }: SupplyTabProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isEnabled, setIsEnabled] = useState(false);
   const [amount, setAmount] = useState(new BigNumber(0));
@@ -183,11 +190,7 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
           <>
             <img src={asset.img} alt="asset" />
             <p className="center warning-label">
-              To Supply
-              {' '}
-              {asset.name}
-              {' '}
-              to the Venus Protocol, you need to approve it first.
+              To Supply {asset.name} to the Venus Protocol, you need to approve it first.
             </p>
           </>
         )}
@@ -217,10 +220,7 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
               <img className="asset-img" src={asset.img} alt="asset" />
               <span>Supply APY</span>
             </div>
-            <span>
-              {asset.supplyApy.dp(2, 1).toString(10)}
-              %
-            </span>
+            <span>{asset.supplyApy.dp(2, 1).toString(10)}%</span>
           </div>
           <div className="description">
             <div className="flex align-center">
@@ -257,11 +257,7 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
               />
               <span>Available VAI Limit</span>
             </div>
-            <span>
-              {mintableVai.dp(2, 1).toString(10)}
-              {' '}
-              VAI
-            </span>
+            <span>{mintableVai.dp(2, 1).toString(10)} VAI</span>
           </div>
         </div>
         {isEnabled && (
@@ -269,42 +265,24 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
             <div className="borrow-limit">
               <span>Borrow Limit</span>
               {amount.isZero() || amount.isNaN() ? (
-                <span>
-                  $
-                  {format(borrowLimit.dp(2, 1).toString(10))}
-                </span>
+                <span>${format(borrowLimit.dp(2, 1).toString(10))}</span>
               ) : (
                 <div className="flex align-center just-between">
-                  <span>
-                    $
-                    {format(borrowLimit.dp(2, 1).toString(10))}
-                  </span>
+                  <span>${format(borrowLimit.dp(2, 1).toString(10))}</span>
                   <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                  <span>
-                    $
-                    {format(newBorrowLimit.dp(2, 1).toString(10))}
-                  </span>
+                  <span>${format(newBorrowLimit.dp(2, 1).toString(10))}</span>
                 </div>
               )}
             </div>
             <div className="flex align-center just-between borrow-limit-used">
               <span>Borrow Limit Used</span>
               {amount.isZero() || amount.isNaN() ? (
-                <span>
-                  {borrowPercent.dp(2, 1).toString(10)}
-                  %
-                </span>
+                <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
               ) : (
                 <div className="flex align-center just-between">
-                  <span>
-                    {borrowPercent.dp(2, 1).toString(10)}
-                    %
-                  </span>
+                  <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
                   <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                  <span>
-                    {newBorrowPercent.dp(2, 1).toString(10)}
-                    %
-                  </span>
+                  <span>{newBorrowPercent.dp(2, 1).toString(10)}%</span>
                 </div>
               )}
             </div>
@@ -324,9 +302,7 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
               onApprove();
             }}
           >
-            {isLoading && <Icon type="loading" />}
-            {' '}
-            Enable
+            {isLoading && <Icon type="loading" />} Enable
           </Button>
         ) : (
           <Button
@@ -340,35 +316,18 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
             }
             onClick={handleSupply}
           >
-            {isLoading && <Icon type="loading" />}
-            {' '}
-            Supply
+            {isLoading && <Icon type="loading" />} Supply
           </Button>
         )}
         <div className="description">
           <span>Wallet Balance</span>
           <span>
-            {format(asset.walletBalance.dp(2, 1).toString(10))}
-            {' '}
-            {asset.symbol}
+            {format(asset.walletBalance.dp(2, 1).toString(10))} {asset.symbol}
           </span>
         </div>
       </TabContent>
     </TabSection>
   );
 }
-
-SupplyTab.propTypes = {
-  asset: PropTypes.object,
-  changeTab: PropTypes.func,
-  onCancel: PropTypes.func,
-  setSetting: PropTypes.func.isRequired,
-};
-
-SupplyTab.defaultProps = {
-  asset: {},
-  changeTab: () => {},
-  onCancel: () => {},
-};
 
 export default connectAccount()(SupplyTab);

--- a/src/components/Basic/SupplyTabs/WithdrawTab.tsx
+++ b/src/components/Basic/SupplyTabs/WithdrawTab.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import PropTypes from 'prop-types';
 import BigNumber from 'bignumber.js';
 
 import { Icon, Progress } from 'antd';
@@ -8,6 +7,7 @@ import NumberFormat from 'react-number-format';
 import { useWeb3React } from '@web3-react/core';
 import { connectAccount } from 'core';
 import commaNumber from 'comma-number';
+import { Asset, Setting } from 'types';
 import coinImg from 'assets/img/venus_32.png';
 import arrowRightImg from 'assets/img/arrow-right.png';
 import vaiImg from 'assets/img/coins/vai.svg';
@@ -20,7 +20,14 @@ import { useVaiUser } from '../../../hooks/useVaiUser';
 
 const format = commaNumber.bindWith(',', '.');
 
-function WithdrawTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
+interface WithdrawTabProps {
+  asset: Asset;
+  changeTab: (tab: 'supply' | 'withdraw') => void;
+  onCancel: () => void;
+  setSetting: (setting: Setting | undefined) => void;
+}
+
+function WithdrawTab({ asset, changeTab, onCancel, setSetting }: WithdrawTabProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [amount, setAmount] = useState(new BigNumber(0));
   const [borrowLimit, setBorrowLimit] = useState(new BigNumber(0));
@@ -205,10 +212,7 @@ function WithdrawTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
               <img className="asset-img" src={asset.img} alt="asset" />
               <span>Supply APY</span>
             </div>
-            <span>
-              {asset.supplyApy.dp(2, 1).toString(10)}
-              %
-            </span>
+            <span>{asset.supplyApy.dp(2, 1).toString(10)}%</span>
           </div>
           <div className="description">
             <div className="flex align-center">
@@ -240,11 +244,7 @@ function WithdrawTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
               />
               <span>Available VAI Limit</span>
             </div>
-            <span>
-              {mintableVai.dp(2, 1).toString(10)}
-              {' '}
-              VAI
-            </span>
+            <span>{mintableVai.dp(2, 1).toString(10)} VAI</span>
           </div>
           {asset.symbol !== 'BNB' && (
             <div className="description">
@@ -268,12 +268,8 @@ function WithdrawTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
                       .times(feePercent / 100)
                       .dp(4)
                       .toString(10)
-                  : 0}
-                {' '}
-                {asset.symbol}
-                {' '}
-                (
-                {feePercent.toString(10)}
+                  : 0}{' '}
+                {asset.symbol} ({feePercent.toString(10)}
                 %)
               </span>
             </div>
@@ -283,42 +279,24 @@ function WithdrawTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
           <div className="borrow-limit">
             <span>Borrow Limit</span>
             {amount.isZero() || amount.isNaN() ? (
-              <span>
-                $
-                {format(borrowLimit.dp(2, 1).toString(10))}
-              </span>
+              <span>${format(borrowLimit.dp(2, 1).toString(10))}</span>
             ) : (
               <div className="flex align-center just-between">
-                <span>
-                  $
-                  {format(borrowLimit.dp(2, 1).toString(10))}
-                </span>
+                <span>${format(borrowLimit.dp(2, 1).toString(10))}</span>
                 <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                <span>
-                  $
-                  {format(newBorrowLimit.dp(2, 1).toString(10))}
-                </span>
+                <span>${format(newBorrowLimit.dp(2, 1).toString(10))}</span>
               </div>
             )}
           </div>
           <div className="flex align-center just-between borrow-limit-used">
             <span>Borrow Limit Used</span>
             {amount.isZero() || amount.isNaN() ? (
-              <span>
-                {borrowPercent.dp(2, 1).toString(10)}
-                %
-              </span>
+              <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
             ) : (
               <div className="flex align-center just-between">
-                <span>
-                  {borrowPercent.dp(2, 1).toString(10)}
-                  %
-                </span>
+                <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
                 <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                <span>
-                  {newBorrowPercent.dp(2, 1).toString(10)}
-                  %
-                </span>
+                <span>{newBorrowPercent.dp(2, 1).toString(10)}%</span>
               </div>
             )}
           </div>
@@ -342,34 +320,17 @@ function WithdrawTab({ asset, changeTab, onCancel, setSetting }: $TSFixMe) {
           }
           onClick={handleWithdraw}
         >
-          {isLoading && <Icon type="loading" />}
-          {' '}
-          Withdraw
+          {isLoading && <Icon type="loading" />} Withdraw
         </Button>
         <div className="description">
           <span>Protocol Balance</span>
           <span>
-            {format(asset.supplyBalance.dp(2, 1).toString(10))}
-            {' '}
-            {asset.symbol}
+            {format(asset.supplyBalance.dp(2, 1).toString(10))} {asset.symbol}
           </span>
         </div>
       </TabContent>
     </TabSection>
   );
 }
-
-WithdrawTab.propTypes = {
-  asset: PropTypes.object,
-  changeTab: PropTypes.func,
-  onCancel: PropTypes.func,
-  setSetting: PropTypes.func.isRequired,
-};
-
-WithdrawTab.defaultProps = {
-  asset: {},
-  changeTab: () => {},
-  onCancel: () => {},
-};
 
 export default connectAccount(null)(WithdrawTab);

--- a/src/components/Basic/Table.tsx
+++ b/src/components/Basic/Table.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Table } from 'antd';
-import PropTypes from 'prop-types';
+import { ColumnProps } from 'antd/lib/table';
 import styled from 'styled-components';
 
 const MarketTableWrapper = styled.div`
@@ -152,9 +152,14 @@ const MarketTableWrapper = styled.div`
   }
 `;
 
-function MarketTable({
-  columns, data, title, handleClickRow,
-}: $TSFixMe) {
+interface MarketTableProps {
+  data: unknown[];
+  columns: ColumnProps<unknown>[];
+  title: string;
+  handleClickRow: (row: unknown) => void;
+}
+
+function MarketTable({ columns, data, title, handleClickRow }: MarketTableProps) {
   return (
     <MarketTableWrapper>
       <div className="all-title">{title}</div>
@@ -169,18 +174,5 @@ function MarketTable({
     </MarketTableWrapper>
   );
 }
-
-MarketTable.propTypes = {
-  data: PropTypes.array,
-  columns: PropTypes.array,
-  title: PropTypes.string,
-  handleClickRow: PropTypes.func.isRequired,
-};
-
-MarketTable.defaultProps = {
-  data: [],
-  columns: [],
-  title: '',
-};
 
 export default MarketTable;

--- a/src/components/Basic/Toast.tsx
+++ b/src/components/Basic/Toast.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { toast as toastify } from 'react-toastify';
 
-export function Toast({
-  title, description, type, ...props
-}: $TSFixMe) {
+interface ToastProps {
+  title: string;
+  description: string;
+  type: 'success' | 'info' | 'error';
+}
+
+export function Toast({ title, description, type, ...props }: ToastProps) {
   return (
     <div {...props} className={`toast_container_wrapper ${type}`}>
       {title && <p className="title">{title}</p>}
@@ -13,24 +16,13 @@ export function Toast({
   );
 }
 
-Toast.propTypes = {
-  title: PropTypes.string,
-  description: PropTypes.string,
-  type: PropTypes.oneOf(['success', 'info', 'error']),
-};
-
 Toast.defaultProps = {
   title: '',
   description: '',
   type: 'success',
 };
 
-function toast(
-  {
-    title, description, type = 'success', ...props
-  }: $TSFixMe,
-  options = {},
-) {
+function toast({ title, description, type = 'success', ...props }: $TSFixMe, options = {}) {
   return toastify(
     <Toast title={title} description={description} type={type} {...props} />,
     options,
@@ -39,9 +31,11 @@ function toast(
 
 toast.info = (content: $TSFixMe, options: $TSFixMe) => toast({ ...content, type: 'info' }, options);
 
-toast.error = (content: $TSFixMe, options: $TSFixMe) => toast({ ...content, type: 'error' }, options);
+toast.error = (content: $TSFixMe, options: $TSFixMe) =>
+  toast({ ...content, type: 'error' }, options);
 
-toast.success = (content: $TSFixMe, options: $TSFixMe) => toast({ ...content, type: 'success' }, options);
+toast.success = (content: $TSFixMe, options: $TSFixMe) =>
+  toast({ ...content, type: 'success' }, options);
 toast.update = toastify.update;
 
 export default toast;

--- a/src/components/Basic/Toggle.tsx
+++ b/src/components/Basic/Toggle.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Switch } from 'antd';
 
@@ -27,18 +26,18 @@ const ToggleWrapper = styled.div`
   }
 `;
 
-function Toggle({ checked, onChecked }: $TSFixMe) {
+interface ToggleProps {
+  checked: boolean;
+  onChecked: () => void;
+}
+
+function Toggle({ checked, onChecked }: ToggleProps) {
   return (
     <ToggleWrapper onClick={(e: $TSFixMe) => e.stopPropagation()}>
       <Switch checked={checked} onChange={onChecked} />
     </ToggleWrapper>
   );
 }
-
-Toggle.propTypes = {
-  checked: PropTypes.bool,
-  onChecked: PropTypes.func,
-};
 
 Toggle.defaultProps = {
   checked: true,

--- a/src/components/Dashboard/Market.tsx
+++ b/src/components/Dashboard/Market.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
-import { connectAccount } from 'core';
+import { connect } from 'react-redux';
 import SupplyMarket from 'components/Dashboard/Market/SupplyMarket';
 import BorrowMarket from 'components/Dashboard/Market/BorrowMarket';
 import { Card } from 'components/Basic/Card';
 import MintTab from 'components/Basic/VaiTabs/MintTab';
 import RepayVaiTab from 'components/Basic/VaiTabs/RepayVaiTab';
 import { State } from 'core/modules/initialState';
+import { accountActionCreators } from 'core/modules/account/actions';
 import { Setting } from 'types';
 import { useMarketsUser } from '../../hooks/useMarketsUser';
 
@@ -54,11 +55,12 @@ const MintRepayVai = styled.div`
   }
 `;
 
-interface Props {
+interface MarketProps {
+  settings: Setting;
   setSetting: (setting: Partial<Setting> | undefined) => void;
 }
 
-const Market = ({ setSetting }: Props) => {
+const Market = ({ setSetting }: MarketProps) => {
   const [currentTab, setCurrentTab] = useState('supply');
   const [suppliedAssets, setSuppliedAssets] = useState([]);
   const [nonSuppliedAssets, setNonSuppliedAssets] = useState([]);
@@ -163,4 +165,4 @@ const mapStateToProps = ({ account }: State) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(Market);
+export default connect(mapStateToProps, accountActionCreators)(Market);

--- a/src/components/Dashboard/Market/SupplyMarket.tsx
+++ b/src/components/Dashboard/Market/SupplyMarket.tsx
@@ -36,7 +36,7 @@ interface Props {
 function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateProps) {
   const [isOpenModal, setIsOpenModal] = useState(false);
   const [isOpenCollateralConfirm, setIsCollateralConfirm] = useState(false);
-  const [record, setRecord] = useState({});
+  const [record, setRecord] = useState({} as Asset);
   const [isCollateralEnalbe, setIsCollateralEnable] = useState(true);
   const { account } = useWeb3React();
   const comptrollerContract = useComptroller();
@@ -88,10 +88,7 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
                 <Label size="14" primary>
                   {asset.name}
                 </Label>
-                <Label size="14">
-                  {asset.supplyApy.dp(2, 1).toString(10)}
-                  %
-                </Label>
+                <Label size="14">{asset.supplyApy.dp(2, 1).toString(10)}%</Label>
               </div>
             </div>
           ),
@@ -125,9 +122,7 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
         return {
           children: (
             <Label size="14" primary>
-              {format(walletBalance.dp(2, 1).toString(10))}
-              {' '}
-              {asset.symbol}
+              {format(walletBalance.dp(2, 1).toString(10))} {asset.symbol}
             </Label>
           ),
         };
@@ -163,10 +158,7 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
                 <Label size="14" primary>
                   {asset.name}
                 </Label>
-                <Label size="14">
-                  {asset.supplyApy.dp(2, 1).toString(10)}
-                  %
-                </Label>
+                <Label size="14">{asset.supplyApy.dp(2, 1).toString(10)}%</Label>
               </div>
             </div>
           ),
@@ -209,9 +201,7 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
                 )}
               </Label>
               <Label size="14">
-                {format(supplyBalance.dp(4, 1).toString(10))}
-                {' '}
-                {asset.symbol}
+                {format(supplyBalance.dp(4, 1).toString(10))} {asset.symbol}
               </Label>
             </div>
           ),

--- a/src/components/Dashboard/Overview.tsx
+++ b/src/components/Dashboard/Overview.tsx
@@ -1,9 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import BigNumber from 'bignumber.js';
 import { Select, Icon } from 'antd';
-import { connectAccount } from 'core';
+import { connect } from 'react-redux';
+import { accountActionCreators } from 'core/modules/account/actions';
 import OverviewChart from 'components/Basic/OverviewChart';
 import { promisify } from 'utilities';
 import * as constants from 'utilities/constants';
@@ -11,6 +11,7 @@ import commaNumber from 'comma-number';
 import { addToken, getBigNumber, formatApy } from 'utilities/common';
 import { Card } from 'components/Basic/Card';
 import { uid } from 'react-uid';
+import { Setting } from 'types';
 import { useMarkets } from '../../hooks/useMarkets';
 import { useMarketsUser } from '../../hooks/useMarketsUser';
 import { vtokenDecimals } from '../../config';
@@ -139,7 +140,12 @@ const { Option } = Select;
 const abortController = new AbortController();
 const format = commaNumber.bindWith(',', '.');
 
-function Overview({ settings, getMarketHistory }: $TSFixMe) {
+interface OverviewProps {
+  settings: Setting;
+  getMarketHistory: $TSFixMe;
+}
+
+function Overview({ settings, getMarketHistory }: OverviewProps) {
   const [currentAsset, setCurrentAsset] = useState('sxp');
   const [data, setData] = useState([]);
   const [marketInfo, setMarketInfo] = useState({});
@@ -255,8 +261,7 @@ function Overview({ settings, getMarketHistory }: $TSFixMe) {
                       // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
                       src={constants.CONTRACT_TOKEN_ADDRESS[key].asset}
                       alt="asset"
-                    />
-                    {' '}
+                    />{' '}
                     <span>
                       {/* @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message */}
                       {constants.CONTRACT_TOKEN_ADDRESS[key].symbol}
@@ -435,12 +440,8 @@ function Overview({ settings, getMarketHistory }: $TSFixMe) {
   );
 }
 
-Overview.propTypes = {
-  getMarketHistory: PropTypes.func.isRequired,
-};
-
 const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(Overview);
+export default connect(mapStateToProps, accountActionCreators)(Overview);

--- a/src/components/Dashboard/VaiInfo.tsx
+++ b/src/components/Dashboard/VaiInfo.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Icon } from 'antd';
-import { connectAccount } from 'core';
+import { connect } from 'react-redux';
 import commaNumber from 'comma-number';
 import coinImg from 'assets/img/coins/vai.svg';
 import { Card } from 'components/Basic/Card';
 import { addToken } from 'utilities/common';
 import { useWeb3React } from '@web3-react/core';
+import { Setting } from 'types';
 import { BASE_BSC_SCAN_URL } from '../../config';
 import { useVaiUser } from '../../hooks/useVaiUser';
 import { getVaiTokenAddress } from '../../utilities/addressHelpers';
@@ -63,7 +64,11 @@ const CardWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
-function VaiInfo({ settings }: $TSFixMe) {
+interface VaiInfoProps {
+  settings: Setting;
+}
+
+function VaiInfo({ settings }: VaiInfoProps) {
   const { account } = useWeb3React();
   const { userVaiBalance } = useVaiUser();
   const handleLink = () => {
@@ -75,12 +80,7 @@ function VaiInfo({ settings }: $TSFixMe) {
       <CardWrapper className="flex align-center just-between">
         <div className="flex align-center">
           <img src={coinImg} alt="coin" />
-          <p>
-            {format(userVaiBalance.dp(2, 1).toString(10))}
-            {' '}
-            VAI
-            {' '}
-          </p>
+          <p>{format(userVaiBalance.dp(2, 1).toString(10))} VAI </p>
           {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'ethereum' does not exist on type 'Window... Remove this comment to see the full error message */}
           {(window.ethereum || window.BinanceChain) && (
             <Icon
@@ -99,8 +99,7 @@ function VaiInfo({ settings }: $TSFixMe) {
           {settings.vaiAPY && (
             <p className="vai-apy">
               APY:
-              {settings.vaiAPY}
-              %
+              {settings.vaiAPY}%
             </p>
           )}
         </div>
@@ -121,4 +120,4 @@ const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(VaiInfo);
+export default connect(mapStateToProps)(VaiInfo);

--- a/src/components/Dashboard/WalletBalance.tsx
+++ b/src/components/Dashboard/WalletBalance.tsx
@@ -1,17 +1,18 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import PropTypes from 'prop-types';
-import { connectAccount } from 'core';
+import { connect } from 'react-redux';
 import styled from 'styled-components';
 import CircleProgressBar from 'components/Basic/CircleProgressBar';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
 import AnimatedNumber from 'animated-number-react';
+import { useWeb3React } from '@web3-react/core';
+import { accountActionCreators } from 'core/modules/account/actions';
 import { Card } from 'components/Basic/Card';
 import { Row, Column } from 'components/Basic/Style';
 import { getBigNumber } from 'utilities/common';
 import Toggle from 'components/Basic/Toggle';
 import { Label } from 'components/Basic/Label';
-import { useWeb3React } from '@web3-react/core';
+import { Setting } from 'types';
 import { useVaiUser } from '../../hooks/useVaiUser';
 import { useMarketsUser } from '../../hooks/useMarketsUser';
 import { useVaiVault } from '../../hooks/useContract';
@@ -80,7 +81,12 @@ const BalancerWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
-function WalletBalance({ settings, setSetting }: $TSFixMe) {
+interface WalletBalanceProps {
+  settings: Setting;
+  setSetting: (setting: Partial<Setting> | undefined) => void;
+}
+
+function WalletBalance({ settings, setSetting }: WalletBalanceProps) {
   const [netAPY, setNetAPY] = useState(0);
   const [withXVS, setWithXVS] = useState(true);
   const { userVaiMinted } = useVaiUser();
@@ -253,12 +259,8 @@ function WalletBalance({ settings, setSetting }: $TSFixMe) {
   );
 }
 
-WalletBalance.propTypes = {
-  setSetting: PropTypes.func.isRequired,
-};
-
 const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(WalletBalance);
+export default connect(mapStateToProps, accountActionCreators)(WalletBalance);

--- a/src/components/MarketDetail/InterestRateModel.tsx
+++ b/src/components/MarketDetail/InterestRateModel.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
 import BigNumber from 'bignumber.js';
@@ -121,6 +120,16 @@ interface Props extends RouteComponentProps {
   currentAsset: string;
 }
 
+interface CustomizedAxisTickProps {
+  x: number;
+  y: number;
+}
+
+interface CustomTooltipProps {
+  active: boolean;
+  payload: Array<{ value: BigNumber.Value }>;
+}
+
 function InterestRateModel({ currentAsset }: Props) {
   const [graphData, setGraphData] = useState([]);
   const [tickerPos, setTickerPos] = useState(null);
@@ -132,17 +141,13 @@ function InterestRateModel({ currentAsset }: Props) {
   const { markets } = useMarkets();
   const web3 = useWeb3();
 
-  const CustomizedAxisTick = ({ x, y }: $TSFixMe) => (
+  const CustomizedAxisTick = ({ x, y }: CustomizedAxisTickProps) => (
     <g transform={`translate(${x},${y})`}>
       <text x={0} y={0} dy={16}>
         {/* {moment(payload.value).format('LLLL')} */}
       </text>
     </g>
   );
-  CustomizedAxisTick.propTypes = {
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
-  };
 
   const getGraphData = async (asset: $TSFixMe) => {
     flag = true;
@@ -254,7 +259,7 @@ function InterestRateModel({ currentAsset }: Props) {
     flag = false;
   }, [currentAsset]);
 
-  const CustomTooltip = ({ active, payload }: $TSFixMe) => {
+  const CustomTooltip = ({ active, payload }: CustomTooltipProps) => {
     if (active && payload && payload.length !== 0) {
       return (
         <div className="custom-tooltip">
@@ -268,10 +273,6 @@ function InterestRateModel({ currentAsset }: Props) {
       );
     }
     return null;
-  };
-  CustomTooltip.propTypes = {
-    active: PropTypes.bool.isRequired,
-    payload: PropTypes.array.isRequired,
   };
 
   const handleMouseMove = (e: $TSFixMe) => {
@@ -308,9 +309,7 @@ function InterestRateModel({ currentAsset }: Props) {
           </div>
         )}
         <div className="ticker-percent" style={{ left: tickerPos || currentPos }}>
-          {percent === null ? currentPercent : percent}
-          {' '}
-          %
+          {percent === null ? currentPercent : percent} %
         </div>
         <div
           id="ticker-line"

--- a/src/components/MarketDetail/MarketSummary.tsx
+++ b/src/components/MarketDetail/MarketSummary.tsx
@@ -4,6 +4,7 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
 import { connectAccount } from 'core';
+import { State } from 'core/modules/initialState';
 import * as constants from 'utilities/constants';
 import { vtokenDecimals } from '../../config';
 
@@ -92,8 +93,7 @@ function MarketSummary({ marketInfo, currentAsset }: Props) {
       <div className="description">
         <p className="label">Borrow Cap</p>
         <p className="value">
-          $
-          {format(new BigNumber(marketInfo.totalBorrowsUsd).dp(2, 1).toString(10))}
+          ${format(new BigNumber(marketInfo.totalBorrowsUsd).dp(2, 1).toString(10))}
         </p>
       </div>
       <div className="description">
@@ -157,12 +157,7 @@ function MarketSummary({ marketInfo, currentAsset }: Props) {
         </p>
       </div>
       <div className="description">
-        <p className="label">
-          v
-          {marketInfo.underlyingSymbol}
-          {' '}
-          Minted
-        </p>
+        <p className="label">v{marketInfo.underlyingSymbol} Minted</p>
         <p className="value">{format(marketInfo.totalSupply2)}</p>
       </div>
       <div className="description">
@@ -188,12 +183,7 @@ function MarketSummary({ marketInfo, currentAsset }: Props) {
   );
 }
 
-MarketSummary.defaultProps = {
-  marketInfo: {},
-  currentAsset: '',
-};
-
-const mapStateToProps = ({ account }: $TSFixMe) => ({
+const mapStateToProps = ({ account }: State) => ({
   settings: account.setting,
 });
 

--- a/src/components/PrivateRoute/PrivateRoute.tsx
+++ b/src/components/PrivateRoute/PrivateRoute.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { Route, Redirect } from 'react-router-dom';
 import { connectAuth } from 'core';
+import { User } from 'types';
 import { State } from 'core/modules/initialState';
 
-class PrivateRoute extends React.PureComponent {
+interface PrivateRouteProps {
+  user?: User;
+}
+
+class PrivateRoute extends React.PureComponent<PrivateRouteProps> {
   render() {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'user' does not exist on type 'Readonly<{... Remove this comment to see the full error message
     const { user, ...props } = this.props;
     if (user && user.Token) {
       return <Route {...props} />;
@@ -14,16 +17,6 @@ class PrivateRoute extends React.PureComponent {
     return <Redirect to="/" />;
   }
 }
-
-// @ts-expect-error ts-migrate(2339) FIXME: Property 'propTypes' does not exist on type 'typeo... Remove this comment to see the full error message
-PrivateRoute.propTypes = {
-  user: PropTypes.object,
-};
-
-// @ts-expect-error ts-migrate(2339) FIXME: Property 'defaultProps' does not exist on type 'ty... Remove this comment to see the full error message
-PrivateRoute.defaultProps = {
-  user: PropTypes.object,
-};
 
 const mapStateToProps = ({ auth }: State) => ({
   user: auth.user,

--- a/src/components/Vault/Card.tsx
+++ b/src/components/Vault/Card.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { Row, Col } from 'antd';
 import BigNumber from 'bignumber.js';
-import PropTypes from 'prop-types';
 import commaNumber from 'comma-number';
 import * as constants from 'utilities/constants';
 import VaultCardContent from './CardContent';
@@ -21,6 +20,18 @@ function getTokenImg(name: $TSFixMe) {
   }[name];
 }
 
+interface VaultCardProps {
+  poolId: BigNumber;
+  stakedToken: string;
+  rewardToken: string;
+  userStakedAmount: BigNumber;
+  pendingReward: BigNumber;
+  lockPeriodSecond: BigNumber;
+  apr: BigNumber;
+  totalStaked: BigNumber;
+  dailyEmission: BigNumber;
+}
+
 function VaultCard({
   poolId,
   stakedToken,
@@ -31,7 +42,7 @@ function VaultCard({
   apr,
   totalStaked,
   dailyEmission,
-}: $TSFixMe) {
+}: VaultCardProps) {
   const stakedTokenDecimal = new BigNumber(10).pow(
     // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     constants.CONTRACT_TOKEN_ADDRESS[stakedToken].decimals,
@@ -45,52 +56,28 @@ function VaultCard({
     <VaultCardWrapper>
       <div className={`header-container ${expanded ? '' : 'fold'}`}>
         <Row className="header">
-          <Col
-            className="col-item"
-            lg={{ span: 3 }}
-            md={{ span: 6 }}
-            xs={{ span: 12 }}
-          >
+          <Col className="col-item" lg={{ span: 3 }} md={{ span: 6 }} xs={{ span: 12 }}>
             <div className="title">Stake</div>
             <div className="content">
               <img src={getTokenImg(stakedToken)} alt="stakedToken" />
               <span>{stakedToken.toUpperCase()}</span>
             </div>
           </Col>
-          <Col
-            className="col-item"
-            lg={{ span: 3 }}
-            md={{ span: 6 }}
-            xs={{ span: 12 }}
-          >
+          <Col className="col-item" lg={{ span: 3 }} md={{ span: 6 }} xs={{ span: 12 }}>
             <div className="title">Earn</div>
             <div className="content">
               <img src={getTokenImg(rewardToken)} alt="rewardToken" />
               <span>{rewardToken.toUpperCase()}</span>
             </div>
           </Col>
-          <Col
-            className="col-item"
-            lg={{ span: 4 }}
-            md={{ span: 6 }}
-            xs={{ span: 12 }}
-          >
+          <Col className="col-item" lg={{ span: 4 }} md={{ span: 6 }} xs={{ span: 12 }}>
             <div className="title">Available Rewards</div>
             <div className="content">
               {commaFormatter(pendingReward.div(rewardTokenDecimal).toFixed(4))}
             </div>
           </Col>
-          <Col
-            className="col-item"
-            lg={{ span: 4 }}
-            md={{ span: 6 }}
-            xs={{ span: 12 }}
-          >
-            <div className="title">
-              {stakedToken.toUpperCase()}
-              {' '}
-              Staking APR
-            </div>
+          <Col className="col-item" lg={{ span: 4 }} md={{ span: 6 }} xs={{ span: 12 }}>
+            <div className="title">{stakedToken.toUpperCase()} Staking APR</div>
             <div className="content">
               {commaFormatter(
                 apr
@@ -101,18 +88,10 @@ function VaultCard({
               %
             </div>
           </Col>
-          <Col
-            className="col-item"
-            lg={{ span: 4 }}
-            md={{ span: 6 }}
-            xs={{ span: 12 }}
-          >
+          <Col className="col-item" lg={{ span: 4 }} md={{ span: 6 }} xs={{ span: 12 }}>
             <div className="title">
               Total
-              {' '}
-              {stakedToken.toUpperCase()}
-              {' '}
-              Staked
+              {stakedToken.toUpperCase()} Staked
             </div>
             <div className="content">
               {commaFormatter(
@@ -123,25 +102,15 @@ function VaultCard({
               )}
             </div>
           </Col>
-          <Col
-            className="col-item"
-            lg={{ span: 4 }}
-            md={{ span: 6 }}
-            xs={{ span: 12 }}
-          >
-            <div className="title">
-              {rewardToken.toUpperCase()}
-              {' '}
-              Daily Emission
-            </div>
+          <Col className="col-item" lg={{ span: 4 }} md={{ span: 6 }} xs={{ span: 12 }}>
+            <div className="title">{rewardToken.toUpperCase()} Daily Emission</div>
             <div className="content">
               {commaFormatter(
                 dailyEmission
                   .div(rewardTokenDecimal)
                   .dp(4, 1)
                   .toString(10),
-              )}
-              {' '}
+              )}{' '}
               {rewardToken.toUpperCase()}
             </div>
           </Col>
@@ -172,17 +141,5 @@ function VaultCard({
     </VaultCardWrapper>
   );
 }
-
-VaultCard.propTypes = {
-  poolId: PropTypes.instanceOf(BigNumber).isRequired,
-  stakedToken: PropTypes.string.isRequired,
-  rewardToken: PropTypes.string.isRequired,
-  userStakedAmount: PropTypes.instanceOf(BigNumber).isRequired,
-  pendingReward: PropTypes.instanceOf(BigNumber).isRequired,
-  lockPeriodSecond: PropTypes.instanceOf(BigNumber).isRequired,
-  apr: PropTypes.instanceOf(BigNumber).isRequired,
-  totalStaked: PropTypes.instanceOf(BigNumber).isRequired,
-  dailyEmission: PropTypes.instanceOf(BigNumber).isRequired,
-};
 
 export default VaultCard;

--- a/src/components/Vault/VaiCard.tsx
+++ b/src/components/Vault/VaiCard.tsx
@@ -6,8 +6,10 @@ import React, { useState, useEffect } from 'react';
 import { Row, Col } from 'antd';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
-import { connectAccount } from 'core';
+import { connect } from 'react-redux';
 import { useWeb3React } from '@web3-react/core';
+import { Setting } from 'types';
+import { State } from 'core/modules/initialState';
 import VAICardContent from './VaiCardContent';
 import { VaultCardWrapper } from './styles';
 import useRefresh from '../../hooks/useRefresh';
@@ -20,7 +22,11 @@ import { getVaiVaultAddress } from '../../utilities/addressHelpers';
 
 const commaFormatter = commaNumber.bindWith(',', '.');
 
-function VaultCard({ settings }: $TSFixMe) {
+interface VaultCardProps {
+  settings: Setting;
+}
+
+function VaultCard({ settings }: VaultCardProps) {
   const { account } = useWeb3React();
   const { fastRefresh } = useRefresh();
 
@@ -113,35 +119,26 @@ function VaultCard({ settings }: $TSFixMe) {
                   .div(1e18)
                   .dp(4, 1)
                   .toString(10),
-              )}
-              {' '}
+              )}{' '}
               XVS
             </div>
           </Col>
           <Col className="col-item" lg={{ span: 4 }} md={{ span: 6 }} xs={{ span: 12 }}>
             <div className="title">VAI Staking APR</div>
-            <div className="content">
-              {settings.vaiAPY}
-              %
-            </div>
+            <div className="content">{settings.vaiAPY}%</div>
           </Col>
           <Col className="col-item" lg={{ span: 4 }} md={{ span: 6 }} xs={{ span: 12 }}>
             <div className="title">Total VAI Staked</div>
             <div className="content">
               {settings.vaultVaiStaked
                 ? commaFormatter(new BigNumber(settings.vaultVaiStaked).dp(4, 1).toString(10))
-                : 0}
-              {' '}
+                : 0}{' '}
               VAI
             </div>
           </Col>
           <Col className="col-item" lg={{ span: 4 }} md={{ span: 6 }} xs={{ span: 12 }}>
             <div className="title">XVS Daily Emission</div>
-            <div className="content">
-              {commaFormatter(dailyEmission.toString(10))}
-              {' '}
-              XVS
-            </div>
+            <div className="content">{commaFormatter(dailyEmission.toString(10))} XVS</div>
           </Col>
           <Col
             className="col-item expand-icon-wrapper"
@@ -167,10 +164,8 @@ function VaultCard({ settings }: $TSFixMe) {
   );
 }
 
-VaultCard.defaultProps = {};
-
-const mapStateToProps = ({ account }: $TSFixMe) => ({
+const mapStateToProps = ({ account }: State) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(VaultCard);
+export default connect(mapStateToProps)(VaultCard);

--- a/src/components/Vault/VaiCardContent.tsx
+++ b/src/components/Vault/VaiCardContent.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import { Row, Col, Icon } from 'antd';
 import BigNumber from 'bignumber.js';
-import PropTypes from 'prop-types';
 import { useWeb3React } from '@web3-react/core';
 import NumberFormat from 'react-number-format';
 import { useVaiToken, useVaiVault } from '../../hooks/useContract';
@@ -13,12 +12,19 @@ const VaiCardContentWrapper = styled.div`
   padding: 16px 40px 0 24px;
 `;
 
+interface VaiCardContentProps {
+  userPendingReward: BigNumber;
+  userVaiBalance: BigNumber;
+  userVaiAllowance: BigNumber;
+  userVaiStakedAmount: BigNumber;
+}
+
 function VaiCardContent({
   userPendingReward,
   userVaiBalance,
   userVaiAllowance,
   userVaiStakedAmount,
-}: $TSFixMe) {
+}: VaiCardContentProps) {
   const { account } = useWeb3React();
   const vaiTokenContract = useVaiToken();
   const vaiVaultContract = useVaiVault();
@@ -115,8 +121,7 @@ function VaiCardContent({
                   {userPendingReward
                     .div(1e18)
                     .dp(6, 1)
-                    .toString(10)}
-                  {' '}
+                    .toString(10)}{' '}
                   XVS
                 </div>
               </div>
@@ -128,9 +133,7 @@ function VaiCardContent({
                   handleClaimReward();
                 }}
               >
-                {isClaimLoading && <Icon type="loading" />}
-                {' '}
-                Claim
+                {isClaimLoading && <Icon type="loading" />} Claim
               </button>
             </div>
           </CardItemWrapper>
@@ -143,8 +146,7 @@ function VaiCardContent({
               <div className="left">
                 <div className="card-title">
                   <span>
-                    VAI Staked:
-                    {' '}
+                    VAI Staked:{' '}
                     {userVaiStakedAmount
                       .div(1e18)
                       .dp(4, 1)
@@ -155,17 +157,11 @@ function VaiCardContent({
                   <div className="input-wrapper">
                     <NumberFormat
                       autoFocus
-                      value={
-                        withdrawAmount.isZero()
-                          ? '0'
-                          : withdrawAmount.toString(10)
-                      }
-                      onValueChange={(values) => {
+                      value={withdrawAmount.isZero() ? '0' : withdrawAmount.toString(10)}
+                      onValueChange={values => {
                         const value = new BigNumber(values.value || 0);
                         const maxValue = userVaiStakedAmount.div(1e18).dp(4, 1);
-                        setWithdrawAmount(
-                          value.gt(maxValue) ? maxValue : value,
-                        );
+                        setWithdrawAmount(value.gt(maxValue) ? maxValue : value);
                       }}
                       thousandSeparator
                       allowNegative={false}
@@ -185,18 +181,12 @@ function VaiCardContent({
               <button
                 type="button"
                 className="button claim-button"
-                disabled={
-                  !withdrawAmount.gt(0)
-                  || !userVaiStakedAmount.gt(0)
-                  || !account
-                }
+                disabled={!withdrawAmount.gt(0) || !userVaiStakedAmount.gt(0) || !account}
                 onClick={() => {
                   handleWithdrawVAI();
                 }}
               >
-                {isWithdrawLoading && <Icon type="loading" />}
-                {' '}
-                Withdraw
+                {isWithdrawLoading && <Icon type="loading" />} Withdraw
               </button>
             </div>
           </CardItemWrapper>
@@ -208,8 +198,7 @@ function VaiCardContent({
             <div className="card-item stake">
               <div className="withdraw-request">
                 <div className="card-title">
-                  Available VAI to stake:
-                  {' '}
+                  Available VAI to stake:{' '}
                   {userVaiBalance
                     .div(1e18)
                     .dp(4, 1)
@@ -218,10 +207,8 @@ function VaiCardContent({
                 <div className="input-wrapper">
                   <NumberFormat
                     autoFocus
-                    value={
-                      stakeAmount.isZero() ? '0' : stakeAmount.toString(10)
-                    }
-                    onValueChange={(values) => {
+                    value={stakeAmount.isZero() ? '0' : stakeAmount.toString(10)}
+                    onValueChange={values => {
                       const value = new BigNumber(values.value || 0);
                       const maxValue = userVaiBalance.div(1e18).dp(4, 1);
                       setStakeAmount(value.gt(maxValue) ? maxValue : value);
@@ -262,12 +249,5 @@ function VaiCardContent({
     </VaiCardContentWrapper>
   );
 }
-
-VaiCardContent.propTypes = {
-  userPendingReward: PropTypes.instanceOf(BigNumber).isRequired,
-  userVaiBalance: PropTypes.instanceOf(BigNumber).isRequired,
-  userVaiAllowance: PropTypes.instanceOf(BigNumber).isRequired,
-  userVaiStakedAmount: PropTypes.instanceOf(BigNumber).isRequired,
-};
 
 export default VaiCardContent;

--- a/src/components/Vault/WithdrawHistoryModal.tsx
+++ b/src/components/Vault/WithdrawHistoryModal.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled from 'styled-components';
 import { Modal } from 'antd';
 import BigNumber from 'bignumber.js';
-import PropTypes from 'prop-types';
 import closeImg from 'assets/img/close.png';
 import moment from 'moment';
 import { uid } from 'react-uid';
@@ -57,13 +56,21 @@ const WithdrawHistoryModalWrapper = styled.div`
   }
 `;
 
+interface WithdrawHistoryModalProps {
+  visible: boolean;
+  onCancel: () => void;
+  pendingWithdrawals: unknown[];
+  withdrawableAmount: BigNumber;
+  stakedToken: string;
+}
+
 function WithdrawHistoryModal({
   visible,
   onCancel,
   pendingWithdrawals,
   withdrawableAmount,
   stakedToken,
-}: $TSFixMe) {
+}: WithdrawHistoryModalProps) {
   const stakedTokenDecimal = new BigNumber(10).pow(
     // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
     constants.CONTRACT_TOKEN_ADDRESS[stakedToken].decimals,
@@ -80,21 +87,14 @@ function WithdrawHistoryModal({
       centered
     >
       <WithdrawHistoryModalWrapper>
-        <img
-          className="close-btn pointer"
-          src={closeImg}
-          alt="close"
-          onClick={onCancel}
-        />
+        <img className="close-btn pointer" src={closeImg} alt="close" onClick={onCancel} />
         <div className="title">Request Withdrawal List</div>
         <div className="subtitle">
-          Withdrawable amount:
-          {' '}
+          Withdrawable amount:{' '}
           {withdrawableAmount
             .div(stakedTokenDecimal)
             .dp(4, 1)
-            .toString(10)}
-          {' '}
+            .toString(10)}{' '}
           {stakedToken.toUpperCase()}
         </div>
         <div className="list">
@@ -109,15 +109,13 @@ function WithdrawHistoryModal({
                   {withdraw.amount
                     .div(stakedTokenDecimal)
                     .dp(4, 1)
-                    .toString(10)}
-                  {' '}
+                    .toString(10)}{' '}
                   {stakedToken.toUpperCase()}
                 </span>
                 <span className="right">
-                  {moment(
-                    new Date(withdraw.lockedUntil.toNumber(10) * 1000),
-                  ).format('DD/MM/YYYY HH:mm:ss')}
-                  {' '}
+                  {moment(new Date(withdraw.lockedUntil.toNumber(10) * 1000)).format(
+                    'DD/MM/YYYY HH:mm:ss',
+                  )}{' '}
                 </span>
               </div>
             ))}
@@ -127,13 +125,5 @@ function WithdrawHistoryModal({
     </Modal>
   );
 }
-
-WithdrawHistoryModal.propTypes = {
-  visible: PropTypes.bool.isRequired,
-  onCancel: PropTypes.func.isRequired,
-  pendingWithdrawals: PropTypes.array.isRequired,
-  withdrawableAmount: PropTypes.instanceOf(BigNumber).isRequired,
-  stakedToken: PropTypes.string.isRequired,
-};
 
 export default WithdrawHistoryModal;

--- a/src/components/Vote/CoinInfo.tsx
+++ b/src/components/Vote/CoinInfo.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Icon } from 'antd';
 import { connectAccount } from 'core';
@@ -46,7 +45,12 @@ const CardWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
-function CoinInfo({ address, balance }: $TSFixMe) {
+interface CoinInfoProps {
+  address: string;
+  balance: string;
+}
+
+function CoinInfo({ address, balance }: CoinInfoProps) {
   const handleLink = () => {
     window.open(`${BASE_BSC_SCAN_URL}/address/${address}`, '_blank');
   };
@@ -74,11 +78,6 @@ function CoinInfo({ address, balance }: $TSFixMe) {
     </Card>
   );
 }
-
-CoinInfo.propTypes = {
-  address: PropTypes.string,
-  balance: PropTypes.string,
-};
 
 CoinInfo.defaultProps = {
   address: '',

--- a/src/components/Vote/ProposerDetail/VotingHistory.tsx
+++ b/src/components/Vote/ProposerDetail/VotingHistory.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable no-useless-escape */
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Pagination } from 'antd';
-import { withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import Voting from 'components/Basic/Voting';
 import arrowRightImg from 'assets/img/arrow-right.png';
 import { Card } from 'components/Basic/Card';
@@ -95,8 +94,19 @@ const VotingHistoryWrapper = styled.div`
   }
 `;
 
-function VotingHistory({ data, pageNumber, total, onChangePage }: $TSFixMe) {
-  const [current, setCurrent] = useState(pageNumber);
+interface VotingHistoryProps extends RouteComponentProps {
+  data: {
+    proposalId?: number;
+    description?: string;
+    state?: string;
+  }[];
+  pageNumber?: number;
+  total: number;
+  onChangePage: (page: number, prev: number, size: number) => void;
+}
+
+function VotingHistory({ data, pageNumber, total, onChangePage }: VotingHistoryProps) {
+  const [current, setCurrent] = useState(pageNumber || 1);
   const [pageSize, setPageSize] = useState(5);
 
   const handleChangePage = (page: $TSFixMe, size: $TSFixMe) => {
@@ -154,19 +164,6 @@ function VotingHistory({ data, pageNumber, total, onChangePage }: $TSFixMe) {
     </Card>
   );
 }
-
-VotingHistory.propTypes = {
-  data: PropTypes.arrayOf(
-    PropTypes.shape({
-      proposalId: PropTypes.number,
-      description: PropTypes.string,
-      state: PropTypes.string,
-    }),
-  ),
-  pageNumber: PropTypes.number,
-  total: PropTypes.number,
-  onChangePage: PropTypes.func.isRequired,
-};
 
 VotingHistory.defaultProps = {
   data: [],

--- a/src/components/Vote/VoteOverview/ProposalDetail.tsx
+++ b/src/components/Vote/VoteOverview/ProposalDetail.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
 import { Card } from 'components/Basic/Card';
 import { Label } from 'components/Basic/Label';
 import { uid } from 'react-uid';
+import { ProposalInfo } from 'types';
 
 const ProposalDetailWrapper = styled.div`
   width: 100%;
@@ -33,7 +33,11 @@ const ProposalDetailWrapper = styled.div`
   }
 `;
 
-function ProposalDetail({ proposalInfo }: $TSFixMe) {
+interface ProposalDetailProps {
+  proposalInfo: Partial<ProposalInfo>;
+}
+
+function ProposalDetail({ proposalInfo }: ProposalDetailProps) {
   return (
     <Card>
       <ProposalDetailWrapper className="flex flex-column">
@@ -44,11 +48,7 @@ function ProposalDetail({ proposalInfo }: $TSFixMe) {
           <Label size="14">
             {/**/}
             {(proposalInfo.actions || []).map((s: $TSFixMe) => (
-              <ReactMarkdown
-                className="proposal-detail"
-                source={s.title}
-                key={uid(s)}
-              />
+              <ReactMarkdown className="proposal-detail" source={s.title} key={uid(s)} />
             ))}
           </Label>
         </div>
@@ -65,9 +65,6 @@ function ProposalDetail({ proposalInfo }: $TSFixMe) {
   );
 }
 
-ProposalDetail.propTypes = {
-  proposalInfo: PropTypes.object,
-};
 ProposalDetail.defaultProps = {
   proposalInfo: {},
 };

--- a/src/components/Vote/VoteOverview/ProposalHistory.tsx
+++ b/src/components/Vote/VoteOverview/ProposalHistory.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import moment from 'moment';
 import styled from 'styled-components';
 import { Steps, Icon } from 'antd';
 import { Card } from 'components/Basic/Card';
+import { ProposalInfo } from 'types';
 import { FORMAT_STRING } from '../../../utilities/time';
 
 const ProposalHistoryWrapper = styled.div`
@@ -74,18 +74,13 @@ const ProposalHistoryWrapper = styled.div`
 
 const { Step } = Steps;
 
-// Pending,
-// Active,
-// Canceled,
-// Defeated,
-// Succeeded,
-// Queued,
-// Expired,
-// Executed
-
 const STATUSES = ['Pending', 'Active', 'Succeeded', 'Queued', 'Executed'];
 
-function ProposalHistory({ proposalInfo }: $TSFixMe) {
+interface ProposalHistoryProps {
+  proposalInfo: Partial<ProposalInfo>;
+}
+
+function ProposalHistory({ proposalInfo }: ProposalHistoryProps) {
   const getStepNumber = () => {
     if (proposalInfo.state === 'Defeated' || proposalInfo.state === 'Canceled') return 2;
     return STATUSES.findIndex(s => s === proposalInfo.state);
@@ -100,8 +95,7 @@ function ProposalHistory({ proposalInfo }: $TSFixMe) {
             direction="vertical"
             current={getStepNumber()}
             status={
-              proposalInfo.state === 'Canceled'
-              || proposalInfo.state === 'Defeated'
+              proposalInfo.state === 'Canceled' || proposalInfo.state === 'Defeated'
                 ? 'error'
                 : 'finish'
             }
@@ -110,67 +104,41 @@ function ProposalHistory({ proposalInfo }: $TSFixMe) {
               title="Created"
               description={
                 proposalInfo.createdTimestamp
-                  ? moment(proposalInfo.createdTimestamp * 1000).format(
-                    FORMAT_STRING,
-                  )
+                  ? moment(proposalInfo.createdTimestamp * 1000).format(FORMAT_STRING)
                   : ''
               }
-              icon={(
-                <Icon
-                  type="check"
-                  style={{ fontSize: '10px', color: 'white' }}
-                />
-              )}
+              icon={<Icon type="check" style={{ fontSize: '10px', color: 'white' }} />}
               disabled
             />
             <Step
               title="Active"
               description={
                 proposalInfo.startTimestamp
-                  ? moment(proposalInfo.startTimestamp * 1000).format(
-                    FORMAT_STRING,
-                  )
+                  ? moment(proposalInfo.startTimestamp * 1000).format(FORMAT_STRING)
                   : ''
               }
-              icon={(
-                <Icon
-                  type="check"
-                  style={{ fontSize: '10px', color: 'white' }}
-                />
-              )}
+              icon={<Icon type="check" style={{ fontSize: '10px', color: 'white' }} />}
               disabled
             />
             <Step
               title={
-                proposalInfo.state === 'Canceled'
-                || proposalInfo.state === 'Defeated'
-                  ? `${
-                    proposalInfo.state === 'Defeated' ? 'Failed' : 'Canceled'
-                  }`
-                  : `${
-                    proposalInfo.state === 'Succeeded'
-                      ? 'Succeeded'
-                      : 'Succeed'
-                  }`
+                proposalInfo.state === 'Canceled' || proposalInfo.state === 'Defeated'
+                  ? `${proposalInfo.state === 'Defeated' ? 'Failed' : 'Canceled'}`
+                  : `${proposalInfo.state === 'Succeeded' ? 'Succeeded' : 'Succeed'}`
               }
               description={
                 proposalInfo.endTimestamp
-                  ? moment(proposalInfo.endTimestamp * 1000).format(
-                    FORMAT_STRING,
-                  )
+                  ? moment(proposalInfo.endTimestamp * 1000).format(FORMAT_STRING)
                   : `${
-                    proposalInfo.cancelTimestamp
-                      ? moment(proposalInfo.cancelTimestamp * 1000).format(
-                        FORMAT_STRING,
-                      )
-                      : ''
-                  }`
+                      proposalInfo.cancelTimestamp
+                        ? moment(proposalInfo.cancelTimestamp * 1000).format(FORMAT_STRING)
+                        : ''
+                    }`
               }
               icon={(
                 <Icon
                   type={
-                    proposalInfo.state === 'Canceled'
-                    || proposalInfo.state === 'Defeated'
+                    proposalInfo.state === 'Canceled' || proposalInfo.state === 'Defeated'
                       ? 'close'
                       : 'check'
                   }
@@ -179,55 +147,33 @@ function ProposalHistory({ proposalInfo }: $TSFixMe) {
               )}
               disabled
             />
-            {proposalInfo.state !== 'Defeated'
-              && proposalInfo.state !== 'Canceled' && (
-                <Step
-                  title={`${
-                    proposalInfo.state === 'Queued' ? 'Queued' : 'Queue'
-                  }`}
-                  description={
-                    proposalInfo.queuedTimestamp
-                      ? moment(proposalInfo.queuedTimestamp * 1000).format(
-                        FORMAT_STRING,
-                      )
-                      : ''
-                  }
-                  icon={(
-                    <Icon
-                      type="check"
-                      style={{ fontSize: '10px', color: 'white' }}
-                    />
-                  )}
-                  disabled
-                />
+            {proposalInfo.state !== 'Defeated' && proposalInfo.state !== 'Canceled' && (
+              <Step
+                title={`${proposalInfo.state === 'Queued' ? 'Queued' : 'Queue'}`}
+                description={
+                  proposalInfo.queuedTimestamp
+                    ? moment(proposalInfo.queuedTimestamp * 1000).format(FORMAT_STRING)
+                    : ''
+                }
+                icon={<Icon type="check" style={{ fontSize: '10px', color: 'white' }} />}
+                disabled
+              />
             )}
-            {proposalInfo.state !== 'Defeated'
-              && proposalInfo.state !== 'Canceled' && (
-                <Step
-                  title={
-                    proposalInfo.state === 'Expired'
-                      ? proposalInfo.state
-                      : `${
-                        proposalInfo.state === 'Executed'
-                          ? 'Executed'
-                          : 'Execute'
-                      }`
-                  }
-                  description={
-                    proposalInfo.executedTimestamp
-                      ? moment(proposalInfo.executedTimestamp * 1000).format(
-                        FORMAT_STRING,
-                      )
-                      : ''
-                  }
-                  icon={(
-                    <Icon
-                      type="check"
-                      style={{ fontSize: '10px', color: 'white' }}
-                    />
-                  )}
-                  disabled
-                />
+            {proposalInfo.state !== 'Defeated' && proposalInfo.state !== 'Canceled' && (
+              <Step
+                title={
+                  proposalInfo.state === 'Expired'
+                    ? proposalInfo.state
+                    : `${proposalInfo.state === 'Executed' ? 'Executed' : 'Execute'}`
+                }
+                description={
+                  proposalInfo.executedTimestamp
+                    ? moment(proposalInfo.executedTimestamp * 1000).format(FORMAT_STRING)
+                    : ''
+                }
+                icon={<Icon type="check" style={{ fontSize: '10px', color: 'white' }} />}
+                disabled
+              />
             )}
           </Steps>
         </div>
@@ -236,10 +182,4 @@ function ProposalHistory({ proposalInfo }: $TSFixMe) {
   );
 }
 
-ProposalHistory.propTypes = {
-  proposalInfo: PropTypes.object,
-};
-ProposalHistory.defaultProps = {
-  proposalInfo: {},
-};
 export default ProposalHistory;

--- a/src/components/Vote/VoteOverview/ProposalInfo.tsx
+++ b/src/components/Vote/VoteOverview/ProposalInfo.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import moment from 'moment';
 import Markdown from 'react-remarkable';
 import { Card } from 'components/Basic/Card';
+import { ProposalInfo as ProposalInfoType } from 'types';
 import { getRemainingTime, FORMAT_STRING } from '../../../utilities/time';
 
 const ProposalInfoWrapper = styled.div`
@@ -60,7 +60,11 @@ const ProposalInfoWrapper = styled.div`
   }
 `;
 
-function ProposalInfo({ proposalInfo }: $TSFixMe) {
+interface ProposalInfoProps {
+  proposalInfo: Partial<ProposalInfoType>;
+}
+
+function ProposalInfo({ proposalInfo }: ProposalInfoProps) {
   const getStatus = (proposal: $TSFixMe) => {
     if (proposal.state === 'Executed') {
       return 'Passed';
@@ -85,15 +89,11 @@ function ProposalInfo({ proposalInfo }: $TSFixMe) {
         )}
         <div className="flex align-center just-start proposal-status">
           <p>
-            {`${proposalInfo.id} ${getStatus(proposalInfo)} ${moment(
-              proposalInfo.updatedAt,
-            ).format(FORMAT_STRING)}`}
-          </p>
-          <div
-            className={`flex align-center just-center status ${getStatus(
-              proposalInfo,
+            {`${proposalInfo.id} ${getStatus(proposalInfo)} ${moment(proposalInfo.updatedAt).format(
+              FORMAT_STRING,
             )}`}
-          >
+          </p>
+          <div className={`flex align-center just-center status ${getStatus(proposalInfo)}`}>
             {getStatus(proposalInfo)}
           </div>
           <div className="left-time">{getRemainingTime(proposalInfo)}</div>
@@ -103,10 +103,4 @@ function ProposalInfo({ proposalInfo }: $TSFixMe) {
   );
 }
 
-ProposalInfo.propTypes = {
-  proposalInfo: PropTypes.object,
-};
-ProposalInfo.defaultProps = {
-  proposalInfo: {},
-};
 export default ProposalInfo;

--- a/src/components/Vote/VoteOverview/ProposalUser.tsx
+++ b/src/components/Vote/VoteOverview/ProposalUser.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Icon } from 'antd';
 import { Card } from 'components/Basic/Card';
+import { ProposalInfo } from 'types';
 import { BASE_BSC_SCAN_URL } from '../../../config';
 
 const ProposalUserWrapper = styled.div`
@@ -34,12 +34,13 @@ const ProposalUserWrapper = styled.div`
   }
 `;
 
-function ProposalUser({ proposalInfo }: $TSFixMe) {
+interface ProposalUserProps {
+  proposalInfo: Partial<ProposalInfo>;
+}
+
+function ProposalUser({ proposalInfo }: ProposalUserProps) {
   const handleAddLink = (linkType: $TSFixMe, v: $TSFixMe) => {
-    window.open(
-      `${BASE_BSC_SCAN_URL}/${linkType === 'address' ? 'address' : 'tx'}/${v}`,
-      '_blank',
-    );
+    window.open(`${BASE_BSC_SCAN_URL}/${linkType === 'address' ? 'address' : 'tx'}/${v}`, '_blank');
   };
 
   return (
@@ -51,10 +52,7 @@ function ProposalUser({ proposalInfo }: $TSFixMe) {
         >
           <p className="highlight">
             {proposalInfo.proposer
-              ? `${proposalInfo.proposer.substr(
-                0,
-                5,
-              )}...${proposalInfo.proposer.substr(-4, 4)}`
+              ? `${proposalInfo.proposer.substr(0, 5)}...${proposalInfo.proposer.substr(-4, 4)}`
               : ''}
           </p>
           <div className="flex align-center just-center copy-btn">
@@ -66,10 +64,4 @@ function ProposalUser({ proposalInfo }: $TSFixMe) {
   );
 }
 
-ProposalUser.propTypes = {
-  proposalInfo: PropTypes.object,
-};
-ProposalUser.defaultProps = {
-  proposalInfo: {},
-};
 export default ProposalUser;

--- a/src/components/Vote/VotingPower.tsx
+++ b/src/components/Vote/VotingPower.tsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Icon } from 'antd';
 import BigNumber from 'bignumber.js';
@@ -8,6 +7,7 @@ import { useWeb3React } from '@web3-react/core';
 import { Card } from 'components/Basic/Card';
 import { Row, Column } from 'components/Basic/Style';
 import DelegationTypeModal from 'components/Basic/DelegationTypeModal';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 
 const VotingPowerWrapper = styled.div`
   width: 100%;
@@ -103,13 +103,14 @@ const VotingPowerWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
-function VotingPower({
-  history,
-  power,
-  balance,
-  delegateStatus,
-  stakedAmount,
-}: $TSFixMe) {
+interface VotingPowerProps extends RouteComponentProps {
+  power: string;
+  balance: string;
+  delegateStatus: string;
+  stakedAmount: string;
+}
+
+function VotingPower({ history, power, balance, delegateStatus, stakedAmount }: VotingPowerProps) {
   const { account } = useWeb3React();
 
   const [isOpenDelegationModal, setIsOpenDelegationModal] = useState(false);
@@ -127,31 +128,17 @@ function VotingPower({
                 </Column>
                 <Column xs="12" sm="12" md="7" className=" voting-hint">
                   <Row className="flex flex-wrap align-center">
-                    <Column
-                      xs="12"
-                      md="5"
-                      lg="4"
-                      className="voting-hint-left flex align-center"
-                    >
+                    <Column xs="12" md="5" lg="4" className="voting-hint-left flex align-center">
                       <Icon className="info-circle" type="info-circle" />
                       <span>To vote you should:</span>
                     </Column>
-                    <Column
-                      xs="12"
-                      md="7"
-                      lg="8"
-                      className="voting-hint-right just-between"
-                    >
+                    <Column xs="12" md="7" lg="8" className="voting-hint-right just-between">
                       <div className="flex align-center voting-hint-right-l1">
                         <div className="connect-line" />
                         {!new BigNumber(stakedAmount).gt(0) ? (
                           <span className="step-number">1</span>
                         ) : (
-                          <Icon
-                            className="check-circle-icon"
-                            type="check-circle"
-                            theme="filled"
-                          />
+                          <Icon className="check-circle-icon" type="check-circle" theme="filled" />
                         )}
                         <span className="step-text">
                           <i
@@ -160,8 +147,7 @@ function VotingPower({
                             }}
                           >
                             Lock your tokens
-                          </i>
-                          {' '}
+                          </i>{' '}
                           to the XVS Vault
                         </span>
                       </div>
@@ -169,11 +155,7 @@ function VotingPower({
                         {!delegateStatus ? (
                           <span className="step-number">2</span>
                         ) : (
-                          <Icon
-                            className="check-circle-icon"
-                            type="check-circle"
-                            theme="filled"
-                          />
+                          <Icon className="check-circle-icon" type="check-circle" theme="filled" />
                         )}
                         <span className="step-text">
                           <i
@@ -204,16 +186,8 @@ function VotingPower({
   );
 }
 
-VotingPower.propTypes = {
-  power: PropTypes.string,
-  history: PropTypes.object.isRequired,
-  balance: PropTypes.string.isRequired,
-  delegateStatus: PropTypes.string.isRequired,
-  stakedAmount: PropTypes.string.isRequired,
-};
-
 VotingPower.defaultProps = {
   power: '0.00000000',
 };
 
-export default VotingPower;
+export default withRouter(VotingPower);

--- a/src/components/Vote/VotingWallet.tsx
+++ b/src/components/Vote/VotingWallet.tsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Icon } from 'antd';
 import commaNumber from 'comma-number';
@@ -88,13 +87,21 @@ const VotingWalletWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
+interface VotingWalletProps {
+  balance: string;
+  earnedBalance: string;
+  vaiMint: string;
+  delegateAddress: string;
+  delegateStatus: string;
+}
+
 function VotingWallet({
   balance,
   earnedBalance,
   vaiMint,
   delegateAddress,
   delegateStatus,
-}: $TSFixMe) {
+}: VotingWalletProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingEarn, setIsLoadingEarn] = useState(false);
   const { account } = useWeb3React();
@@ -120,9 +127,11 @@ function VotingWallet({
       )
       .call();
 
-    const outstandingVTokens = vTokensBalanceInfos.filter((info: $TSFixMe) =>
-      // info[2]: borrowBalanceCurrent, info[3]: balanceOfUnderlying
-      new BigNumber(info[2]).gt(0) || new BigNumber(info[3]).gt(0));
+    const outstandingVTokens = vTokensBalanceInfos.filter(
+      (info: $TSFixMe) =>
+        // info[2]: borrowBalanceCurrent, info[3]: balanceOfUnderlying
+        new BigNumber(info[2]).gt(0) || new BigNumber(info[3]).gt(0),
+    );
 
     // const t = (await this.venusLens.vTokenBalancesAll(this.vBep20Delegator.vTokenWithMetadataAll.map(t=>t.address), this.address)).filter(t=>t.balanceOfUnderlying.gt(0) || t.borrowBalanceCurrent.gt(0)).map(t=>t.address)
     if (+earnedBalance !== 0 || +vaiMint !== 0) {
@@ -176,9 +185,7 @@ function VotingWallet({
               {account && (
                 <div className="flex align-center">
                   <p className="pointer" onClick={handleCollect}>
-                    {isLoading && <Icon type="loading" />}
-                    {' '}
-                    Collect
+                    {isLoading && <Icon type="loading" />} Collect
                   </p>
                 </div>
               )}
@@ -198,21 +205,14 @@ function VotingWallet({
                 >
                   {delegateStatus === 'self'
                     ? 'Self'
-                    : `${delegateAddress.substr(
-                      0,
-                      4,
-                    )}...${delegateAddress.substr(
-                      delegateAddress.length - 4,
-                      4,
-                    )}`}
+                    : `${delegateAddress.substr(0, 4)}...${delegateAddress.substr(
+                        delegateAddress.length - 4,
+                        4,
+                      )}`}
                 </a>
               </div>
               <div className="flex align-center">
-                <p
-                  className="change pointer"
-                >
-                  Change
-                </p>
+                <p className="change pointer">Change</p>
               </div>
             </div>
           </div>
@@ -221,13 +221,5 @@ function VotingWallet({
     </Card>
   );
 }
-
-VotingWallet.propTypes = {
-  balance: PropTypes.string.isRequired,
-  earnedBalance: PropTypes.string.isRequired,
-  vaiMint: PropTypes.string.isRequired,
-  delegateAddress: PropTypes.string.isRequired,
-  delegateStatus: PropTypes.string.isRequired,
-};
 
 export default VotingWallet;

--- a/src/containers/Layout/Sidebar.tsx
+++ b/src/containers/Layout/Sidebar.tsx
@@ -1,18 +1,19 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
-import { NavLink, withRouter } from 'react-router-dom';
+import { NavLink, RouteComponentProps, withRouter } from 'react-router-dom';
+import { connect } from 'react-redux';
 import { Select, Icon } from 'antd';
 import BigNumber from 'bignumber.js';
 import { useWeb3React } from '@web3-react/core';
+import { accountActionCreators } from 'core/modules/account/actions';
 import ConnectButton from 'components/Basic/ConnectButton';
 import { Label } from 'components/Basic/Label';
-import { connectAccount } from 'core';
 import logoImg from 'assets/img/logo.png';
 import prdtImg from 'assets/img/prdt.png';
 import commaNumber from 'comma-number';
 import { getBigNumber } from 'utilities/common';
 import toast from 'components/Basic/Toast';
+import { Setting } from 'types';
 import XVSIcon from 'assets/img/venus.svg';
 import XVSActiveIcon from 'assets/img/venus_active.svg';
 import { useMarkets } from '../../hooks/useMarkets';
@@ -248,7 +249,13 @@ const { Option } = Select;
 
 const format = commaNumber.bindWith(',', '.');
 
-function Sidebar({ history, setSetting }: $TSFixMe) {
+interface SidebarProps extends RouteComponentProps {
+  settings: Setting;
+  setSetting: (setting: Partial<Setting> | undefined) => void;
+  getGovernanceVenus: $TSFixMe;
+}
+
+function Sidebar({ history, setSetting }: SidebarProps) {
   const [isMarketInfoUpdating, setMarketInfoUpdating] = useState(false);
   const [totalVaiMinted, setTotalVaiMinted] = useState('0');
   const [tvl, setTVL] = useState(new BigNumber(0));
@@ -446,10 +453,7 @@ function Sidebar({ history, setSetting }: $TSFixMe) {
       {account && (
         <TotalValue>
           <div className="flex flex-column align-center just-center">
-            <Label primary>
-              $
-              {format(new BigNumber(tvl).dp(2, 1).toString(10))}
-            </Label>
+            <Label primary>${format(new BigNumber(tvl).dp(2, 1).toString(10))}</Label>
             <Label className="center">Total Value Locked</Label>
           </div>
         </TotalValue>
@@ -539,18 +543,8 @@ function Sidebar({ history, setSetting }: $TSFixMe) {
   );
 }
 
-Sidebar.propTypes = {
-  history: PropTypes.object,
-  setSetting: PropTypes.func.isRequired,
-  getGovernanceVenus: PropTypes.func.isRequired,
-};
-
-Sidebar.defaultProps = {
-  history: {},
-};
-
 const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(withRouter(Sidebar));
+export default connect(mapStateToProps, accountActionCreators)(withRouter(Sidebar));

--- a/src/containers/Main/Dashboard.tsx
+++ b/src/containers/Main/Dashboard.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable no-useless-escape */
 import React from 'react';
 import styled from 'styled-components';
+import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import MainLayout from 'containers/Layout/MainLayout';
 import CoinInfo from 'components/Dashboard/CoinInfo';
@@ -9,7 +10,6 @@ import BorrowLimit from 'components/Dashboard/BorrowLimit';
 import Overview from 'components/Dashboard/Overview';
 import WalletBalance from 'components/Dashboard/WalletBalance';
 import Market from 'components/Dashboard/Market';
-import { connectAccount } from 'core';
 import { Row, Column } from 'components/Basic/Style';
 
 const DashboardWrapper = styled.div`
@@ -57,4 +57,4 @@ const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(withRouter(Dashboard));
+export default connect(mapStateToProps)(withRouter(Dashboard));

--- a/src/containers/Main/Faucet.tsx
+++ b/src/containers/Main/Faucet.tsx
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import { Input, Form, Dropdown, Menu } from 'antd';
-import { withRouter } from 'react-router-dom';
+import { FormComponentProps } from 'antd/lib/form';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { connectAccount } from 'core';
 import MainLayout from 'containers/Layout/MainLayout';
 import { promisify } from 'utilities';
@@ -91,7 +91,12 @@ const ButtonWrapper = styled.div`
   }
 `;
 
-function Faucet({ form, getFromFaucet }: $TSFixMe) {
+type HOCProps = FormComponentProps & RouteComponentProps;
+interface FaucetProps extends HOCProps {
+  getFromFaucet: $TSFixMe;
+}
+
+function Faucet({ form, getFromFaucet }: FaucetProps) {
   const { getFieldDecorator } = form;
   const [isLoading, setIsLoading] = useState(false);
 
@@ -401,8 +406,7 @@ function Faucet({ form, getFromFaucet }: $TSFixMe) {
               {' are issued as BEP20 token.'}
             </p>
             <p className="description">
-              Click to get detail about
-              {' '}
+              Click to get detail about{' '}
               <a
                 href="https://github.com/binance-chain/BEPs/blob/master/BEP20.md"
                 target="_blank"
@@ -417,10 +421,5 @@ function Faucet({ form, getFromFaucet }: $TSFixMe) {
     </MainLayout>
   );
 }
-
-Faucet.propTypes = {
-  form: PropTypes.object.isRequired,
-  getFromFaucet: PropTypes.func.isRequired,
-};
 
 export default Form.create({ name: 'faucet-form' })(connectAccount(undefined)(withRouter(Faucet)));

--- a/src/containers/Main/Market.tsx
+++ b/src/containers/Main/Market.tsx
@@ -1,16 +1,16 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
 import { Row, Col, Icon } from 'antd';
 import styled from 'styled-components';
-import { connectAccount } from 'core';
+import { connect } from 'react-redux';
 import MainLayout from 'containers/Layout/MainLayout';
 import { promisify } from 'utilities';
-
 import * as constants from 'utilities/constants';
 import { currencyFormatter, formatApy } from 'utilities/common';
 import { uid } from 'react-uid';
+import { Setting } from 'types';
 import { useMarkets } from '../../hooks/useMarkets';
 
 const MarketWrapper = styled.div`
@@ -160,7 +160,12 @@ const TableWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
-function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
+interface MarketProps extends RouteComponentProps {
+  settings: Setting;
+  getTreasuryBalance: () => void;
+}
+
+function Market({ history, settings, getTreasuryBalance }: MarketProps) {
   const [totalSupply, setTotalSupply] = useState('0');
   const [totalBorrow, setTotalBorrow] = useState('0');
   const [availableLiquidity, setAvailableLiquidity] = useState('0');
@@ -212,14 +217,14 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
 
     setTotalSupply(
       tempTS
-        .plus(settings.vaultVaiStaked)
+        .plus(settings.vaultVaiStaked || new BigNumber(0))
         .dp(2, 1)
         .toString(10),
     );
     setTotalBorrow(tempTB.dp(2, 1).toString(10));
     setAvailableLiquidity(
       tempAL
-        .plus(settings.vaultVaiStaked)
+        .plus(settings.vaultVaiStaked || new BigNumber(0))
         .dp(2, 1)
         .toString(10),
     );
@@ -245,46 +250,32 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
           <div className="total-info">
             <div className="total-item">
               <div className="prop">Total Supply</div>
-              <div className="value">
-                $
-                {format(totalSupply)}
-              </div>
+              <div className="value">${format(totalSupply)}</div>
             </div>
             <div className="total-item">
               <div className="prop">Total Borrow</div>
-              <div className="value">
-                $
-                {format(totalBorrow)}
-              </div>
+              <div className="value">${format(totalBorrow)}</div>
             </div>
             <div className="total-item">
               <div className="prop">Available Liquidity</div>
-              <div className="value">
-                $
-                {format(availableLiquidity)}
-              </div>
+              <div className="value">${format(availableLiquidity)}</div>
             </div>
             <div className="total-item">
               <div className="prop">Total Treasury</div>
-              <div className="value">
-                $
-                {format(totalTreasury)}
-              </div>
+              <div className="value">${format(totalTreasury)}</div>
             </div>
           </div>
           {settings.vaiAPY && (
             <div className="vai-apy">
               VAI Staking APY:
-              {settings.vaiAPY}
-              %
+              {settings.vaiAPY}%
             </div>
           )}
           <Row className="table_header">
             <Col xs={{ span: 24 }} lg={{ span: 2 }} className="market" />
             <Col xs={{ span: 6 }} lg={{ span: 4 }} className="total-supply right">
               <span onClick={() => handleSort('total_supply')}>
-                Total Supply
-                {' '}
+                Total Supply{' '}
                 {sortInfo.field === 'total_supply' && (
                   <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                 )}
@@ -292,8 +283,7 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
             </Col>
             <Col xs={{ span: 6 }} lg={{ span: 3 }} className="supply-apy right">
               <span onClick={() => handleSort('supply_apy')}>
-                Supply APY
-                {' '}
+                Supply APY{' '}
                 {sortInfo.field === 'supply_apy' && (
                   <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                 )}
@@ -301,8 +291,7 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
             </Col>
             <Col xs={{ span: 6 }} lg={{ span: 4 }} className="total-borrow right">
               <span onClick={() => handleSort('total_borrow')}>
-                Total Borrow
-                {' '}
+                Total Borrow{' '}
                 {sortInfo.field === 'total_borrow' && (
                   <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                 )}
@@ -310,8 +299,7 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
             </Col>
             <Col xs={{ span: 6 }} lg={{ span: 3 }} className="borrow-apy right">
               <span onClick={() => handleSort('borrow_apy')}>
-                Borrow APY
-                {' '}
+                Borrow APY{' '}
                 {sortInfo.field === 'borrow_apy' && (
                   <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                 )}
@@ -319,8 +307,7 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
             </Col>
             <Col xs={{ span: 6 }} lg={{ span: 4 }} className="liquidity right">
               <span onClick={() => handleSort('liquidity')}>
-                Liquidity
-                {' '}
+                Liquidity{' '}
                 {sortInfo.field === 'liquidity' && (
                   <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                 )}
@@ -328,8 +315,7 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
             </Col>
             <Col xs={{ span: 6 }} lg={{ span: 4 }} className="price right">
               <span onClick={() => handleSort('price')}>
-                Price
-                {' '}
+                Price{' '}
                 {sortInfo.field === 'price' && (
                   <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                 )}
@@ -431,8 +417,7 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
                             .div(new BigNumber(item.tokenPrice))
                             .dp(0, 1)
                             .toString(10),
-                        )}
-                        {' '}
+                        )}{' '}
                         {item.underlyingSymbol}
                       </p>
                     </Col>
@@ -450,8 +435,7 @@ function Market({ history, settings, getTreasuryBalance }: $TSFixMe) {
                             .div(new BigNumber(item.tokenPrice))
                             .dp(0, 1)
                             .toString(10),
-                        )}
-                        {' '}
+                        )}{' '}
                         {item.underlyingSymbol}
                       </p>
                     </Col>
@@ -484,4 +468,4 @@ const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(withRouter(Market));
+export default connect(mapStateToProps)(withRouter(Market));

--- a/src/containers/Main/Transaction.tsx
+++ b/src/containers/Main/Transaction.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { withRouter } from 'react-router-dom';
+import { withRouter, RouteComponentProps } from 'react-router-dom';
 
 import commaNumber from 'comma-number';
 import { Row, Col, Pagination, Select } from 'antd';
@@ -264,7 +264,11 @@ const eventTypes = [
 const { Option } = Select;
 const format = commaNumber.bindWith(',', '.');
 
-function Transaction({ getTransactionHistory }: $TSFixMe) {
+interface TransactionProps extends RouteComponentProps {
+  getTransactionHistory: $TSFixMe;
+}
+
+function Transaction({ getTransactionHistory }: TransactionProps) {
   const [data, setData] = useState([]);
   const [offset, setOffset] = useState(1);
   const [pageSize, setPageSize] = useState(20);

--- a/src/containers/Main/Vote.tsx
+++ b/src/containers/Main/Vote.tsx
@@ -1,10 +1,7 @@
 /* eslint-disable no-useless-escape */
 import React, { useEffect, useState, useCallback } from 'react';
-import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import BigNumber from 'bignumber.js';
-
-import { withRouter } from 'react-router-dom';
 import { connectAccount } from 'core';
 import MainLayout from 'containers/Layout/MainLayout';
 import CoinInfo from 'components/Vote/CoinInfo';
@@ -29,7 +26,11 @@ const VoteWrapper = styled.div`
   height: 100%;
 `;
 
-function Vote({ history, getProposals }: $TSFixMe) {
+interface VoteProps {
+  getProposals: $TSFixMe;
+}
+
+function Vote({ getProposals }: VoteProps) {
   const [balance, setBalance] = useState(0);
   const [votingWeight, setVotingWeight] = useState('0');
   const [proposals, setProposals] = useState({});
@@ -237,7 +238,6 @@ function Vote({ history, getProposals }: $TSFixMe) {
         <Row>
           <Column xs="12" sm="12" md="12">
             <VotingPower
-              history={history}
               stakedAmount={stakedAmount}
               // @ts-expect-error ts-migrate(2367) FIXME: This condition will always return 'true' since the... Remove this comment to see the full error message
               balance={balance !== '0' ? `${balance}` : '0.00000000'}
@@ -295,15 +295,8 @@ function Vote({ history, getProposals }: $TSFixMe) {
   );
 }
 
-Vote.propTypes = {
-  getProposals: PropTypes.func.isRequired,
-  history: PropTypes.object.isRequired,
-};
-
-Vote.defaultProps = {};
-
 const mapStateToProps = ({ account }: $TSFixMe) => ({
   settings: account.setting,
 });
 
-export default connectAccount(mapStateToProps)(withRouter(Vote));
+export default connectAccount(mapStateToProps)(Vote);

--- a/src/containers/Main/VoteOverview.tsx
+++ b/src/containers/Main/VoteOverview.tsx
@@ -19,6 +19,7 @@ import toast from 'components/Basic/Toast';
 import { Row, Column } from 'components/Basic/Style';
 import { useWeb3React } from '@web3-react/core';
 import { uid } from 'react-uid';
+import { ProposalInfo as ProposalInfoType } from 'types';
 import { useToken, useGovernorBravo } from '../../hooks/useContract';
 
 const VoteOverviewWrapper = styled.div`
@@ -93,7 +94,7 @@ interface Props extends RouteComponentProps<{ id?: string }> {
 }
 
 function VoteOverview({ getVoters, getProposalById, match }: Props) {
-  const [proposalInfo, setProposalInfo] = useState({});
+  const [proposalInfo, setProposalInfo] = useState<Partial<ProposalInfoType>>({});
   const [agreeVotes, setAgreeVotes] = useState({
     sumVotes: 0,
     result: [],
@@ -119,14 +120,10 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
   const governorBravoContract = useGovernorBravo();
 
   const updateBalance = useCallback(async () => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
     if (proposalInfo.id) {
       const threshold = await governorBravoContract.methods.proposalThreshold().call();
       setProposalThreshold(+Web3.utils.fromWei(threshold, 'ether'));
-      const weight = await xvsTokenContract.methods
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'proposer' does not exist on type '{}'.
-        .getCurrentVotes(proposalInfo.proposer)
-        .call();
+      const weight = await xvsTokenContract.methods.getCurrentVotes(proposalInfo.proposer).call();
       setProposerVotingWeight(+Web3.utils.fromWei(weight, 'ether'));
     }
   }, [proposalInfo]);
@@ -147,10 +144,8 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
   }, [match, getProposalById]);
 
   const loadVotes = async ({ limit, filter, offset }: $TSFixMe) => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
     if (proposalInfo.id) {
       await promisify(getVoters, {
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
         id: proposalInfo.id,
         limit,
         filter,
@@ -207,16 +202,12 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
   }, [getVoters, proposalInfo]);
 
   const getIsPossibleExcuted = async () => {
-    const proposalsRes = await governorBravoContract.methods
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
-      .proposals(proposalInfo.id)
-      .call();
+    const proposalsRes = await governorBravoContract.methods.proposals(proposalInfo.id).call();
     setIsPossibleExcuted(proposalsRes && proposalsRes.eta <= Date.now() / 1000);
     setExcuteEta(moment(proposalsRes.eta * 1000).format('LLLL'));
   };
 
   useEffect(() => {
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
     if (proposalInfo.id) {
       getIsPossibleExcuted();
     }
@@ -226,10 +217,7 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
     if (statusType === 'Queue') {
       setIsLoading(true);
       try {
-        await governorBravoContract.methods
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
-          .queue(proposalInfo.id)
-          .send({ from: account });
+        await governorBravoContract.methods.queue(proposalInfo.id).send({ from: account });
         setStatus('success');
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
         toast.success({
@@ -243,10 +231,7 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
     } else if (statusType === 'Execute') {
       setIsLoading(true);
       try {
-        await governorBravoContract.methods
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
-          .execute(proposalInfo.id)
-          .send({ from: account });
+        await governorBravoContract.methods.execute(proposalInfo.id).send({ from: account });
         setStatus('success');
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
         toast.success({
@@ -260,10 +245,7 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
     } else if (statusType === 'Cancel') {
       setIsCancelLoading(true);
       try {
-        await governorBravoContract.methods
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'id' does not exist on type '{}'.
-          .cancel(proposalInfo.id)
-          .send({ from: account });
+        await governorBravoContract.methods.cancel(proposalInfo.id).send({ from: account });
         setCancelStatus('success');
         // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
         toast.success({
@@ -326,11 +308,8 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
               })}
             </Row>
             <div className="vote-status-update">
-              {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'. */}
               {proposalInfo.state !== 'Executed' &&
-                // @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'.
                 proposalInfo.state !== 'Defeated' &&
-                // @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'.
                 proposalInfo.state !== 'Canceled' && (
                   <div className="flex align-center just-center update-proposal-status">
                     <Button
@@ -343,25 +322,21 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
                       }
                       onClick={() => handleUpdateProposal('Cancel')}
                     >
-                      {isCancelLoading && <Icon type="loading" />}
-                      {' '}
+                      {isCancelLoading && <Icon type="loading" />}{' '}
                       {cancelStatus === 'pending' || cancelStatus === 'failure'
                         ? 'Cancel'
                         : 'Cancelled'}
                     </Button>
-                    {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'. */}
                     {proposalInfo.state === 'Succeeded' && (
                       <Button
                         className="queue-btn"
                         disabled={!account || isLoading || status === 'success'}
                         onClick={() => handleUpdateProposal('Queue')}
                       >
-                        {isLoading && <Icon type="loading" />}
-                        {' '}
+                        {isLoading && <Icon type="loading" />}{' '}
                         {status === 'pending' || status === 'failure' ? 'Queue' : 'Queued'}
                       </Button>
                     )}
-                    {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'. */}
                     {proposalInfo.state === 'Queued' && (
                       <Button
                         className="execute-btn"
@@ -370,12 +345,10 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
                         }
                         onClick={() => handleUpdateProposal('Execute')}
                       >
-                        {isLoading && <Icon type="loading" />}
-                        {' '}
+                        {isLoading && <Icon type="loading" />}{' '}
                         {status === 'pending' || status === 'failure' ? 'Execute' : 'Executed'}
                       </Button>
                     )}
-                    {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'. */}
                     {proposalInfo.state === 'Queued' && !isPossibleExcuted && (
                       <Tooltip title={`You are able to excute at ${excuteEta}`}>
                         <Icon className="pointer" type="info-circle" theme="filled" />
@@ -383,11 +356,8 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
                     )}
                   </div>
                 )}
-              {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'. */}
               {proposalInfo.state !== 'Executed' &&
-                // @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'.
                 proposalInfo.state !== 'Defeated' &&
-                // @ts-expect-error ts-migrate(2339) FIXME: Property 'state' does not exist on type '{}'.
                 proposalInfo.state !== 'Canceled' &&
                 proposerVotingWeight >= proposalThreshold && (
                   <p className="center warning">

--- a/src/containers/Main/VoterLeaderboard.tsx
+++ b/src/containers/Main/VoterLeaderboard.tsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import { withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import Web3 from 'web3';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
@@ -94,7 +93,11 @@ const TableWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
-function VoterLeaderboard({ history, getVoterAccounts }: $TSFixMe) {
+interface VoterLeaderboardProps extends RouteComponentProps {
+  getVoterAccounts: $TSFixMe;
+}
+
+function VoterLeaderboard({ history, getVoterAccounts }: VoterLeaderboardProps) {
   const [voterAccounts, setVoterAccounts] = useState([]);
 
   useEffect(() => {
@@ -159,8 +162,7 @@ function VoterLeaderboard({ history, getVoterAccounts }: $TSFixMe) {
                     <p className="mobile-label">Vote Weight</p>
                     <p>
                       {/* @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'number' is not assignable to par... Remove this comment to see the full error message */}
-                      {parseFloat(item.voteWeight * 100).toFixed(2)}
-                      %
+                      {parseFloat(item.voteWeight * 100).toFixed(2)}%
                     </p>
                   </Col>
                   <Col xs={{ span: 24 }} lg={{ span: 4 }} className="proposals right">
@@ -176,14 +178,5 @@ function VoterLeaderboard({ history, getVoterAccounts }: $TSFixMe) {
     </MainLayout>
   );
 }
-
-VoterLeaderboard.propTypes = {
-  history: PropTypes.object,
-  getVoterAccounts: PropTypes.func.isRequired,
-};
-
-VoterLeaderboard.defaultProps = {
-  history: {},
-};
 
 export default connectAccount()(withRouter(VoterLeaderboard));

--- a/src/containers/Main/XVS.tsx
+++ b/src/containers/Main/XVS.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { withRouter } from 'react-router-dom';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
@@ -12,6 +12,7 @@ import * as constants from 'utilities/constants';
 import coinImg from 'assets/img/venus_32.png';
 import vaiImg from 'assets/img/coins/vai.svg';
 import { State } from 'core/modules/initialState';
+import { Setting } from 'types';
 import { BASE_BSC_SCAN_URL } from '../../config';
 import { useMarkets } from '../../hooks/useMarkets';
 import { useComptroller, useToken } from '../../hooks/useContract';
@@ -186,7 +187,11 @@ const TableWrapper = styled.div`
 
 const format = commaNumber.bindWith(',', '.');
 
-function XVS({ settings }: $TSFixMe) {
+interface XVSProps extends RouteComponentProps {
+  settings: Setting;
+}
+
+function XVS({ settings }: XVSProps) {
   const [totalMarkets, setTotalMarkets] = useState([]);
   const [dailyDistribution, setDailyDistribution] = useState('0');
   const [totalDistributed, setTotalDistributed] = useState('0');
@@ -328,10 +333,7 @@ function XVS({ settings }: $TSFixMe) {
               </Col>
               <Col xs={{ span: 8 }} lg={{ span: 6 }} className="per-day right">
                 <span onClick={() => handleSort('perDay')}>
-                  <img src={coinImg} alt="xvs" />
-                  {' '}
-                  Per Day
-                  {' '}
+                  <img src={coinImg} alt="xvs" /> Per Day{' '}
                   {sortInfo.field === 'perDay' && (
                     <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                   )}
@@ -341,8 +343,7 @@ function XVS({ settings }: $TSFixMe) {
                 <span onClick={() => handleSort('supplyAPY')}>
                   Supply
                   <img src={coinImg} alt="xvs" />
-                  APY
-                  {' '}
+                  APY{' '}
                   {sortInfo.field === 'supplyAPY' && (
                     <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                   )}
@@ -352,8 +353,7 @@ function XVS({ settings }: $TSFixMe) {
                 <span onClick={() => handleSort('borrowAPY')}>
                   Borrow
                   <img src={coinImg} alt="xvs" />
-                  APY
-                  {' '}
+                  APY{' '}
                   {sortInfo.field === 'borrowAPY' && (
                     <Icon type={sortInfo.sort === 'desc' ? 'caret-down' : 'caret-up'} />
                   )}
@@ -445,8 +445,7 @@ function XVS({ settings }: $TSFixMe) {
                         <p className="mobile-label">Supply APY</p>
                         <p>
                           {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'supplyAPY' does not exist on type 'never... Remove this comment to see the full error message */}
-                          {item.supplyAPY}
-                          %
+                          {item.supplyAPY}%
                         </p>
                       </Col>
                       <Col xs={{ span: 24 }} lg={{ span: 6 }} className="borrow-apy right">
@@ -455,8 +454,7 @@ function XVS({ settings }: $TSFixMe) {
                         {item.underlyingSymbol !== 'VAI' ? (
                           <p>
                             {/* @ts-expect-error ts-migrate(2339) FIXME: Property 'borrowAPY' does not exist on type 'never... Remove this comment to see the full error message */}
-                            {item.borrowAPY}
-                            %
+                            {item.borrowAPY}%
                           </p>
                         ) : (
                           <p>-</p>

--- a/src/containers/Theme.tsx
+++ b/src/containers/Theme.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { ThemeProvider } from 'styled-components';
 
 const theme = {};
 
-const Theme = ({ children }: $TSFixMe) => <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+interface ThemeProps {
+  children: React.ReactNode;
+}
 
-Theme.propTypes = {
-  children: PropTypes.node.isRequired,
-};
+const Theme = ({ children }: ThemeProps) => <ThemeProvider theme={theme}>{children}</ThemeProvider>;
 
 export default Theme;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,9 @@
 import BigNumber from 'bignumber.js';
 
+export interface User {
+  Token: string;
+}
+
 export interface Asset {
   id: string;
   name: string;
@@ -16,6 +20,11 @@ export interface Asset {
   borrowCaps: BigNumber;
   totalBorrows: BigNumber;
   liquidity: BigNumber;
+  xvsSupplyApy: BigNumber;
+  supplyApy: BigNumber;
+  collateralFactor: number;
+  collateral: boolean;
+  supplyBalance: BigNumber;
 }
 
 export interface Setting {
@@ -25,9 +34,39 @@ export interface Setting {
     type: string; // 'Borrow'
     status: boolean;
     symbol: string;
-    amount: string;
+    amount: string | number;
   };
-  vaultVaiStaked?: null;
+  vaultVaiStaked?: BigNumber.Value | null;
+  vaiAPY?: number | string;
+}
+
+export interface Action {
+  title: string;
+}
+
+enum ProposalState {
+  pending = 'Pending',
+  active = 'Active',
+  succeeded = 'Succeeded',
+  queued = 'Queued',
+  executed = 'Executed',
+  canceled = 'Canceled',
+  defeated = 'Defeated',
+  expired = 'Expired',
+}
+export interface ProposalInfo {
+  id: string;
+  description: string;
+  actions: Action[];
+  startTimestamp?: number;
+  createdTimestamp?: number;
+  queuedTimestamp?: number;
+  executedTimestamp?: number;
+  endTimestamp?: number;
+  cancelTimestamp?: number;
+  updatedAt?: number;
+  state: ProposalState;
+  proposer: string;
 }
 
 export interface Proposal {


### PR DESCRIPTION
After migrating to typescript. It is no longer necessary to maintain proptypes as typechecking is handled by typescript.

This PR removes prop-types and updates types to be checked by typescript

Some function types in props are marked as to fix relating to `thunks` which we will be removing in favor of sagas