### PR TITLE
Add wallet connect event

### DIFF
--- a/src/clients/googleAnalytics.spec.ts
+++ b/src/clients/googleAnalytics.spec.ts
@@ -13,14 +13,14 @@ describe('Google Analytics Client', () => {
   test('event is called when gtag exists on window', () => {
     window.gtag = () => {};
     const spy = jest.spyOn(window, 'gtag');
-    googleAnalytics.buttonPressed('connect');
+    googleAnalytics.buttonPressed('connect_wallet');
     expect(spy).toHaveBeenCalled();
   });
 
   test('calling event does not crash when gtag does not exit window', () => {
     // @ts-expect-error gtag could be missing if script isn't loaded from document
     window.gtag = undefined;
-    googleAnalytics.buttonPressed('connect');
+    googleAnalytics.buttonPressed('connect_wallet');
     expect(consoleSpy).toHaveBeenCalled();
     expect(consoleSpy.mock.calls[0][1]).toStrictEqual([
       'button_pressed',

--- a/src/clients/googleAnalytics.ts
+++ b/src/clients/googleAnalytics.ts
@@ -1,10 +1,12 @@
+import { ConnectorNames } from 'utilities/connectors';
+
 type EventParameters = Parameters<(eventName: string, parameters?: Record<string, string>) => void>;
 
-export type ButtonEventMap = {
-  connect: Record<string, string>;
+export type EventMap = {
+  connect_wallet: { type: ConnectorNames; code?: string };
 };
 
-export type ButtonEventName = keyof ButtonEventMap;
+export type EventName = keyof EventMap;
 
 const googleAnalytics = () => {
   let gtag: Gtag.Gtag;
@@ -24,15 +26,23 @@ const googleAnalytics = () => {
     gtag('event', eventName, parameters);
   });
 
-  function buttonPressed<E extends ButtonEventName>(
+  function buttonPressed<E extends EventName>(
     buttonName: E,
-    parameters?: ButtonEventMap[E] extends undefined ? never : ButtonEventMap[E],
+    parameters?: EventMap[E] extends undefined ? never : EventMap[E],
   ): void {
     sendEvent('button_pressed', { button_name: buttonName, ...parameters });
   }
 
+  function error<E extends EventName>(
+    errorName: E,
+    parameters?: EventMap[E] extends undefined ? never : EventMap[E],
+  ): void {
+    sendEvent('error', { error_name: errorName, ...parameters });
+  }
+
   return {
     buttonPressed,
+    error,
   };
 };
 

--- a/src/components/Basic/ConnectButton.tsx
+++ b/src/components/Basic/ConnectButton.tsx
@@ -314,7 +314,7 @@ function ConnectButton() {
                 <div className="line" />
                 <div
                   className="flex align-center just-between metamask-connect-btn"
-                  onClick={() => onConnect(ConnectorNames.Injected)}
+                  onClick={() => onConnect(ConnectorNames.MetaMask)}
                 >
                   <div className="flex align-center">
                     <img src={metamaskImg} alt="metamask" />
@@ -324,7 +324,7 @@ function ConnectButton() {
                 </div>
                 <div
                   className="flex align-center just-between metamask-connect-btn"
-                  onClick={() => onConnect(ConnectorNames.Injected)}
+                  onClick={() => onConnect(ConnectorNames.MetaMask)}
                 >
                   <div className="flex align-center">
                     <img src={trustwalletImg} alt="trustwallet" />

--- a/src/components/Basic/ConnectButton.tsx
+++ b/src/components/Basic/ConnectButton.tsx
@@ -13,6 +13,7 @@ import logoImg from 'assets/img/logo.png';
 import { useWeb3React } from '@web3-react/core';
 import { Button } from 'components/v2/Button';
 import toast from 'components/Basic/Toast';
+import ga from 'clients/googleAnalytics';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 import { BASE_BSC_SCAN_URL } from '../../config';
 import { ConnectorNames } from '../../utilities/connectors';
@@ -257,9 +258,10 @@ function ConnectButton() {
   };
 
   const onConnect = useCallback(
-    (type) => {
+    type => {
       onClose();
       login(type);
+      ga.buttonPressed('connect_wallet', { type });
     },
     [login, setShowConnect],
   );
@@ -274,10 +276,7 @@ function ConnectButton() {
       >
         {!account
           ? 'Connect'
-          : `${account.substr(0, 6)}...${account.substr(
-            account.length - 4,
-            4,
-          )}`}
+          : `${account.substr(0, 6)}...${account.substr(account.length - 4, 4)}`}
       </Button>
       <Modal
         className="venus-modal"
@@ -290,12 +289,7 @@ function ConnectButton() {
         centered
       >
         <ModalContent className="flex flex-column align-center just-center">
-          <img
-            className="close-btn pointer"
-            src={closeImg}
-            alt="close"
-            onClick={onClose}
-          />
+          <img className="close-btn pointer" src={closeImg} alt="close" onClick={onClose} />
           {!account ? (
             <>
               <div className="flex flex-column align-center just-center header-content">
@@ -361,11 +355,7 @@ function ConnectButton() {
               </div>
               <p className="center terms-of-use">
                 <span>By connecting, I accept Venus&lsquo;s</span>
-                <a
-                  href="https://www.swipe.io/terms"
-                  target="_blank"
-                  rel="noreferrer"
-                >
+                <a href="https://www.swipe.io/terms" target="_blank" rel="noreferrer">
                   Terms of Service
                 </a>
               </p>
@@ -379,10 +369,7 @@ function ConnectButton() {
                   <div
                     className="wallet-link-scan"
                     onClick={() => {
-                      window.open(
-                        `${BASE_BSC_SCAN_URL}/address/${account}`,
-                        '_blank',
-                      );
+                      window.open(`${BASE_BSC_SCAN_URL}/address/${account}`, '_blank');
                     }}
                   >
                     <span>View on BscScan</span>

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -10,6 +10,7 @@ import {
   WalletConnectConnector,
 } from '@web3-react/walletconnect-connector';
 import toast from 'components/Basic/Toast';
+import ga from 'clients/googleAnalytics';
 import { connectorLocalStorageKey } from '../config';
 import { connectorsByName, ConnectorNames } from '../utilities/connectors';
 import { setupNetwork } from '../utilities/wallet';
@@ -31,6 +32,7 @@ const useAuth = () => {
             if (error instanceof NoEthereumProviderError || error instanceof NoBscProviderError) {
               // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
               toast.error({ title: 'No provider was found' });
+              ga.error('connect_wallet', { type: connectorID, code: 'No provider was found' });
             } else if (
               error instanceof UserRejectedRequestErrorInjected ||
               error instanceof UserRejectedRequestErrorWalletConnect
@@ -41,9 +43,11 @@ const useAuth = () => {
               }
               // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
               toast.error({ title: 'Please authorize to access your account' });
+              ga.error('connect_wallet', { type: connectorID, code: 'User Rejected Request' });
             } else {
               // @ts-expect-error ts-migrate(2554) FIXME: Expected 2 arguments, but got 1.
               toast.error({ title: error.message });
+              ga.error('connect_wallet', { type: connectorID, code: error.message });
             }
           }
         });

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -17,7 +17,7 @@ import { setupNetwork } from '../utilities/wallet';
 const useAuth = () => {
   const { activate, deactivate } = useWeb3React();
   const login = useCallback(
-    connectorID => {
+    (connectorID: ConnectorNames) => {
       const connector = connectorsByName[connectorID];
       if (connector) {
         activate(connector, async error => {
@@ -59,12 +59,8 @@ const useAuth = () => {
     deactivate();
     // This localStorage key is set by @web3-react/walletconnect-connector
     if (window.localStorage.getItem('walletconnect')) {
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'close' does not exist on type 'InjectedC... Remove this comment to see the full error message
       connectorsByName[ConnectorNames.WalletConnect].close();
-      connectorsByName[
-        ConnectorNames.WalletConnect
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'walletConnectProvider' does not exist on... Remove this comment to see the full error message
-      ].walletConnectProvider = null;
+      connectorsByName[ConnectorNames.WalletConnect].walletConnectProvider = null;
     }
     window.localStorage.removeItem(connectorLocalStorageKey);
   }, [deactivate]);

--- a/src/utilities/connectors.ts
+++ b/src/utilities/connectors.ts
@@ -25,12 +25,12 @@ const ledger = new LedgerConnector({
   pollingInterval: POLLING_INTERVAL,
 });
 
-export const ConnectorNames = {
-  Injected: 'MetaMask',
-  WalletConnect: 'WalletConnect',
-  BSC: 'BSC',
-  Ledger: 'Ledger',
-};
+export enum ConnectorNames {
+  Injected = 'MetaMask',
+  WalletConnect = 'WalletConnect',
+  BSC = 'BSC',
+  Ledger = 'Ledger',
+}
 
 export const connectorsByName = {
   [ConnectorNames.Injected]: injected,

--- a/src/utilities/connectors.ts
+++ b/src/utilities/connectors.ts
@@ -26,14 +26,14 @@ const ledger = new LedgerConnector({
 });
 
 export enum ConnectorNames {
-  Injected = 'MetaMask',
+  MetaMask = 'MetaMask',
   WalletConnect = 'WalletConnect',
   BSC = 'BSC',
   Ledger = 'Ledger',
 }
 
 export const connectorsByName = {
-  [ConnectorNames.Injected]: injected,
+  [ConnectorNames.MetaMask]: injected,
   [ConnectorNames.WalletConnect]: walletconnect,
   [ConnectorNames.BSC]: bscConnector,
   [ConnectorNames.Ledger]: ledger,


### PR DESCRIPTION
This PR adds two events for connecting a wallet 
- When the connect wallet button is pressed and sends the connection type as a parameter
- When the connection errors, with the connector and failure reason sent as parameters

To make typing easier, a commit is included to rewrite the `ConnectorNames` as an enum and updates for related types which allowed for the removal of a couple type suppression comments