### PR TITLE
fix: vrt conversion withdraw button

### DIFF
--- a/src/containers/Main/VrtConversion.tsx
+++ b/src/containers/Main/VrtConversion.tsx
@@ -180,9 +180,13 @@ export default () => {
                   <Withdraw
                     withdrawableAmount={withdrawableAmount}
                     handleClickWithdraw={async () => {
-                      await xvsVestingContract.methods.withdraw().send({
-                        from: account,
-                      });
+                      try {
+                        await xvsVestingContract.methods.withdraw().send({
+                          from: account,
+                        });
+                      } catch (e) {
+                        console.log('>> withdraw error', e);
+                      }
                     }}
                     account={account || ''}
                   />


### PR DESCRIPTION
fix the loading status of withdraw button: when there is an error during withdrawal, loading status can't be reset