### PR TITLE
Structure components to be imported directly from components/index.ts

### DIFF
--- a/src/components/Basic/BorrowTabs/BorrowTab.tsx
+++ b/src/components/Basic/BorrowTabs/BorrowTab.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { Icon, Progress } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import NumberFormat from 'react-number-format';
 import { connectAccount } from 'core';
 import BigNumber from 'bignumber.js';

--- a/src/components/Basic/BorrowTabs/RepayBorrowTab.tsx
+++ b/src/components/Basic/BorrowTabs/RepayBorrowTab.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useCallback } from 'react';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import NumberFormat from 'react-number-format';
 import { connectAccount } from 'core';
 import BigNumber from 'bignumber.js';
@@ -205,11 +205,7 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
           <>
             <img src={asset.img} alt="asset" />
             <p className="center warning-label">
-              To Repay
-              {' '}
-              {asset.name}
-              {' '}
-              to the Venus Protocol, you need to enable it first.
+              To Repay {asset.name} to the Venus Protocol, you need to enable it first.
             </p>
           </>
         )}
@@ -239,10 +235,7 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
               <img className="asset-img" src={asset.img} alt="asset" />
               <span>Borrow APY</span>
             </div>
-            <span>
-              {asset.borrowApy.dp(2, 1).toString(10)}
-              %
-            </span>
+            <span>{asset.borrowApy.dp(2, 1).toString(10)}%</span>
           </div>
           <div className="description">
             <div className="flex align-center">
@@ -274,11 +267,7 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
               />
               <span>Repay VAI Balance</span>
             </div>
-            <span>
-              {userVaiMinted.dp(2, 1).toString(10)}
-              {' '}
-              VAI
-            </span>
+            <span>{userVaiMinted.dp(2, 1).toString(10)} VAI</span>
           </div>
         </div>
         {isEnabled && (
@@ -286,42 +275,24 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
             <div className="borrow-balance">
               <span>Borrow Balance</span>
               {amount.isZero() || amount.isNaN() ? (
-                <span>
-                  $
-                  {borrowBalance.dp(2, 1).toString(10)}
-                </span>
+                <span>${borrowBalance.dp(2, 1).toString(10)}</span>
               ) : (
                 <div className="flex align-center just-between">
-                  <span>
-                    $
-                    {borrowBalance.dp(2, 1).toString(10)}
-                  </span>
+                  <span>${borrowBalance.dp(2, 1).toString(10)}</span>
                   <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                  <span>
-                    $
-                    {newBorrowBalance.dp(2, 1).toString(10)}
-                  </span>
+                  <span>${newBorrowBalance.dp(2, 1).toString(10)}</span>
                 </div>
               )}
             </div>
             <div className="borrow-limit">
               <span>Borrow Limit Used</span>
               {amount.isZero() || amount.isNaN() ? (
-                <span>
-                  {borrowPercent.dp(2, 1).toString(10)}
-                  %
-                </span>
+                <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
               ) : (
                 <div className="flex align-center just-between">
-                  <span>
-                    {borrowPercent.dp(2, 1).toString(10)}
-                    %
-                  </span>
+                  <span>{borrowPercent.dp(2, 1).toString(10)}%</span>
                   <img className="arrow-right-img" src={arrowRightImg} alt="arrow" />
-                  <span>
-                    {newBorrowPercent.dp(2, 1).toString(10)}
-                    %
-                  </span>
+                  <span>{newBorrowPercent.dp(2, 1).toString(10)}%</span>
                 </div>
               )}
             </div>
@@ -341,9 +312,7 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
               onApprove();
             }}
           >
-            {isLoading && <Icon type="loading" />}
-            {' '}
-            Enable
+            {isLoading && <Icon type="loading" />} Enable
           </Button>
         ) : (
           <Button
@@ -356,17 +325,13 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
             }
             onClick={handleRepayBorrow}
           >
-            {isLoading && <Icon type="loading" />}
-            {' '}
-            Repay Borrow
+            {isLoading && <Icon type="loading" />} Repay Borrow
           </Button>
         )}
         <div className="description">
           <span>Wallet Balance</span>
           <span>
-            {format(asset.walletBalance.dp(2, 1).toString(10))}
-            {' '}
-            {asset.symbol}
+            {format(asset.walletBalance.dp(2, 1).toString(10))} {asset.symbol}
           </span>
         </div>
       </TabContent>

--- a/src/components/Basic/ConnectButton.tsx
+++ b/src/components/Basic/ConnectButton.tsx
@@ -11,7 +11,7 @@ import arrowRightImg from 'assets/img/arrow-right.png';
 import closeImg from 'assets/img/close.png';
 import logoImg from 'assets/img/logo.png';
 import { useWeb3React } from '@web3-react/core';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import toast from 'components/Basic/Toast';
 import ga from 'clients/googleAnalytics';
 import { CopyToClipboard } from 'react-copy-to-clipboard';

--- a/src/components/Basic/DelegationVoting.tsx
+++ b/src/components/Basic/DelegationVoting.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import styled from 'styled-components';
 import { Input, Icon } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import { useWeb3React } from '@web3-react/core';
 
 const VotingWrapper = styled.div`
@@ -97,8 +97,8 @@ const VotingWrapper = styled.div`
 `;
 
 interface Props extends RouteComponentProps {
-  isLoading: boolean,
-  onDelegate: (address: string) => void,
+  isLoading: boolean;
+  onDelegate: (address: string) => void;
 }
 
 function DelegationVoting({ history, isLoading, onDelegate }: Props) {
@@ -114,18 +114,14 @@ function DelegationVoting({ history, isLoading, onDelegate }: Props) {
           <span className="address">Select and Address</span>
         </div>
         <div className="detail">
-          If you know the address you wish to delegate to, enter it below. If
-          not, you can view the Delegate Leaderboard to find a political party
-          you wish to support.
+          If you know the address you wish to delegate to, enter it below. If not, you can view the
+          Delegate Leaderboard to find a political party you wish to support.
         </div>
       </div>
       <div className="flex flex-column voting-selection">
         <div className="flex align-center just-between">
           <span className="address">Delegate Address</span>
-          <span
-            className="leaderboard pointer"
-            onClick={() => history.push('/vote/leaderboard')}
-          >
+          <span className="leaderboard pointer" onClick={() => history.push('/vote/leaderboard')}>
             Delegate Leaderboard
           </span>
         </div>
@@ -151,9 +147,7 @@ function DelegationVoting({ history, isLoading, onDelegate }: Props) {
           disabled={isLoading}
           onClick={() => onDelegate(delegateAddress)}
         >
-          {isLoading && <Icon type="loading" />}
-          {' '}
-          Delegate Votes
+          {isLoading && <Icon type="loading" />} Delegate Votes
         </Button>
       </div>
     </VotingWrapper>

--- a/src/components/Basic/Proposal.tsx
+++ b/src/components/Basic/Proposal.tsx
@@ -3,7 +3,7 @@ import ReactMarkdown from 'react-markdown';
 import styled from 'styled-components';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Icon, Modal, Input } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import moment from 'moment';
 import dashImg from 'assets/img/dash.png';
 import closeImg from 'assets/img/close.png';
@@ -183,21 +183,20 @@ const VOTE_TYPE = {
   ABSTAIN: 2,
 };
 
-const getVoteTypeStringFromValue = (type: $TSFixMe) => [
-  ['👎', 'Against'],
-  ['👍', 'For'],
-  ['🤔️', 'Abstain'],
-][type];
+const getVoteTypeStringFromValue = (type: $TSFixMe) =>
+  [
+    ['👎', 'Against'],
+    ['👍', 'For'],
+    ['🤔️', 'Abstain'],
+  ][type];
 
 interface Props extends RouteComponentProps {
-  address: string,
-  proposal: ProposalObject,
-  votingWeight: string,
+  address: string;
+  proposal: ProposalObject;
+  votingWeight: string;
 }
 
-function Proposal({
-  address, proposal, votingWeight, history,
-}: Props) {
+function Proposal({ address, proposal, votingWeight, history }: Props) {
   const [isLoading, setIsLoading] = useState(false);
   const [voteType, setVoteType] = useState(VOTE_TYPE.FOR);
   const [voteStatus, setVoteStatus] = useState('');
@@ -219,9 +218,7 @@ function Proposal({
   };
 
   const getIsHasVoted = useCallback(async () => {
-    const res = await governorBravoContract.methods
-      .getReceipt(proposal.id, address)
-      .call();
+    const res = await governorBravoContract.methods.getReceipt(proposal.id, address).call();
     setVoteStatus(res.hasVoted ? 'voted' : 'novoted');
   }, [address, proposal]);
 
@@ -244,9 +241,7 @@ function Proposal({
           .castVoteWithReason(proposal.id, voteType, voteReason)
           .send({ from: address });
       } else {
-        await governorBravoContract.methods
-          .castVote(proposal.id, voteType)
-          .send({ from: address });
+        await governorBravoContract.methods.castVote(proposal.id, voteType).send({ from: address });
       }
     } catch (error) {
       console.log('cast vote error :>> ', error);
@@ -287,11 +282,7 @@ function Proposal({
               </Label>
             </Column>
             <Column xs="12" sm="5" className="description">
-              <div
-                className={`description-item orange-text ${getStatus(
-                  proposal,
-                )}-btn`}
-              >
+              <div className={`description-item orange-text ${getStatus(proposal)}-btn`}>
                 {getStatus(proposal)}
               </div>
               <Label size="16">{getRemainingTime(proposal)}</Label>
@@ -299,13 +290,11 @@ function Proposal({
           </Row>
         </Column>
         <Column xs="12" sm="3" className="vote-status">
-          {voteStatus
-            && voteStatus === 'novoted'
-            && proposal.state !== 'Active' && (
-              <div className="flex align-center">
-                <img src={dashImg} alt="dash" />
-                <p className="orange-text">NO VOTE</p>
-              </div>
+          {voteStatus && voteStatus === 'novoted' && proposal.state !== 'Active' && (
+            <div className="flex align-center">
+              <img src={dashImg} alt="dash" />
+              <p className="orange-text">NO VOTE</p>
+            </div>
           )}
           {voteStatus && voteStatus === 'voted' && (
             <div className="flex align-center">
@@ -322,14 +311,11 @@ function Proposal({
                 key={type}
                 className="vote-btn"
                 disabled={
-                    votingWeight === '0'
-                    || !proposal
-                    || (proposal && proposal.state !== 'Active')
-                  }
+                  votingWeight === '0' || !proposal || (proposal && proposal.state !== 'Active')
+                }
                 onClick={() => handleOpenVoteConfirmModal(type)}
               >
-                {isLoading && voteType === type && <Icon type="loading" />}
-                {' '}
+                {isLoading && voteType === type && <Icon type="loading" />}{' '}
                 {getVoteTypeStringFromValue(type)[1]}
               </Button>
             ))}
@@ -359,18 +345,13 @@ function Proposal({
           />
           <div className="header">
             <span className="title">
-              {getVoteTypeStringFromValue(voteType)[0]}
-              {' '}
-              I vote:
-              {' '}
+              {getVoteTypeStringFromValue(voteType)[0]} I vote:{' '}
               {getVoteTypeStringFromValue(voteType)[1]}
             </span>
           </div>
           <div className="input-wrapper">
             <div className="input-caption">
-              Why do you vote
-              {' '}
-              <span>{getVoteTypeStringFromValue(voteType)[1]}</span>
+              Why do you vote <span>{getVoteTypeStringFromValue(voteType)[1]}</span>
             </div>
             <Input.TextArea
               value={voteReason}
@@ -378,9 +359,7 @@ function Proposal({
               onChange={e => setVoteReason(e.target.value)}
               maxLength={MAX_INPUT_LENGTH}
             />
-            <div className="input-remaining">
-              {MAX_INPUT_LENGTH - voteReason.length}
-            </div>
+            <div className="input-remaining">{MAX_INPUT_LENGTH - voteReason.length}</div>
           </div>
           <div className="confirm-button-wrapper">
             <button
@@ -389,9 +368,7 @@ function Proposal({
               disabled={isLoading || voteReason.length > MAX_INPUT_LENGTH}
               onClick={() => handleVote()}
             >
-              {isLoading && <Icon type="loading" />}
-              {' '}
-              Confirm
+              {isLoading && <Icon type="loading" />} Confirm
             </button>
           </div>
         </ModalContentWrapper>

--- a/src/components/Basic/SupplyTabs/SupplyTab.tsx
+++ b/src/components/Basic/SupplyTabs/SupplyTab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import BigNumber from 'bignumber.js';
 import { Icon, Progress } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import NumberFormat from 'react-number-format';
 import { connectAccount } from 'core';
 import { useWeb3React } from '@web3-react/core';

--- a/src/components/Basic/SupplyTabs/WithdrawTab.tsx
+++ b/src/components/Basic/SupplyTabs/WithdrawTab.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from 'react';
 import BigNumber from 'bignumber.js';
 
 import { Icon, Progress } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import NumberFormat from 'react-number-format';
 import { useWeb3React } from '@web3-react/core';
 import { connectAccount } from 'core';

--- a/src/components/Basic/VaiTabs/MintTab.tsx
+++ b/src/components/Basic/VaiTabs/MintTab.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import BigNumber from 'bignumber.js';
 import { Icon } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import NumberFormat from 'react-number-format';
 import { useWeb3React } from '@web3-react/core';
 import commaNumber from 'comma-number';

--- a/src/components/Basic/VaiTabs/RepayVaiTab.tsx
+++ b/src/components/Basic/VaiTabs/RepayVaiTab.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Icon } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import NumberFormat from 'react-number-format';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';

--- a/src/components/Vote/ProposalModal.tsx
+++ b/src/components/Vote/ProposalModal.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import { Form, Input, Modal, Icon, Collapse } from 'antd';
 import { FormComponentProps } from 'antd/lib/form/Form';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import { connectAccount } from 'core';
 import MarkdownIt from 'markdown-it';
 import MdEditor from 'react-markdown-editor-lite';

--- a/src/components/VrtConversion/Convert.tsx
+++ b/src/components/VrtConversion/Convert.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import BigNumber from 'bignumber.js';
 import NumberFormat from 'react-number-format';
-import { Button, Icon } from 'components/v2';
+import { Button, Icon } from 'components';
 
 import { ButtonWrapper, ConvertWrapper } from './styles';
 
@@ -28,15 +28,14 @@ function formatCountdownInSeconds(seconds: number) {
   return `${hours} hours, ${minutes} minutes, ${remainingSeconds} seconds`;
 }
 
-
 export type ConvertPropsType = {
-  xvsVestingXvsBalance: BigNumber,
-  userVrtBalance: BigNumber,
-  userEnabled: boolean,
-  conversionEndTime: BigNumber,
-  conversionRatio: BigNumber,
-  account: string,
-  handleClickConvert: (convertAmount: BigNumber) => void,
+  xvsVestingXvsBalance: BigNumber;
+  userVrtBalance: BigNumber;
+  userEnabled: boolean;
+  conversionEndTime: BigNumber;
+  conversionRatio: BigNumber;
+  account: string;
+  handleClickConvert: (convertAmount: BigNumber) => void;
 };
 
 export default ({
@@ -50,9 +49,7 @@ export default ({
 }: ConvertPropsType) => {
   const [convertInputAmount, setConvertInputAmount] = useState(new BigNumber(0));
   const [convertLoading, setConvertLoading] = useState(false);
-  const maxConvertAmountRegardingXvsBalance = xvsVestingXvsBalance.div(
-    conversionRatio,
-  );
+  const maxConvertAmountRegardingXvsBalance = xvsVestingXvsBalance.div(conversionRatio);
 
   let confirmButtonText = '';
   if (!account) {
@@ -71,11 +68,7 @@ export default ({
       </div>
       {/* display available XVS in pool */}
       <div className="xvs-pool">
-        <div className="xvs-pool-line-1">
-          {xvsVestingXvsBalance.toFixed(4)}
-          {' '}
-          XVS
-        </div>
+        <div className="xvs-pool-line-1">{xvsVestingXvsBalance.toFixed(4)} XVS</div>
         <div className="xvs-pool-line-2">Current available</div>
       </div>
       {/* convert section */}
@@ -106,10 +99,7 @@ export default ({
               className="button max-button"
               onClick={() => {
                 setConvertInputAmount(
-                  BigNumber.min(
-                    userVrtBalance,
-                    maxConvertAmountRegardingXvsBalance,
-                  ),
+                  BigNumber.min(userVrtBalance, maxConvertAmountRegardingXvsBalance),
                 );
               }}
             >
@@ -120,9 +110,7 @@ export default ({
         </div>
         <div className="user-vrt-balance">
           Balance:
-          {account ? userVrtBalance.toFixed(4) : '-'}
-          {' '}
-          VRT
+          {account ? userVrtBalance.toFixed(4) : '-'} VRT
         </div>
       </div>
       {/* recieve section */}
@@ -165,10 +153,7 @@ export default ({
         <Icon className="clock-icon" name="countdown" />
         <span className="remaining-cap-text">Remaining time: </span>
         <span className="remaining-time-text">
-          {formatCountdownInSeconds(
-            Math.floor(Number(conversionEndTime.minus(Date.now() / 1000))),
-          )}
-          {' '}
+          {formatCountdownInSeconds(Math.floor(Number(conversionEndTime.minus(Date.now() / 1000))))}{' '}
         </span>
       </div>
     </ConvertWrapper>

--- a/src/components/VrtConversion/Withdraw.tsx
+++ b/src/components/VrtConversion/Withdraw.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
-import { Button } from 'components/v2';
+import { Button } from 'components';
 import { ButtonWrapper } from './styles';
 
 const WithdrawWrapper = styled.div`
@@ -45,9 +45,7 @@ export default ({ withdrawableAmount, account, handleClickWithdraw }: WithdrawPr
       <div className="withdraw-title">
         <div className="withdraw-title-line-1">Withdrawable amount</div>
         <div className="withdraw-title-line-2">
-          {commaFormatter(withdrawableAmount.toFixed(6))}
-          {' '}
-          XVS
+          {commaFormatter(withdrawableAmount.toFixed(6))} XVS
         </div>
       </div>
       <ButtonWrapper>

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,0 +1,4 @@
+export { Button } from './v2/Button';
+export { Icon } from './v2/Icon';
+export { Dropdown } from './v2/Dropdown';
+export { Layout } from './v2/Layout';

--- a/src/components/v2/Button/index.tsx
+++ b/src/components/v2/Button/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Button as MuiButton, ButtonProps } from '@mui/material';
-import { Icon } from 'components/v2/Icon';
+import { Icon } from 'components';
 // import SwapHorizIcon from '@mui/icons-material/loading';
 interface IButtonProps extends ButtonProps {
   className?: string;
@@ -18,6 +18,7 @@ export const Button = ({
   ...restProps
 }: IButtonProps) => (
   <MuiButton className={className} {...restProps}>
-    {loading && <Icon size={loadingIconSize} color={loadingIconColor} name="loading" />}{children}
+    {loading && <Icon size={loadingIconSize} color={loadingIconColor} name="loading" />}
+    {children}
   </MuiButton>
 );

--- a/src/components/v2/index.ts
+++ b/src/components/v2/index.ts
@@ -1,2 +1,0 @@
-export { Button } from './Button';
-export { Icon } from './Icon';

--- a/src/containers/Main/Faucet.tsx
+++ b/src/containers/Main/Faucet.tsx
@@ -6,7 +6,7 @@ import { withRouter, RouteComponentProps } from 'react-router-dom';
 import { connectAccount } from 'core';
 import MainLayout from 'containers/Layout/MainLayout';
 import { promisify } from 'utilities';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import LoadingSpinner from 'components/Basic/LoadingSpinner';
 import toast from 'components/Basic/Toast';
 import * as constants from 'utilities/constants';

--- a/src/containers/Main/VoteOverview.tsx
+++ b/src/containers/Main/VoteOverview.tsx
@@ -6,7 +6,7 @@ import Web3 from 'web3';
 import BigNumber from 'bignumber.js';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { Icon, Tooltip } from 'antd';
-import { Button } from 'components/v2/Button';
+import { Button } from 'components';
 import { connectAccount } from 'core';
 import MainLayout from 'containers/Layout/MainLayout';
 import ProposalInfo from 'components/Vote/VoteOverview/ProposalInfo';


### PR DESCRIPTION
This is a proposal to export all components from `components/index.ts` and import them directly from `components`

It is nice to export all components from the index of the components dir because it makes importing them easy.
- You don't have to remember the dir
- They can all be imported on a single line

As a side effect  when we drop the old components dirs and the v2 dir we'll only have to update this file and remove `/v2`. The imports in the rest of the application won't change.