### PR TITLE
Fix total treasury balance displayed on Market page

### DIFF
--- a/src/components/Dashboard/Overview.tsx
+++ b/src/components/Dashboard/Overview.tsx
@@ -179,10 +179,7 @@ function Overview({ settings, getMarketHistory }: OverviewProps) {
   useEffect(() => {
     if (!currentAsset) return;
     if (markets && markets.length > 0) {
-      const info = markets.find(
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'underlyingSymbol' does not exist on type... Remove this comment to see the full error message
-        item => item.underlyingSymbol.toLowerCase() === currentAsset,
-      );
+      const info = markets.find(item => item.underlyingSymbol.toLowerCase() === currentAsset);
       setMarketInfo(info || {});
     }
   }, [markets, currentAsset]);

--- a/src/components/MarketDetail/InterestRateModel.tsx
+++ b/src/components/MarketDetail/InterestRateModel.tsx
@@ -158,14 +158,11 @@ function InterestRateModel({ currentAsset }: Props) {
 
     const data: $TSFixMe = [];
     const marketInfo = markets.find(
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'underlyingSymbol' does not exist on type... Remove this comment to see the full error message
       item => item.underlyingSymbol.toLowerCase() === asset.toLowerCase(),
     );
     // Get Current Utilization Rate
     const cash = new BigNumber(cashValue).div(1e18);
-    // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
     const borrows = new BigNumber(marketInfo.totalBorrows2);
-    // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
     const reserves = new BigNumber(marketInfo.totalReserves || 0).div(
       // @ts-expect-error ts-migrate(7053) FIXME: Element implicitly has an 'any' type because expre... Remove this comment to see the full error message
       new BigNumber(10).pow(constants.CONTRACT_TOKEN_ADDRESS[asset].decimals),
@@ -210,7 +207,6 @@ function InterestRateModel({ currentAsset }: Props) {
               .toString(10),
             1e4,
             0,
-            // @ts-expect-error ts-migrate(2532) FIXME: Object is possibly 'undefined'.
             marketInfo.reserveFactor.toString(10),
           )
           .call(),

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -8,6 +8,15 @@ const API_ENDPOINT_URLS = {
   97: 'https://testnetapi.venus.io/api',
 };
 
+// Note: this is a temporary fix. Once we start refactoring this part we should
+// probably fetch the treasury address using the Comptroller contract
+const TREASURY_ADDRESSES = {
+  56: '0xF322942f644A996A617BD29c16bd7d231d9F35E9',
+  // When querying comptroller.treasuryAddress() we get an empty address back,
+  // so for now I've let it as it is
+  97: '0x0000000000000000000000000000000000000000',
+};
+
 export const BASE_BSC_SCAN_URL =
   // @ts-expect-error ts-migrate(2538) FIXME: Type 'undefined' cannot be used as an index type.
   BASE_BSC_SCAN_URLS[process.env.REACT_APP_CHAIN_ID];
@@ -19,3 +28,6 @@ export const API_ENDPOINT_URL =
 export const connectorLocalStorageKey = 'venus-local-key';
 
 export const vtokenDecimals = 8;
+
+// @ts-expect-error ts-migrate(2538) FIXME: Type 'undefined' cannot be used as an index type.
+export const TREASURY_ADDRESS = TREASURY_ADDRESSES[process.env.REACT_APP_CHAIN_ID];

--- a/src/containers/Layout/Sidebar.tsx
+++ b/src/containers/Layout/Sidebar.tsx
@@ -330,10 +330,8 @@ function Sidebar({ history, setSetting }: SidebarProps) {
       venusVAIVaultRate = new BigNumber(venusVAIVaultRate).div(1e18).times(20 * 60 * 24);
 
       // VAI APY
-      // @ts-expect-error ts-migrate(2339) FIXME: Property 'underlyingSymbol' does not exist on type... Remove this comment to see the full error message
       const xvsMarket = markets.find(ele => ele.underlyingSymbol === 'XVS');
       const vaiAPY = new BigNumber(venusVAIVaultRate)
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'tokenPrice' does not exist on type 'neve... Remove this comment to see the full error message
         .times(xvsMarket ? xvsMarket.tokenPrice : 0)
         .times(365 * 100)
         .div(vaultVaiStaked)
@@ -342,10 +340,7 @@ function Sidebar({ history, setSetting }: SidebarProps) {
 
       const totalLiquidity = (markets || []).reduce(
         (accumulator, market) =>
-          new BigNumber(accumulator).plus(
-            // @ts-expect-error ts-migrate(2339) FIXME: Property 'totalSupplyUsd' does not exist on type '... Remove this comment to see the full error message
-            new BigNumber(market.totalSupplyUsd),
-          ),
+          new BigNumber(accumulator).plus(new BigNumber(market.totalSupplyUsd)),
         vaultVaiStaked,
       );
       setSetting({

--- a/src/containers/Main/Market/index.tsx
+++ b/src/containers/Main/Market/index.tsx
@@ -168,7 +168,7 @@ function Market({ history, settings }: MarketProps) {
   const [totalBorrow, setTotalBorrow] = useState('0');
   const [availableLiquidity, setAvailableLiquidity] = useState('0');
   const [sortInfo, setSortInfo] = useState({ field: '', sort: 'desc' });
-  const { markets } = useMarkets();
+  const { markets, treasuryTotalUSDBalance } = useMarkets();
 
   const getTotalInfo = async () => {
     const tempTS = (markets || []).reduce(
@@ -233,8 +233,7 @@ function Market({ history, settings }: MarketProps) {
             </div>
             <div className="total-item">
               <div className="prop">Total Treasury</div>
-              {/* TODO: update with actual total treasury value, calculated using data from contract */}
-              <div className="value">${format(0)}</div>
+              <div className="value">${format(treasuryTotalUSDBalance.dp(2).toString())}</div>
             </div>
           </div>
           {settings.vaiAPY && (

--- a/src/containers/Main/Market/index.tsx
+++ b/src/containers/Main/Market/index.tsx
@@ -173,24 +173,16 @@ function Market({ history, settings }: MarketProps) {
   const getTotalInfo = async () => {
     const tempTS = (markets || []).reduce(
       (accumulator, market) =>
-        new BigNumber(accumulator).plus(
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'totalSupplyUsd' does not exist on type '... Remove this comment to see the full error message
-          new BigNumber(market.totalSupplyUsd),
-        ),
+        new BigNumber(accumulator).plus(new BigNumber(market.totalSupplyUsd)),
       new BigNumber(0),
     );
     const tempTB = (markets || []).reduce(
       (accumulator, market) =>
-        new BigNumber(accumulator).plus(
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'totalBorrowsUsd' does not exist on type ... Remove this comment to see the full error message
-          new BigNumber(market.totalBorrowsUsd),
-        ),
+        new BigNumber(accumulator).plus(new BigNumber(market.totalBorrowsUsd)),
       new BigNumber(0),
     );
     const tempAL = (markets || []).reduce(
-      (accumulator, market) =>
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'liquidity' does not exist on type 'never... Remove this comment to see the full error message
-        new BigNumber(accumulator).plus(new BigNumber(market.liquidity)),
+      (accumulator, market) => new BigNumber(accumulator).plus(new BigNumber(market.liquidity)),
       new BigNumber(0),
     );
 
@@ -306,16 +298,11 @@ function Market({ history, settings }: MarketProps) {
             {markets &&
               (markets || [])
                 .map(market => ({
-                  // @ts-expect-error ts-migrate(2698) FIXME: Spread types may only be created from object types... Remove this comment to see the full error message
                   ...market,
-                  // @ts-expect-error ts-migrate(manual) FIXME: Remove this comment to see the full error message
                   totalSupplyApy: new BigNumber(market.supplyApy).plus(
-                    // @ts-expect-error ts-migrate(manual) FIXME: Remove this comment to see the full error message
                     new BigNumber(market.supplyVenusApy),
                   ),
-                  // @ts-expect-error ts-migrate(manual) FIXME: Remove this comment to see the full error message
                   totalBorrowApy: new BigNumber(market.borrowVenusApy).plus(
-                    // @ts-expect-error ts-migrate(manual) FIXME: Remove this comment to see the full error message
                     new BigNumber(market.borrowApy),
                   ),
                 }))

--- a/src/containers/Main/Market/index.tsx
+++ b/src/containers/Main/Market/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import BigNumber from 'bignumber.js';
 import commaNumber from 'comma-number';
@@ -6,7 +6,6 @@ import { Row, Col, Icon } from 'antd';
 import styled from 'styled-components';
 import { connect } from 'react-redux';
 import MainLayout from 'containers/Layout/MainLayout';
-import { promisify } from 'utilities';
 import * as constants from 'utilities/constants';
 import { currencyFormatter, formatApy } from 'utilities/common';
 import { uid } from 'react-uid';
@@ -162,34 +161,14 @@ const format = commaNumber.bindWith(',', '.');
 
 interface MarketProps extends RouteComponentProps {
   settings: Setting;
-  getTreasuryBalance: () => void;
 }
 
-function Market({ history, settings, getTreasuryBalance }: MarketProps) {
+function Market({ history, settings }: MarketProps) {
   const [totalSupply, setTotalSupply] = useState('0');
   const [totalBorrow, setTotalBorrow] = useState('0');
   const [availableLiquidity, setAvailableLiquidity] = useState('0');
   const [sortInfo, setSortInfo] = useState({ field: '', sort: 'desc' });
-  const [totalTreasury, setTotalTreasury] = useState(0);
   const { markets } = useMarkets();
-
-  const loadTreasuryBalance = useCallback(async () => {
-    await promisify(getTreasuryBalance, {})
-      .then(res => {
-        // @ts-expect-error ts-migrate(2571) FIXME: Object is of type 'unknown'.
-        const total = (res.data || []).reduce(
-          (accumulator: $TSFixMe, asset: $TSFixMe) =>
-            accumulator + Number(asset.balance) * Number(asset.price),
-          0,
-        );
-        setTotalTreasury(total.toFixed(2));
-      })
-      .catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    loadTreasuryBalance();
-  }, [markets]);
 
   const getTotalInfo = async () => {
     const tempTS = (markets || []).reduce(
@@ -262,7 +241,8 @@ function Market({ history, settings, getTreasuryBalance }: MarketProps) {
             </div>
             <div className="total-item">
               <div className="prop">Total Treasury</div>
-              <div className="value">${format(totalTreasury)}</div>
+              {/* TODO: update with actual total treasury value, calculated using data from contract */}
+              <div className="value">${format(0)}</div>
             </div>
           </div>
           {settings.vaiAPY && (

--- a/src/containers/Main/MarketDetail.tsx
+++ b/src/containers/Main/MarketDetail.tsx
@@ -144,10 +144,7 @@ function MarketDetail({ match, getMarketHistory }: Props) {
 
   const getGovernanceData = useCallback(async () => {
     if (markets && markets.length > 0 && currentAsset) {
-      const info = markets.find(
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'underlyingSymbol' does not exist on type... Remove this comment to see the full error message
-        item => item.underlyingSymbol.toLowerCase() === currentAsset,
-      );
+      const info = markets.find(item => item.underlyingSymbol.toLowerCase() === currentAsset);
       setMarketInfo(info || {});
     }
   }, [markets, currentAsset]);

--- a/src/containers/Main/XVS/index.tsx
+++ b/src/containers/Main/XVS/index.tsx
@@ -207,11 +207,7 @@ function XVS({ settings }: XVSProps) {
     const tempMarkets = [];
     const sum = (markets || []).reduce(
       (accumulator, market) =>
-        // @ts-expect-error ts-migrate(2769) FIXME: No overload matches this call.
-        new BigNumber(accumulator).plus(
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'totalDistributed' does not exist on type... Remove this comment to see the full error message
-          new BigNumber(market.totalDistributed),
-        ),
+        new BigNumber(accumulator).plus(new BigNumber(market.totalDistributed)),
       0,
     );
 
@@ -226,7 +222,6 @@ function XVS({ settings }: XVSProps) {
         .dp(2, 1)
         .toString(10),
     );
-    // @ts-expect-error ts-migrate(2339) FIXME: Property 'toString' does not exist on type 'never'... Remove this comment to see the full error message
     setTotalDistributed(sum.toString(10));
     setRemainAmount(
       new BigNumber(remainedAmount)
@@ -236,25 +231,18 @@ function XVS({ settings }: XVSProps) {
     );
     for (let i = 0; i < markets.length; i += 1) {
       tempMarkets.push({
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'underlyingSymbol' does not exist on type... Remove this comment to see the full error message
         underlyingSymbol: markets[i].underlyingSymbol,
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'supplierDailyVenus' does not exist on ty... Remove this comment to see the full error message
         perDay: +new BigNumber(markets[i].supplierDailyVenus)
-          // @ts-expect-error ts-migrate(2339) FIXME: Property 'borrowerDailyVenus' does not exist on ty... Remove this comment to see the full error message
           .plus(new BigNumber(markets[i].borrowerDailyVenus))
           .div(new BigNumber(10).pow(18))
           .dp(2, 1)
           .toString(10),
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'supplyVenusApy' does not exist on type '... Remove this comment to see the full error message
         supplyAPY: +(new BigNumber(markets[i].supplyVenusApy).isLessThan(0.01)
           ? '0.01'
-          : // @ts-expect-error ts-migrate(2339) FIXME: Property 'supplyVenusApy' does not exist on type '... Remove this comment to see the full error message
-            new BigNumber(markets[i].supplyVenusApy).dp(2, 1).toString(10)),
-        // @ts-expect-error ts-migrate(2339) FIXME: Property 'borrowVenusApy' does not exist on type '... Remove this comment to see the full error message
+          : new BigNumber(markets[i].supplyVenusApy).dp(2, 1).toString(10)),
         borrowAPY: +(new BigNumber(markets[i].borrowVenusApy).isLessThan(0.01)
           ? '0.01'
-          : // @ts-expect-error ts-migrate(2339) FIXME: Property 'borrowVenusApy' does not exist on type '... Remove this comment to see the full error message
-            new BigNumber(markets[i].borrowVenusApy).dp(2, 1).toString(10)),
+          : new BigNumber(markets[i].borrowVenusApy).dp(2, 1).toString(10)),
       });
     }
     tempMarkets.push({

--- a/src/context/MarketContext.tsx
+++ b/src/context/MarketContext.tsx
@@ -11,7 +11,7 @@ import { useComptroller, useVenusLens } from '../hooks/useContract';
 import * as constants from '../utilities/constants';
 
 const MarketContext = React.createContext({
-  markets: [],
+  markets: [] as any[],
   dailyVenus: 0,
   userMarketInfo: {},
   userTotalBorrowLimit: new BigNumber(0),
@@ -23,7 +23,7 @@ const MarketContext = React.createContext({
 // duplicated requests
 
 const MarketContextProvider = ({ children }: $TSFixMe) => {
-  const [markets, setMarkets] = useState([]);
+  const [markets, setMarkets] = useState<$TSFixMe[]>([]);
   const [dailyVenus, setDailyVenus] = useState(0);
   const [userMarketInfo, setUserMarketInfo] = useState({});
   const [userTotalBorrowLimit, setUserTotalBorrowLimit] = useState(new BigNumber(0));
@@ -59,7 +59,6 @@ const MarketContextProvider = ({ children }: $TSFixMe) => {
         return;
       }
 
-      // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'any[]' is not assignable to para... Remove this comment to see the full error message
       setMarkets(data);
       // @ts-expect-error ts-migrate(2339) FIXME: Property 'data' does not exist on type '{ status: ... Remove this comment to see the full error message
       setDailyVenus(res.data.data.dailyVenus);

--- a/src/context/MarketContext.tsx
+++ b/src/context/MarketContext.tsx
@@ -12,8 +12,9 @@ import { useComptroller, useVenusLens } from '../hooks/useContract';
 import * as constants from '../utilities/constants';
 
 const MarketContext = React.createContext({
-  markets: [] as any[],
+  markets: [] as $TSFixMe[],
   dailyVenus: 0,
+  treasuryTotalUSDBalance: new BigNumber(0),
   userMarketInfo: {},
   userTotalBorrowLimit: new BigNumber(0),
   userTotalBorrowBalance: new BigNumber(0),
@@ -30,6 +31,7 @@ const MarketContextProvider = ({ children }: $TSFixMe) => {
   const [userTotalBorrowLimit, setUserTotalBorrowLimit] = useState(new BigNumber(0));
   const [userTotalBorrowBalance, setUserTotalBorrowBalance] = useState(new BigNumber(0));
   const [userXVSBalance, setUserXVSBalance] = useState(new BigNumber(0));
+  const [treasuryTotalUSDBalance, setTreasuryTotalUSDBalance] = useState(new BigNumber(0));
   const comptrollerContract = useComptroller();
   const lens = useVenusLens();
   const { account } = useWeb3React();
@@ -258,9 +260,14 @@ const MarketContextProvider = ({ children }: $TSFixMe) => {
           return;
         }
 
-        // TODO: calculate total treasury value in USD
-        console.log(assetList);
+        // Calculate total treasury balance in USD
+        const updatedTreasuryTotalUSDBalance = assetList.reduce((accumulator, asset) => {
+          // @ts-expect-error ts-migrate(2531) FIXME: Object is possibly 'null'.
+          const treasuryUSDBalance = asset.treasuryBalance.multipliedBy(asset.tokenPrice);
+          return accumulator.plus(treasuryUSDBalance);
+        }, new BigNumber(0));
 
+        setTreasuryTotalUSDBalance(updatedTreasuryTotalUSDBalance);
         setUserMarketInfo(assetList);
         setUserTotalBorrowLimit(totalBorrowLimit);
         setUserTotalBorrowBalance(totalBorrowBalance);
@@ -280,6 +287,7 @@ const MarketContextProvider = ({ children }: $TSFixMe) => {
       value={{
         markets,
         dailyVenus,
+        treasuryTotalUSDBalance,
         userMarketInfo,
         userTotalBorrowLimit,
         userTotalBorrowBalance,

--- a/src/core/modules/account/actions.ts
+++ b/src/core/modules/account/actions.ts
@@ -23,7 +23,6 @@ export const GET_VOTER_HISTORY_REQUEST = '@account/GET_VOTER_HISTORY_REQUEST';
 
 export const GET_VOTER_ACCOUNTS_REQUEST = '@account/GET_VOTER_ACCOUNTS_REQUEST';
 export const GET_TRANSACTION_HISTORY_REQUEST = '@account/GET_TRANSACTION_HISTORY_REQUEST';
-export const GET_TREASURY_BALANCE_REQUEST = '@account/GET_TREASURY_BALANCE_REQUEST';
 
 /**
  * Action Creators
@@ -43,5 +42,4 @@ export const accountActionCreators = {
   getVoterHistory: createPromiseAction(GET_VOTER_HISTORY_REQUEST),
   getVoterAccounts: createPromiseAction(GET_VOTER_ACCOUNTS_REQUEST),
   getTransactionHistory: createPromiseAction(GET_TRANSACTION_HISTORY_REQUEST),
-  getTreasuryBalance: createPromiseAction(GET_TREASURY_BALANCE_REQUEST),
 };

--- a/src/core/modules/account/saga.ts
+++ b/src/core/modules/account/saga.ts
@@ -1,7 +1,5 @@
 /* eslint-disable no-unused-vars */
-import {
-  put, call, fork, all, take,
-} from 'redux-saga/effects';
+import { put, call, fork, all, take } from 'redux-saga/effects';
 
 import {
   GET_MARKET_HISTORY_REQUEST,
@@ -14,17 +12,12 @@ import {
   GET_VOTER_HISTORY_REQUEST,
   GET_VOTER_ACCOUNTS_REQUEST,
   GET_TRANSACTION_HISTORY_REQUEST,
-  GET_TREASURY_BALANCE_REQUEST,
   accountActionCreators,
 } from 'core/modules/account/actions';
 
 import { restService } from 'utilities';
 
-export function* asyncGetMarketHistoryRequest({
-  payload,
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetMarketHistoryRequest({ payload, resolve, reject }: $TSFixMe) {
   const { asset, limit, type } = payload;
   let api = `/market_history/graph?asset=${asset}&type=${type}`;
   if (limit) api += `&limit=${limit}`;
@@ -43,10 +36,7 @@ export function* asyncGetMarketHistoryRequest({
   }
 }
 
-export function* asyncGetGovernanceVenusRequest({
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetGovernanceVenusRequest({ resolve, reject }: $TSFixMe) {
   try {
     // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
     const response = yield call(restService, {
@@ -62,11 +52,7 @@ export function* asyncGetGovernanceVenusRequest({
   }
 }
 
-export function* asyncGetProposalsRequest({
-  payload,
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetProposalsRequest({ payload, resolve, reject }: $TSFixMe) {
   const { limit, offset } = payload;
   try {
     // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
@@ -110,11 +96,7 @@ export function* asyncGetFaucetRequest({ payload, resolve, reject }: $TSFixMe) {
   }
 }
 
-export function* asyncGetProposalByIdRequest({
-  payload,
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetProposalByIdRequest({ payload, resolve, reject }: $TSFixMe) {
   const { id } = payload;
   try {
     // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
@@ -134,9 +116,7 @@ export function* asyncGetProposalByIdRequest({
 }
 
 export function* asyncGetVotersRequest({ payload, resolve, reject }: $TSFixMe) {
-  const {
-    limit, filter, id, offset,
-  } = payload;
+  const { limit, filter, id, offset } = payload;
   try {
     let api = `/voters/${id}?filter=${filter}`;
     if (limit) {
@@ -160,11 +140,7 @@ export function* asyncGetVotersRequest({ payload, resolve, reject }: $TSFixMe) {
     reject(e);
   }
 }
-export function* asyncGetVoterDetailRequest({
-  payload,
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetVoterDetailRequest({ payload, resolve, reject }: $TSFixMe) {
   const { address } = payload;
   try {
     // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
@@ -182,17 +158,12 @@ export function* asyncGetVoterDetailRequest({
     reject(e);
   }
 }
-export function* asyncGetVoterHistoryRequest({
-  payload,
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetVoterHistoryRequest({ payload, resolve, reject }: $TSFixMe) {
   const { offset, limit, address } = payload;
   try {
     // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
     const response = yield call(restService, {
-      api: `/voters/history/${address}?offset=${offset || 0}&limit=${limit
-        || 5}`,
+      api: `/voters/history/${address}?offset=${offset || 0}&limit=${limit || 5}`,
       method: 'GET',
       params: {},
     });
@@ -205,11 +176,7 @@ export function* asyncGetVoterHistoryRequest({
     reject(e);
   }
 }
-export function* asyncGetVoterAccountsRequest({
-  payload,
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetVoterAccountsRequest({ payload, resolve, reject }: $TSFixMe) {
   const { limit, offset } = payload;
 
   try {
@@ -226,38 +193,12 @@ export function* asyncGetVoterAccountsRequest({
     reject(e);
   }
 }
-export function* asyncGetTransactionHistoryRequest({
-  payload,
-  resolve,
-  reject,
-}: $TSFixMe) {
+export function* asyncGetTransactionHistoryRequest({ payload, resolve, reject }: $TSFixMe) {
   const { offset, event } = payload;
   try {
     // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
     const response = yield call(restService, {
-      api: `/transactions?page=${offset || 0}${
-        event !== 'All' ? `&event=${event}` : ''
-      }`,
-      method: 'GET',
-      params: {},
-    });
-    if (response.status === 200) {
-      resolve(response.data);
-    } else {
-      reject(response);
-    }
-  } catch (e) {
-    reject(e);
-  }
-}
-export function* asyncGetTreasuryBalanceRequest({
-  resolve,
-  reject,
-}: $TSFixMe) {
-  try {
-    // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
-    const response = yield call(restService, {
-      api: '/treasury/balance',
+      api: `/transactions?page=${offset || 0}${event !== 'All' ? `&event=${event}` : ''}`,
       method: 'GET',
       params: {},
     });
@@ -343,15 +284,8 @@ export function* watchGetTransactionHistoryRequest() {
     yield* asyncGetTransactionHistoryRequest(action);
   }
 }
-export function* watchGetTreasuryBalanceRequest() {
-  while (true) {
-    // @ts-expect-error ts-migrate(7057) FIXME: 'yield' expression implicitly results in an 'any' ... Remove this comment to see the full error message
-    const action = yield take(GET_TREASURY_BALANCE_REQUEST);
-    yield* asyncGetTreasuryBalanceRequest(action);
-  }
-}
 
-export default function* () {
+export default function* saga() {
   yield all([
     fork(watchGetMarketHistoryRequest),
     fork(watchGetGovernanceVenusRequest),
@@ -363,6 +297,5 @@ export default function* () {
     fork(watchGetVoterHistoryRequest),
     fork(watchGetVoterAccountsRequest),
     fork(watchGetTransactionHistoryRequest),
-    fork(watchGetTreasuryBalanceRequest),
   ]);
 }

--- a/src/hooks/useMarkets.ts
+++ b/src/hooks/useMarkets.ts
@@ -2,6 +2,6 @@ import { useContext } from 'react';
 import { MarketContext } from '../context/MarketContext';
 
 export const useMarkets = () => {
-  const { markets, dailyVenus } = useContext(MarketContext);
-  return { markets, dailyVenus };
+  const { markets, dailyVenus, treasuryTotalUSDBalance } = useContext(MarketContext);
+  return { markets, dailyVenus, treasuryTotalUSDBalance };
 };


### PR DESCRIPTION
This is a temporary fix, until we refactor our state management logic and optimise how we fetch data so that we can rely more on calling contracts directly rather than calling our backend.

<img width="696" alt="Screenshot 2022-02-25 at 17 04 02" src="https://user-images.githubusercontent.com/44675210/155756605-74e5a68b-4319-4cae-a70e-f0e962479d50.png">
