### PR TITLE
Add prepare script to apply postcss patch after install

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "start": "react-scripts --max_old_space_size=4096 start",
+    "prepare": "git apply patches/@stylelint+postcss-css-in-js+0.37.2.patch",
     "build": "react-scripts --max_old_space_size=4096 build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",


### PR DESCRIPTION
Add a `prepare` script so that the git patch for the postcss stylelint package is applied automatically after every install