### PR TITLE
Add google analytics client

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,15 +39,17 @@ module.exports = {
     'react/no-unused-prop-types': 0,
     'react/prefer-stateless-function': 0,
     'react/require-default-props': 0,
-    "import/no-extraneous-dependencies": [
-      "error",
+    'import/no-extraneous-dependencies': [
+      'error',
       {
-        "devDependencies": [
-          "**/*.stories.tsx",
-          "**/*.stories.ts",
-          "src/stories/**"
-        ]
-      }
+        devDependencies: [
+          '**/*.stories.tsx',
+          '**/*.stories.ts',
+          'src/stories/**',
+          '**/*.spec.tsx',
+          'src/**/*.spec.ts',
+        ],
+      },
     ],
   },
   settings: {

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@storybook/preset-create-react-app": "^3.2.0",
     "@storybook/react": "^6.4.9",
     "@types/gtag.js": "^0.0.8",
+    "@types/jest": "^27.4.1",
     "@types/lodash": "^4.14.178",
     "@types/markdown-it": "^12.2.3",
     "@types/react-copy-to-clipboard": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@storybook/node-logger": "^6.4.9",
     "@storybook/preset-create-react-app": "^3.2.0",
     "@storybook/react": "^6.4.9",
+    "@types/gtag.js": "^0.0.8",
     "@types/lodash": "^4.14.178",
     "@types/markdown-it": "^12.2.3",
     "@types/react-copy-to-clipboard": "^5.0.2",

--- a/src/clients/googleAnalytics.spec.ts
+++ b/src/clients/googleAnalytics.spec.ts
@@ -1,0 +1,30 @@
+import googleAnalytics from './googleAnalytics';
+
+describe('Google Analytics Client', () => {
+  let consoleSpy: jest.SpyInstance;
+  beforeAll(() => {
+    consoleSpy = jest.spyOn(console, 'warn');
+  });
+
+  afterAll(() => {
+    consoleSpy.mockRestore();
+  });
+
+  test('event is called when gtag exists on window', () => {
+    window.gtag = () => {};
+    const spy = jest.spyOn(window, 'gtag');
+    googleAnalytics.buttonPressed('connect');
+    expect(spy).toHaveBeenCalled();
+  });
+
+  test('calling event does not crash when gtag does not exit window', () => {
+    // @ts-expect-error gtag could be missing if script isn't loaded from document
+    window.gtag = undefined;
+    googleAnalytics.buttonPressed('connect');
+    expect(consoleSpy).toHaveBeenCalled();
+    expect(consoleSpy.mock.calls[0][1]).toStrictEqual([
+      'button_pressed',
+      { button_name: 'connect' },
+    ]);
+  });
+});

--- a/src/clients/googleAnalytics.ts
+++ b/src/clients/googleAnalytics.ts
@@ -1,0 +1,27 @@
+type EventParameters = Parameters<(eventName: string, parameters?: Record<string, string>) => void>;
+
+const googleAnalytics = () => {
+  let gtag: Gtag.Gtag;
+  const loadGTag = (callback: (...args: EventParameters) => void) => (...args: EventParameters) => {
+    gtag = window?.gtag;
+    if (!gtag && process.env.NODE_ENV !== 'production') {
+      console.warn('gtag not loaded. Google Analytics event not sent', args);
+    } else {
+      callback(...args);
+    }
+  };
+
+  const sendEvent = loadGTag((eventName: string, parameters?: Record<string, string>) => {
+    gtag('event', eventName, parameters);
+  });
+
+  const buttonPressed = (buttonName: string, parameters: Record<string, string> = {}) => {
+    sendEvent('button_pressed', { button_name: buttonName, ...parameters });
+  };
+
+  return {
+    buttonPressed,
+  };
+};
+
+export default googleAnalytics();

--- a/src/clients/googleAnalytics.ts
+++ b/src/clients/googleAnalytics.ts
@@ -3,11 +3,14 @@ type EventParameters = Parameters<(eventName: string, parameters?: Record<string
 const googleAnalytics = () => {
   let gtag: Gtag.Gtag;
   const loadGTag = (callback: (...args: EventParameters) => void) => (...args: EventParameters) => {
-    gtag = window?.gtag;
-    if (!gtag && process.env.NODE_ENV !== 'production') {
-      console.warn('gtag not loaded. Google Analytics event not sent', args);
-    } else {
+    ({ gtag } = window);
+    // This check exists because the gtag script is loaded outside of react and could potentially be missing
+    // although it is typed as if it alwasy exists
+    // @ts-expect-error gtag could be missing if script isn't loaded from document
+    if (gtag) {
       callback(...args);
+    } else if (process.env.NODE_ENV !== 'production') {
+      console.warn('gtag not loaded. Google Analytics event not sent', args);
     }
   };
 

--- a/src/clients/googleAnalytics.ts
+++ b/src/clients/googleAnalytics.ts
@@ -1,5 +1,11 @@
 type EventParameters = Parameters<(eventName: string, parameters?: Record<string, string>) => void>;
 
+export type ButtonEventMap = {
+  connect: Record<string, string>;
+};
+
+export type ButtonEventName = keyof ButtonEventMap;
+
 const googleAnalytics = () => {
   let gtag: Gtag.Gtag;
   const loadGTag = (callback: (...args: EventParameters) => void) => (...args: EventParameters) => {
@@ -18,9 +24,12 @@ const googleAnalytics = () => {
     gtag('event', eventName, parameters);
   });
 
-  const buttonPressed = (buttonName: string, parameters: Record<string, string> = {}) => {
+  function buttonPressed<E extends ButtonEventName>(
+    buttonName: E,
+    parameters?: ButtonEventMap[E] extends undefined ? never : ButtonEventMap[E],
+  ): void {
     sendEvent('button_pressed', { button_name: buttonName, ...parameters });
-  };
+  }
 
   return {
     buttonPressed,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3938,6 +3938,14 @@
   dependencies:
     "@types/istanbul-lib-report" "*"
 
+"@types/jest@^27.4.1":
+  version "27.4.1"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-27.4.1.tgz#185cbe2926eaaf9662d340cc02e548ce9e11ab6d"
+  integrity sha512-23iPJADSmicDVrWk+HT58LMJtzLAnB2AgIzplQuq/bSrGaxCrlvRFjGbXmamnnk/mAmCdLStiGqggu28ocUyiw==
+  dependencies:
+    jest-matcher-utils "^27.0.0"
+    pretty-format "^27.0.0"
+
 "@types/js-levenshtein@^1.1.0":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@types/js-levenshtein/-/js-levenshtein-1.1.1.tgz#ba05426a43f9e4e30b631941e0aa17bf0c890ed5"
@@ -5180,6 +5188,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 ansi-styles@^6.0.0:
   version "6.1.0"
@@ -8860,6 +8873,11 @@ diff-sequences@^26.6.2:
   version "26.6.2"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-26.6.2.tgz#48ba99157de1923412eed41db6b6d4aa9ca7c0b1"
   integrity sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+
+diff-sequences@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
+  integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
 
 diffie-hellman@^5.0.0:
   version "5.0.3"
@@ -13201,6 +13219,16 @@ jest-diff@^26.6.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
 
+jest-diff@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-27.5.1.tgz#a07f5011ac9e6643cf8a95a462b7b1ecf6680def"
+  integrity sha512-m0NvkX55LDt9T4mctTEgnZk3fmEg3NRYutvMPWM/0iPnkFj2wIeF45O1718cMSOFO1vINkqmxqD8vE37uTEbqw==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -13248,6 +13276,11 @@ jest-get-type@^26.3.0:
   version "26.3.0"
   resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-26.3.0.tgz#e97dc3c3f53c2b406ca7afaed4493b1d099199e0"
   integrity sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+
+jest-get-type@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-get-type/-/jest-get-type-27.5.1.tgz#3cd613c507b0f7ace013df407a1c1cd578bcb4f1"
+  integrity sha512-2KY95ksYSaK7DMBWQn6dQz3kqAf3BB64y2udeG+hv4KfSOb9qwcYQstTJc1KCbsix+wLZWZYN8t7nwX3GOBLRw==
 
 jest-haste-map@^26.6.2:
   version "26.6.2"
@@ -13311,6 +13344,16 @@ jest-matcher-utils@^26.6.0, jest-matcher-utils@^26.6.2:
     jest-diff "^26.6.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.6.2"
+
+jest-matcher-utils@^27.0.0:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-27.5.1.tgz#9c0cdbda8245bc22d2331729d1091308b40cf8ab"
+  integrity sha512-z2uTx/T6LBaCoNWNFWwChLBKYxTMcGBRjAt+2SbP929/Fflb9aa5LGma654Rz8z9HLxsrUaYzxE9T/EFIL/PAw==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^27.5.1"
+    jest-get-type "^27.5.1"
+    pretty-format "^27.5.1"
 
 jest-message-util@^26.6.0, jest-message-util@^26.6.2:
   version "26.6.2"
@@ -17208,6 +17251,15 @@ pretty-format@^26.6.0, pretty-format@^26.6.2:
     "@jest/types" "^26.6.2"
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
+    react-is "^17.0.1"
+
+pretty-format@^27.0.0, pretty-format@^27.5.1:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
     react-is "^17.0.1"
 
 pretty-hrtime@^1.0.3:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3869,6 +3869,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/gtag.js@^0.0.8":
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/@types/gtag.js/-/gtag.js-0.0.8.tgz#43035ab23a06b3bd0b23968c5c4ef000c597ad8a"
+  integrity sha512-xKDygydxruSUNkVbZWjiEbMijz9+xZCLb2yiTiQT88pm5EhIAUhaCo05IZF1HcQc90u4W7cp+7OZNpcJxpyL5g==
+
 "@types/hast@^2.0.0":
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/@types/hast/-/hast-2.3.4.tgz#8aa5ef92c117d20d974a82bdfb6a648b08c0bafc"


### PR DESCRIPTION
This PR adds a client for google analytics.

The client will send events if `gtag` is loaded otherwise it will log an error. It creates a closure around the setup and only exposes to call specific events.

I chose to create a `client` directory for this as a way to organize clients that will interact with external sources like apis, subgraph, ect.