### PR TITLE
Member delimiter style require semi

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -52,6 +52,20 @@ module.exports = {
         ],
       },
     ],
+    // Custom
+    '@typescript-eslint/member-delimiter-style': [
+      'error',
+      {
+        multiline: {
+          delimiter: 'semi',
+          requireLast: true,
+        },
+        singleline: {
+          delimiter: 'semi',
+          requireLast: false,
+        },
+      },
+    ],
   },
   settings: {
     'import/resolver': {

--- a/src/components/Basic/BorrowModal.tsx
+++ b/src/components/Basic/BorrowModal.tsx
@@ -208,9 +208,9 @@ export const TabContent = styled.div`
 `;
 
 interface Props {
-  asset: Asset
-  visible: boolean,
-  onCancel: () => void,
+  asset: Asset;
+  visible: boolean;
+  onCancel: () => void;
 }
 
 function BorrowModal({ visible, asset, onCancel }: Props) {
@@ -235,29 +235,16 @@ function BorrowModal({ visible, asset, onCancel }: Props) {
       centered
     >
       <ModalContent className="flex flex-column align-center just-center">
-        <img
-          className="close-btn pointer"
-          src={closeImg}
-          alt="close"
-          onClick={onCancel}
-        />
+        <img className="close-btn pointer" src={closeImg} alt="close" onClick={onCancel} />
         <div className="flex align-center just-center header-content">
           <img src={asset.img} alt="asset" />
           <p className="title">{asset.name}</p>
         </div>
         {currentTab === 'borrow' && (
-          <BorrowTab
-            asset={asset}
-            changeTab={setCurrentTab}
-            onCancel={onCancel}
-          />
+          <BorrowTab asset={asset} changeTab={setCurrentTab} onCancel={onCancel} />
         )}
         {currentTab === 'repayBorrow' && (
-          <RepayBorrowTab
-            asset={asset}
-            changeTab={setCurrentTab}
-            onCancel={onCancel}
-          />
+          <RepayBorrowTab asset={asset} changeTab={setCurrentTab} onCancel={onCancel} />
         )}
       </ModalContent>
     </Modal>

--- a/src/components/Basic/Label.ts
+++ b/src/components/Basic/Label.ts
@@ -1,13 +1,14 @@
 import styled from 'styled-components';
 
 interface Props {
-  size?: number | string,
-  primary?: boolean,
+  size?: number | string;
+  primary?: boolean;
 }
 
 export const Label = styled.span`
   font-size: ${({ size }: Props) => size || 16}px;
   font-weight: 900;
 
-  color: ${({ primary }: Props) => (primary ? 'var(--color-text-main)' : 'var(--color-text-secondary)')};
+  color: ${({ primary }: Props) =>
+    primary ? 'var(--color-text-main)' : 'var(--color-text-secondary)'};
 `;

--- a/src/components/Basic/Style.ts
+++ b/src/components/Basic/Style.ts
@@ -17,10 +17,10 @@ function getWidthString(span: $TSFixMe) {
 }
 
 interface Props {
-  xs?: string,
-  sm?: string,
-  md?: string,
-  lg?: string,
+  xs?: string;
+  sm?: string;
+  md?: string;
+  lg?: string;
 }
 
 export const Column = styled.div`

--- a/src/components/Dashboard/animated-number-react.d.ts
+++ b/src/components/Dashboard/animated-number-react.d.ts
@@ -1,20 +1,20 @@
 // / <reference types="react" />
 
 declare module 'animated-number-react' {
-    interface AnimatedNumberReactProps {
-        value: number | PropTypes.string
-        duration?: number,
-        delay?: number,
-        formatValue: (value: string) => void,
-        begin?: () => void,
-        complete?: () => void,
-        run?: () => void,
-        update?: () => void,
-        easing?: string,
-        className?: string,
-    }
-
-    declare class AnimatedNumberReact extends React.Component<AnimatedNumberReactProps> {}
-
-    export default AnimatedNumberReact;
+  interface AnimatedNumberReactProps {
+    value: number | PropTypes.string;
+    duration?: number;
+    delay?: number;
+    formatValue: (value: string) => void;
+    begin?: () => void;
+    complete?: () => void;
+    run?: () => void;
+    update?: () => void;
+    easing?: string;
+    className?: string;
   }
+
+  declare class AnimatedNumberReact extends React.Component<AnimatedNumberReactProps> {}
+
+  export default AnimatedNumberReact;
+}

--- a/src/components/Vote/ProposerDetail/Holding.tsx
+++ b/src/components/Vote/ProposerDetail/Holding.tsx
@@ -54,13 +54,13 @@ const HoldingWrapper = styled.div`
 const format = commaNumber.bindWith(',', '.');
 
 interface Props extends RouteComponentProps {
-  address: string,
+  address: string;
   holdingInfo: {
-    balance?: string,
-    delegateCount?: string,
-    votes?: string,
-    delegates?: string,
-  }
+    balance?: string;
+    delegateCount?: string;
+    votes?: string;
+    delegates?: string;
+  };
 }
 
 function Holding({ address, holdingInfo }: Props) {
@@ -81,19 +81,13 @@ function Holding({ address, holdingInfo }: Props) {
             </div>
           </div>
           <div className="value">{format(holdingInfo.votes || '0.0000')}</div>
-          <Progress
-            percent={100}
-            strokeColor="#d99d43"
-            strokeWidth={7}
-            showInfo={false}
-          />
+          <Progress percent={100} strokeColor="#d99d43" strokeWidth={7} showInfo={false} />
         </div>
         <div className="flex flex-column holding-section">
           <div className="label">Delegating To</div>
           <div className="value">
-            {holdingInfo.delegates
-              !== '0x0000000000000000000000000000000000000000'
-            && holdingInfo.delegates !== address.toLowerCase()
+            {holdingInfo.delegates !== '0x0000000000000000000000000000000000000000' &&
+            holdingInfo.delegates !== address.toLowerCase()
               ? 'Delegated'
               : 'Undelegated'}
           </div>

--- a/src/components/Vote/ProposerDetail/ProposerInfo.tsx
+++ b/src/components/Vote/ProposerDetail/ProposerInfo.tsx
@@ -35,7 +35,7 @@ const ProposerInfoWrapper = styled.div`
 `;
 
 interface Props extends RouteComponentProps {
-  address: string,
+  address: string;
 }
 
 function ProposerInfo({ address }: Props) {

--- a/src/components/Vote/ProposerDetail/Transactions.tsx
+++ b/src/components/Vote/ProposerDetail/Transactions.tsx
@@ -80,14 +80,14 @@ const TransactionsWrapper = styled.div`
 const format = commaNumber.bindWith(',', '.');
 
 interface Transaction {
-  support: boolean,
-  type: 'vote',
-  blockTimestamp: string,
+  support: boolean;
+  type: 'vote';
+  blockTimestamp: string;
 }
 
 interface Props extends RouteComponentProps {
-  address: string,
-  transactions: Transaction[],
+  address: string;
+  transactions: Transaction[];
 }
 
 function Transactions({ address, transactions }: Props) {
@@ -121,10 +121,7 @@ function Transactions({ address, transactions }: Props) {
         });
       } else {
         tempData.push({
-          action:
-            tx.to.toLowerCase() === address.toLowerCase()
-              ? 'Received XVS'
-              : 'Sent XVS',
+          action: tx.to.toLowerCase() === address.toLowerCase() ? 'Received XVS' : 'Sent XVS',
           age: getDate(tx.blockTimestamp),
           result: format(
             new BigNumber(tx.amount)
@@ -153,8 +150,8 @@ function Transactions({ address, transactions }: Props) {
           <div className="result-column">Result</div>
         </div>
         <div className="flex flex-column data-list">
-          {data
-            && data.map((item) => (
+          {data &&
+            data.map(item => (
               <div className="flex align-center row-text" key={uid(item)}>
                 {/*  @ts-expect-error ts-migrate(2339) FIXME: Property 'action' does not exist on type 'never'. */}
                 <div className="action-column">{item.action}</div>

--- a/src/components/Vote/VoteOverview/VoteCard.tsx
+++ b/src/components/Vote/VoteOverview/VoteCard.tsx
@@ -110,14 +110,14 @@ const VoteList = styled.div`
 `;
 
 interface Props extends RouteComponentProps {
-  type: number,
-  label: string,
-  voteNumber: BigNumber,
-  totalNumber: BigNumber,
-  addressNumber: number,
-  emptyNumber: number,
-  list: Array<{ label: string, value: string, reason: string }>,
-  onViewAll: () => void,
+  type: number;
+  label: string;
+  voteNumber: BigNumber;
+  totalNumber: BigNumber;
+  addressNumber: number;
+  emptyNumber: number;
+  list: Array<{ label: string; value: string; reason: string }>;
+  onViewAll: () => void;
 }
 
 const format = commaNumber.bindWith(',', '.');
@@ -139,9 +139,7 @@ function VoteCard({
   const remainingToLoad = addressNumber - list.length;
 
   useEffect(() => {
-    const percentTmp = new BigNumber(voteNumber)
-      .multipliedBy(100)
-      .div(totalNumber);
+    const percentTmp = new BigNumber(voteNumber).multipliedBy(100).div(totalNumber);
     // @ts-expect-error ts-migrate(2345) FIXME: Argument of type 'string' is not assignable to par... Remove this comment to see the full error message
     setPercent(percentTmp.isNaN() ? '0' : percentTmp.toString(10));
   }, [voteNumber]);
@@ -165,10 +163,7 @@ function VoteCard({
             <span>
               {format(
                 new BigNumber(
-                  Web3.utils.fromWei(
-                    voteNumber.isNaN() ? '' : voteNumber.toString(10),
-                    'ether',
-                  ),
+                  Web3.utils.fromWei(voteNumber.isNaN() ? '' : voteNumber.toString(10), 'ether'),
                 )
                   .dp(8, 1)
                   .toString(10),
@@ -184,34 +179,20 @@ function VoteCard({
         </div>
         <VoteList>
           <div className="flex align-center just-between header">
-            <span>
-              {addressNumber}
-              {' '}
-              addresses
-            </span>
+            <span>{addressNumber} addresses</span>
             <span>Votes</span>
           </div>
           <div className="vote-list scrollbar">
             {/**/}
             {list.map((l: $TSFixMe) => (
-              <div
-                className="flex align-center just-between vote-item"
-                key={uid(l)}
-              >
-                <span
-                  className="pointer"
-                  onClick={() => handleAddLink(l.label)}
-                >
-                  {l.label
-                    ? `${l.label.substr(0, 5)}...${l.label.substr(-4, 4)}`
-                    : ''}
+              <div className="flex align-center just-between vote-item" key={uid(l)}>
+                <span className="pointer" onClick={() => handleAddLink(l.label)}>
+                  {l.label ? `${l.label.substr(0, 5)}...${l.label.substr(-4, 4)}` : ''}
                 </span>
                 <div>
                   <span>
                     {format(
-                      new BigNumber(Web3.utils.fromWei(l.value, 'ether'))
-                        .dp(8, 1)
-                        .toString(10),
+                      new BigNumber(Web3.utils.fromWei(l.value, 'ether')).dp(8, 1).toString(10),
                     )}
                   </span>
                   {l.reason && (
@@ -225,30 +206,21 @@ function VoteCard({
                         overflowY: 'scroll',
                       }}
                     >
-                      <Icon
-                        className="reason-icon"
-                        type="exclamation-circle"
-                        theme="filled"
-                      />
+                      <Icon className="reason-icon" type="exclamation-circle" theme="filled" />
                     </Tooltip>
                   )}
                 </div>
               </div>
             ))}
             {emptyList.map(v => (
-              <div
-                className="flex align-center just-between vote-item empty-item"
-                key={v}
-              >
+              <div className="flex align-center just-between vote-item empty-item" key={v}>
                 <span>—</span>
                 <span>—</span>
               </div>
             ))}
           </div>
           {/* view all is clicked and there are still empty lines to fill up */}
-          {!isViewAll && remainingToLoad > 0 && (
-            <Icon className="loading-icon" type="loading" />
-          )}
+          {!isViewAll && remainingToLoad > 0 && <Icon className="loading-icon" type="loading" />}
           {isViewAll && remainingToLoad > 0 && (
             <div
               className="flex align-center just-center view-all pointer"

--- a/src/containers/Layout/Header.tsx
+++ b/src/containers/Layout/Header.tsx
@@ -26,7 +26,7 @@ const HeaderWrapper = styled.div`
 `;
 
 interface Props extends RouteComponentProps {
-  title: string,
+  title: string;
 }
 
 function Header({ title, history }: Props) {
@@ -44,18 +44,11 @@ function Header({ title, history }: Props) {
 
   return (
     <HeaderWrapper className="flex align-center just-between">
-      <div
-        className="flex align-center pointer title-wrapper"
-        onClick={handleRoute}
-      >
-        {(title === 'Overview'
-          || title === 'Details'
-          || title === 'Market') && <img src={arrowRightImg} alt="arrow-left" />}
-        <p
-          className={`${
-            title === 'Overview' || title === 'Details' ? 'highlight' : ''
-          }`}
-        >
+      <div className="flex align-center pointer title-wrapper" onClick={handleRoute}>
+        {(title === 'Overview' || title === 'Details' || title === 'Market') && (
+          <img src={arrowRightImg} alt="arrow-left" />
+        )}
+        <p className={`${title === 'Overview' || title === 'Details' ? 'highlight' : ''}`}>
           {title}
         </p>
       </div>


### PR DESCRIPTION
This rule wasn't explicitly covered by eslint nor prettier, since a comma or semicolon is valid syntax after an interface member both pass but changes were being introduced into PRs moving between commas and semicolons.

This PR explicitly declares a preference for semicolons after interface members