### PR TITLE
Add slider component

### DIFF
--- a/src/components/v2/Slider/Styles.ts
+++ b/src/components/v2/Slider/Styles.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const styles = ({ over }: { over: boolean }) => {
+  const theme = useTheme();
+  return css`
+    color: ${over ? theme.palette.error.slider : theme.palette.success.slider};
+    background-color: ${theme.palette.background.black};
+    height: 8px;
+    padding: 0;
+    .MuiSlider-track {
+      height: 8px;
+    }
+    .MuiSlider-rail {
+      height: 8px;
+      color: ${theme.palette.background.black};
+    }
+    .MuiSlider-mark {
+      width: 4px;
+      height: 8px;
+      color: ${theme.palette.error.slider};
+    }
+  `;
+};
+
+export default styles;

--- a/src/components/v2/Slider/index.stories.tsx
+++ b/src/components/v2/Slider/index.stories.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { withThemeProvider } from 'stories/decorators';
+import Box from '@mui/material/Box';
+import { Slider } from '.';
+
+export default {
+  title: 'Slider',
+  component: Slider,
+  decorators: [withThemeProvider],
+} as ComponentMeta<typeof Slider>;
+
+export const ValidDropdown = () => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      height: '100vh',
+    }}
+  >
+    <Box sx={{ width: 600, display: 'flex' }}>
+      <Slider
+        onChange={console.log}
+        defaultValue={50}
+        step={10}
+        mark={75}
+        ariaLabel="Storybook slider"
+        min={0}
+        max={100}
+      />
+    </Box>
+  </Box>
+);
+
+export const InValidDropdown = () => (
+  <Box
+    sx={{
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      width: '100%',
+      height: '100vh',
+    }}
+  >
+    <Box sx={{ width: 600, display: 'flex' }}>
+      <Slider
+        onChange={console.log}
+        defaultValue={90}
+        step={10}
+        mark={75}
+        ariaLabel="Storybook slider"
+        min={0}
+        max={100}
+      />
+    </Box>
+  </Box>
+);

--- a/src/components/v2/Slider/index.tsx
+++ b/src/components/v2/Slider/index.tsx
@@ -1,0 +1,45 @@
+/** @jsxImportSource @emotion/react */
+import React, { useState } from 'react';
+import MaterialSlider from '@mui/material/Slider';
+import { styles } from './Styles';
+
+interface ISliderProps {
+  defaultValue: number;
+  mark: number;
+  step: number;
+  ariaLabel: string;
+  min: number;
+  max: number;
+  onChange: (value: number | number[]) => void;
+}
+
+export const Slider = ({
+  defaultValue,
+  mark,
+  step,
+  ariaLabel,
+  min,
+  max,
+  onChange,
+}: ISliderProps) => {
+  const marks = mark ? [{ value: mark }] : undefined;
+  const [over, setOver] = useState(defaultValue > mark);
+  const wrappedOnChange = (event: React.SyntheticEvent | Event, value: number | number[]) => {
+    setOver(value > mark);
+    onChange(value);
+  };
+  return (
+    <MaterialSlider
+      css={styles({ over })}
+      onChange={wrappedOnChange}
+      components={{ Thumb: undefined }}
+      defaultValue={defaultValue}
+      marks={marks}
+      step={step}
+      aria-label={ariaLabel}
+      min={min}
+      max={max}
+      size="medium"
+    />
+  );
+};

--- a/src/theme/MuiThemeProvider/muiTheme.ts
+++ b/src/theme/MuiThemeProvider/muiTheme.ts
@@ -13,6 +13,7 @@ export const PALETTE = {
   background: {
     default: '#090D27',
     paper: '#181C3A',
+    black: '#1F2028',
   },
   primary: {
     light: '#EBBF6E',
@@ -30,9 +31,11 @@ export const PALETTE = {
   },
   success: {
     main: '#9DD562',
+    slider: '#18DF8B',
   },
   error: {
     main: '#F9053E',
+    slider: 'rgba(233, 61, 68, 0.5)',
   },
 };
 

--- a/src/types/mui.d.ts
+++ b/src/types/mui.d.ts
@@ -1,0 +1,14 @@
+import {
+  PaletteColor as MuiPaletteColor,
+  TypeBackground as MuiTypeBackground,
+} from '@mui/material/styles/createPalette';
+
+declare module '@mui/material/styles' {
+  interface PaletteColor extends MuiPaletteColor {
+    slider?: string;
+  }
+
+  interface TypeBackground extends MuiTypeBackground {
+    black?: string;
+  }
+}


### PR DESCRIPTION
Adds a slider component based on designs.

I used the css prop because I thought it would get picked up by style-lint, the current style implementation for Dropdown isn't being picked up either.

I can update to match Dropdown but I wanted to flag the issue with `style-lint`