### PR TITLE
Add TextField component

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,7 @@ import { rest } from 'msw';
 import 'loki/configure-react';
 import 'antd/dist/antd.css';
 import '../src/assets/styles/index.scss';
+import { PALETTE } from '../src/theme/MuiThemeProvider/muiTheme';
 import { withThemeProvider } from '../src/stories/decorators';
 import GovernanceResponse from '../src/__mocks__/api/governance.json';
 import VoteReponse from '../src/__mocks__/api/vote.json';
@@ -15,6 +16,23 @@ initialize({
 export const parameters = {
   layout: 'fullscreen',
   actions: { argTypesRegex: '^on[A-Z].*' },
+  backgrounds: {
+    default: 'Asphalt grey',
+    values: [
+      {
+        name: 'Asphalt grey',
+        value: PALETTE.background.asphaltGrey,
+      },
+      {
+        name: 'Black',
+        value: PALETTE.background.black,
+      },
+      {
+        name: 'Off white',
+        value: PALETTE.background.offWhite,
+      },
+    ],
+  },
   controls: {
     matchers: {
       color: /(background|color)$/i,

--- a/src/assets/styles/App.scss
+++ b/src/assets/styles/App.scss
@@ -163,6 +163,19 @@ input {
     /* Firefox 18- */
     padding-right: 22px;
   }
+
+  /* Hide arrows from input number */
+  /* Chrome, Safari, Edge, Opera */
+  &::-webkit-outer-spin-button,
+  &::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  /* Firefox */
+  &[type='number'] {
+    -moz-appearance: textfield;
+  }
 }
 
 .proposal-detail {
@@ -236,7 +249,8 @@ input {
   background-color: var(--color-yellow);
   color: white;
 
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     background-color: var(--color-gold);
     color: white;
   }

--- a/src/components/VrtConversion/Convert.tsx
+++ b/src/components/VrtConversion/Convert.tsx
@@ -133,7 +133,7 @@ export default ({
           type="button"
           className="button confirm-button"
           loading={convertLoading}
-          loadingIconSize={28}
+          loadingIconSize="28px"
           disabled={
             !convertInputAmount.gt(0) ||
             conversionEndTime.lt(Date.now() / 1000) ||

--- a/src/components/VrtConversion/Withdraw.tsx
+++ b/src/components/VrtConversion/Withdraw.tsx
@@ -52,7 +52,7 @@ export default ({ withdrawableAmount, account, handleClickWithdraw }: WithdrawPr
         <Button
           type="button"
           loading={withdrawLoading}
-          loadingIconSize={28}
+          loadingIconSize="28px"
           className="button withdraw-button"
           disabled={!account || !withdrawableAmount.gt(0) || withdrawLoading}
           onClick={async () => {

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,5 @@
-export { Button } from './v2/Button';
-export { Icon } from './v2/Icon';
-export { Dropdown } from './v2/Dropdown';
-export { Layout } from './v2/Layout';
+export * from './v2/Button';
+export * from './v2/Icon';
+export * from './v2/Dropdown';
+export * from './v2/Layout';
+export * from './v2/TextField';

--- a/src/components/v2/Button/index.tsx
+++ b/src/components/v2/Button/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Button as MuiButton, ButtonProps } from '@mui/material';
 import { Icon } from 'components';
 // import SwapHorizIcon from '@mui/icons-material/loading';
-interface IButtonProps extends ButtonProps {
+export interface IButtonProps extends ButtonProps {
   className?: string;
   loading?: boolean;
   loadingIconSize?: number;

--- a/src/components/v2/Button/index.tsx
+++ b/src/components/v2/Button/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import MuiButton, { ButtonProps } from '@mui/material/Button';
-import { Icon } from 'components';
+import { Icon } from 'components/v2/Icon';
 
 export interface IButtonProps extends ButtonProps {
   className?: string;

--- a/src/components/v2/Button/index.tsx
+++ b/src/components/v2/Button/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Button as MuiButton, ButtonProps } from '@mui/material';
+import MuiButton, { ButtonProps } from '@mui/material/Button';
 import { Icon } from 'components';
-// import SwapHorizIcon from '@mui/icons-material/loading';
+
 export interface IButtonProps extends ButtonProps {
   className?: string;
   loading?: boolean;

--- a/src/components/v2/Button/index.tsx
+++ b/src/components/v2/Button/index.tsx
@@ -5,7 +5,7 @@ import { Icon } from 'components/v2/Icon';
 export interface IButtonProps extends ButtonProps {
   className?: string;
   loading?: boolean;
-  loadingIconSize?: number;
+  loadingIconSize?: string;
   loadingIconColor?: string;
 }
 

--- a/src/components/v2/Icon/Icon.tsx
+++ b/src/components/v2/Icon/Icon.tsx
@@ -6,7 +6,7 @@ export type IconName = keyof typeof icons;
 
 export interface IIconProps {
   name: IconName;
-  size?: number;
+  size?: string;
   color?: string;
   className?: string;
 }

--- a/src/components/v2/Icon/index.stories.tsx
+++ b/src/components/v2/Icon/index.stories.tsx
@@ -30,6 +30,6 @@ const IconWithCustomColorAndSizeTemplate: Story<IIconProps> = args => <Icon {...
 export const IconWithCustomColorAndSize = IconWithCustomColorAndSizeTemplate.bind({});
 IconWithCustomColorAndSize.args = {
   name: 'mask',
-  size: 32,
+  size: '32px',
   color: '#345345',
 };

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -2,6 +2,7 @@
 import React, { InputHTMLAttributes } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
+import { Icon, IconName } from 'components/v2/Icon';
 
 import { useStyles } from './styles';
 
@@ -9,12 +10,14 @@ export interface ITextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   description?: string;
   hasError?: boolean;
+  leftIconName?: IconName;
 }
 
 export const TextField: React.FC<ITextFieldProps> = ({
   label,
   description,
   hasError = false,
+  leftIconName,
   ...inputProps
 }) => {
   const styles = useStyles();
@@ -28,6 +31,8 @@ export const TextField: React.FC<ITextFieldProps> = ({
       )}
 
       <Box css={styles.getInputContainer({ hasError })}>
+        {!!leftIconName && <Icon name={leftIconName} size={22} css={styles.leftIcon} />}
+
         <input css={styles.input} {...inputProps} />
       </Box>
 

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -1,0 +1,16 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import Box from '@mui/material/Box';
+import { useStyles } from './styles';
+
+export const TextField: React.FC = () => {
+  const styles = useStyles();
+
+  return (
+    <Box css={styles.container}>
+      <Box css={styles.inputContainer}>
+        <input css={styles.input} />
+      </Box>
+    </Box>
+  );
+};

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -2,7 +2,7 @@
 import React, { InputHTMLAttributes, HTMLAttributes } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { Icon, IconName } from 'components';
+import { Icon, IconName } from 'components/v2/Icon';
 
 import { useStyles } from './styles';
 

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -29,13 +29,20 @@ export const TextField: React.FC<ITextFieldProps> = ({
   return (
     <Box css={css}>
       {!!label && (
-        <Typography variant="small1" component="label" css={styles.getLabel({ hasError })}>
+        <Typography
+          variant="small1"
+          component="label"
+          css={styles.getLabel({ hasError })}
+          htmlFor={inputProps.id}
+        >
           {label}
         </Typography>
       )}
 
       <Box css={styles.getInputContainer({ hasError })}>
-        {!!leftIconName && <Icon name={leftIconName} size={22} css={styles.leftIcon} />}
+        {!!leftIconName && (
+          <Icon name={leftIconName} size={styles.theme.spacing(3)} css={styles.leftIcon} />
+        )}
 
         <input css={styles.getInput({ hasRightAdornment: !!rightAdornment })} {...inputProps} />
 

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -1,29 +1,36 @@
 /** @jsxImportSource @emotion/react */
-import React, { InputHTMLAttributes } from 'react';
+import React, { InputHTMLAttributes, HTMLAttributes } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import { Icon, IconName } from 'components/v2/Icon';
+import { Button, IButtonProps } from 'components/v2/Button';
 
 import { useStyles } from './styles';
 
-export interface ITextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface ITextFieldProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'css'> {
+  css?: HTMLAttributes<HTMLDivElement>['css'];
   label?: string;
   description?: string;
   hasError?: boolean;
   leftIconName?: IconName;
+  rightButtonProps?: Omit<IButtonProps, 'variant'> & {
+    label: string;
+  };
 }
 
 export const TextField: React.FC<ITextFieldProps> = ({
+  css,
   label,
   description,
   hasError = false,
   leftIconName,
+  rightButtonProps: { label: rightButtonLabel, ...rightButtonProps } = {},
   ...inputProps
 }) => {
   const styles = useStyles();
 
   return (
-    <Box css={inputProps.css}>
+    <Box css={css}>
       {!!label && (
         <Typography variant="small1" component="label" css={styles.getLabel({ hasError })}>
           {label}
@@ -34,6 +41,12 @@ export const TextField: React.FC<ITextFieldProps> = ({
         {!!leftIconName && <Icon name={leftIconName} size={22} css={styles.leftIcon} />}
 
         <input css={styles.input} {...inputProps} />
+
+        {rightButtonProps && (
+          <Button variant="text" {...rightButtonProps} css={styles.rightButton}>
+            {rightButtonLabel}
+          </Button>
+        )}
       </Box>
 
       {!!description && (

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -8,20 +8,26 @@ import { useStyles } from './styles';
 export interface ITextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   description?: string;
+  hasError?: boolean;
 }
 
-export const TextField: React.FC<ITextFieldProps> = ({ label, description, ...inputProps }) => {
+export const TextField: React.FC<ITextFieldProps> = ({
+  label,
+  description,
+  hasError = false,
+  ...inputProps
+}) => {
   const styles = useStyles();
 
   return (
     <Box css={inputProps.css}>
       {!!label && (
-        <Typography variant="small1" component="label" css={styles.label}>
+        <Typography variant="small1" component="label" css={styles.getLabel({ hasError })}>
           {label}
         </Typography>
       )}
 
-      <Box css={styles.inputContainer}>
+      <Box css={styles.getInputContainer({ hasError })}>
         <input css={styles.input} {...inputProps} />
       </Box>
 

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -1,15 +1,27 @@
 /** @jsxImportSource @emotion/react */
-import React from 'react';
+import React, { InputHTMLAttributes } from 'react';
 import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
 import { useStyles } from './styles';
 
-export const TextField: React.FC = () => {
+export interface ITextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+}
+
+export const TextField: React.FC<ITextFieldProps> = ({ label, ...inputProps }) => {
   const styles = useStyles();
 
   return (
-    <Box css={styles.container}>
+    <Box css={inputProps.css}>
+      {!!label && (
+        <Typography variant="small1" component="label" for={inputProps.name} css={styles.label}>
+          {label}
+        </Typography>
+      )}
+
       <Box css={styles.inputContainer}>
-        <input css={styles.input} />
+        <input css={styles.input} {...inputProps} />
       </Box>
     </Box>
   );

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -7,15 +7,16 @@ import { useStyles } from './styles';
 
 export interface ITextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
+  description?: string;
 }
 
-export const TextField: React.FC<ITextFieldProps> = ({ label, ...inputProps }) => {
+export const TextField: React.FC<ITextFieldProps> = ({ label, description, ...inputProps }) => {
   const styles = useStyles();
 
   return (
     <Box css={inputProps.css}>
       {!!label && (
-        <Typography variant="small1" component="label" for={inputProps.name} css={styles.label}>
+        <Typography variant="small1" component="label" css={styles.label}>
           {label}
         </Typography>
       )}
@@ -23,6 +24,12 @@ export const TextField: React.FC<ITextFieldProps> = ({ label, ...inputProps }) =
       <Box css={styles.inputContainer}>
         <input css={styles.input} {...inputProps} />
       </Box>
+
+      {!!description && (
+        <Typography variant="small2" css={styles.description}>
+          {description}
+        </Typography>
+      )}
     </Box>
   );
 };

--- a/src/components/v2/TextField/TextField.tsx
+++ b/src/components/v2/TextField/TextField.tsx
@@ -2,8 +2,7 @@
 import React, { InputHTMLAttributes, HTMLAttributes } from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
-import { Icon, IconName } from 'components/v2/Icon';
-import { Button, IButtonProps } from 'components/v2/Button';
+import { Icon, IconName } from 'components';
 
 import { useStyles } from './styles';
 
@@ -13,9 +12,7 @@ export interface ITextFieldProps extends Omit<InputHTMLAttributes<HTMLInputEleme
   description?: string;
   hasError?: boolean;
   leftIconName?: IconName;
-  rightButtonProps?: Omit<IButtonProps, 'variant'> & {
-    label: string;
-  };
+  rightAdornment?: React.ReactElement;
 }
 
 export const TextField: React.FC<ITextFieldProps> = ({
@@ -24,7 +21,7 @@ export const TextField: React.FC<ITextFieldProps> = ({
   description,
   hasError = false,
   leftIconName,
-  rightButtonProps: { label: rightButtonLabel, ...rightButtonProps } = {},
+  rightAdornment,
   ...inputProps
 }) => {
   const styles = useStyles();
@@ -40,13 +37,9 @@ export const TextField: React.FC<ITextFieldProps> = ({
       <Box css={styles.getInputContainer({ hasError })}>
         {!!leftIconName && <Icon name={leftIconName} size={22} css={styles.leftIcon} />}
 
-        <input css={styles.input} {...inputProps} />
+        <input css={styles.getInput({ hasRightAdornment: !!rightAdornment })} {...inputProps} />
 
-        {rightButtonProps && (
-          <Button variant="text" {...rightButtonProps} css={styles.rightButton}>
-            {rightButtonLabel}
-          </Button>
-        )}
+        {rightAdornment}
       </Box>
 
       {!!description && (

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { ComponentMeta } from '@storybook/react';
+import { withCenterStory, withThemeProvider } from 'stories/decorators';
+import { TextField } from '.';
+
+export default {
+  title: 'TextField',
+  component: TextField,
+  decorators: [withThemeProvider, withCenterStory({ width: 600 })],
+} as ComponentMeta<typeof TextField>;
+
+export const DefaultTextField = () => <TextField />;

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -11,6 +11,8 @@ export default {
 
 export const DefaultTextField = () => <TextField />;
 
+export const WithLeftIcon = () => <TextField leftIconName="xvs" />;
+
 export const WithLabelTextField = () => <TextField label="Label" />;
 
 export const WithLabelAndDescriptionTextField = () => (

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -12,3 +12,7 @@ export default {
 export const DefaultTextField = () => <TextField />;
 
 export const WithLabelTextField = () => <TextField label="Label" />;
+
+export const WithLabelAndDescriptionTextField = () => (
+  <TextField label="Label" description="This is a fake description" />
+);

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -4,21 +4,25 @@ import { withCenterStory, withThemeProvider } from 'stories/decorators';
 import { TextField } from '.';
 
 export default {
-  title: 'TextField',
+  title: 'Components/TextField',
   component: TextField,
   decorators: [withThemeProvider, withCenterStory({ width: 600 })],
 } as ComponentMeta<typeof TextField>;
 
-export const DefaultTextField = () => <TextField />;
+export const Default = () => <TextField />;
+
+export const WithLabel = () => <TextField label="Label" />;
+
+export const WithDescription = () => <TextField description="This is a fake description" />;
 
 export const WithLeftIcon = () => <TextField leftIconName="xvs" />;
 
-export const WithLabelTextField = () => <TextField label="Label" />;
-
-export const WithLabelAndDescriptionTextField = () => (
-  <TextField label="Label" description="This is a fake description" />
+export const WithRightButton = () => (
+  <TextField
+    rightButtonProps={{
+      label: 'Safe max',
+    }}
+  />
 );
 
-export const WithHasError = () => (
-  <TextField label="Label" description="This is a fake description" hasError />
-);
+export const WithHasError = () => <TextField label="Label" hasError />;

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentMeta } from '@storybook/react';
 import { withCenterStory, withThemeProvider } from 'stories/decorators';
+import { Button } from 'components';
 import { TextField } from '.';
 
 export default {
@@ -17,12 +18,6 @@ export const WithDescription = () => <TextField description="This is a fake desc
 
 export const WithLeftIcon = () => <TextField leftIconName="xvs" />;
 
-export const WithRightButton = () => (
-  <TextField
-    rightButtonProps={{
-      label: 'Safe max',
-    }}
-  />
-);
+export const WithRightAdornment = () => <TextField rightAdornment={<Button>Safe max</Button>} />;
 
 export const WithHasError = () => <TextField label="Label" hasError />;

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -10,14 +10,22 @@ export default {
   decorators: [withThemeProvider, withCenterStory({ width: 600 })],
 } as ComponentMeta<typeof TextField>;
 
-export const Default = () => <TextField />;
+export const Default = () => <TextField placeholder="0.0" type="number" min={0} />;
 
-export const WithLabel = () => <TextField label="Label" />;
+export const WithLabel = () => <TextField label="Label" placeholder="0.0" type="number" min={0} />;
 
-export const WithDescription = () => <TextField description="This is a fake description" />;
+export const WithDescription = () => (
+  <TextField description="This is a fake description" placeholder="0.0" type="number" min={0} />
+);
 
-export const WithLeftIcon = () => <TextField leftIconName="xvs" />;
+export const WithLeftIcon = () => (
+  <TextField leftIconName="xvs" placeholder="0.0" type="number" min={0} />
+);
 
-export const WithRightAdornment = () => <TextField rightAdornment={<Button>Safe max</Button>} />;
+export const WithRightAdornment = () => (
+  <TextField rightAdornment={<Button>Safe max</Button>} placeholder="0.0" type="number" min={0} />
+);
 
-export const WithHasError = () => <TextField label="Label" hasError />;
+export const WithHasError = () => (
+  <TextField label="Label" placeholder="0.0" type="number" min={0} hasError />
+);

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -16,3 +16,7 @@ export const WithLabelTextField = () => <TextField label="Label" />;
 export const WithLabelAndDescriptionTextField = () => (
   <TextField label="Label" description="This is a fake description" />
 );
+
+export const WithHasError = () => (
+  <TextField label="Label" description="This is a fake description" hasError />
+);

--- a/src/components/v2/TextField/index.stories.tsx
+++ b/src/components/v2/TextField/index.stories.tsx
@@ -10,3 +10,5 @@ export default {
 } as ComponentMeta<typeof TextField>;
 
 export const DefaultTextField = () => <TextField />;
+
+export const WithLabelTextField = () => <TextField label="Label" />;

--- a/src/components/v2/TextField/index.tsx
+++ b/src/components/v2/TextField/index.tsx
@@ -1,0 +1,1 @@
+export * from './TextField';

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -1,0 +1,36 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  const container = css`
+    display: block;
+  `;
+
+  const inputContainer = css`
+    display: flex;
+    padding: ${theme.spacing(1)};
+    border-radius: 12px;
+    border: 2px solid transparent;
+
+    &:focus-within {
+      border-color: ${theme.palette.text.secondary};
+    }
+  `;
+
+  const input = css`
+    background-color: transparent;
+    flex: 1;
+    font-weight: 600;
+    line-height: ${theme.spacing(3)};
+    height: ${theme.spacing(5)};
+    border: 0;
+
+    &:focus {
+      outline: 0;
+    }
+  `;
+
+  return { container, inputContainer, input };
+};

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -4,8 +4,9 @@ import { useTheme } from '@mui/material';
 export const useStyles = () => {
   const theme = useTheme();
 
-  const container = css`
+  const label = css`
     display: block;
+    margin-bottom: 4px;
   `;
 
   const inputContainer = css`
@@ -32,5 +33,5 @@ export const useStyles = () => {
     }
   `;
 
-  return { container, inputContainer, input };
+  return { label, inputContainer, input };
 };

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -17,7 +17,7 @@ export const useStyles = () => {
     padding: ${theme.spacing(1, 1, 1, 2)};
     border-radius: 12px;
     border: 2px solid transparent;
-    background-color: ${theme.palette.background.default};
+    background-color: ${theme.palette.background.black};
 
     &:focus-within {
       border-color: ${hasError ? theme.palette.error.main : theme.palette.text.secondary};

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -11,7 +11,7 @@ export const useStyles = () => {
 
   const inputContainer = css`
     display: flex;
-    padding: ${theme.spacing(1)};
+    padding: ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(2)};
     border-radius: 12px;
     border: 2px solid transparent;
 
@@ -33,5 +33,11 @@ export const useStyles = () => {
     }
   `;
 
-  return { label, inputContainer, input };
+  const description = css`
+    display: block;
+    color: ${theme.palette.text.secondary};
+    margin-top: 4px;
+  `;
+
+  return { label, inputContainer, input, description };
 };

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -28,13 +28,15 @@ export const useStyles = () => {
     margin-right: ${theme.spacing(1)};
   `;
 
-  const input = css`
+  const getInput = ({ hasRightAdornment }: { hasRightAdornment: boolean }) => css`
     background-color: transparent;
     flex: 1;
     font-weight: 600;
     line-height: ${theme.spacing(3)};
     height: ${theme.spacing(5)};
     border: 0;
+
+    ${hasRightAdornment && `margin-right: ${theme.spacing(1)}`};
 
     &:focus {
       outline: 0;
@@ -51,5 +53,5 @@ export const useStyles = () => {
     margin-top: 4px;
   `;
 
-  return { getLabel, getInputContainer, leftIcon, input, rightButton, description, theme };
+  return { getLabel, getInputContainer, leftIcon, getInput, rightButton, description, theme };
 };

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -17,6 +17,7 @@ export const useStyles = () => {
     padding: ${theme.spacing(1, 1, 1, 2)};
     border-radius: 12px;
     border: 2px solid transparent;
+    background-color: ${theme.palette.background.default};
 
     &:focus-within {
       border-color: ${hasError ? theme.palette.error.main : theme.palette.text.secondary};
@@ -40,11 +41,15 @@ export const useStyles = () => {
     }
   `;
 
+  const rightButton = css`
+    margin-right: ${theme.spacing(1)};
+  `;
+
   const description = css`
     display: block;
     color: ${theme.palette.text.secondary};
     margin-top: 4px;
   `;
 
-  return { getLabel, getInputContainer, leftIcon, input, description, theme };
+  return { getLabel, getInputContainer, leftIcon, input, rightButton, description, theme };
 };

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -34,6 +34,7 @@ export const useStyles = () => {
     font-weight: 600;
     line-height: ${theme.spacing(3)};
     height: ${theme.spacing(5)};
+    padding-top: 4px; /* Vertically align input content */
     border: 0;
 
     ${hasRightAdornment && `margin-right: ${theme.spacing(1)}`};

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -13,13 +13,18 @@ export const useStyles = () => {
 
   const getInputContainer = ({ hasError }: { hasError: boolean }) => css`
     display: flex;
-    padding: ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(2)};
+    align-items: center;
+    padding: ${theme.spacing(1, 1, 1, 2)};
     border-radius: 12px;
     border: 2px solid transparent;
 
     &:focus-within {
       border-color: ${hasError ? theme.palette.error.main : theme.palette.text.secondary};
     }
+  `;
+
+  const leftIcon = css`
+    margin-right: ${theme.spacing(1)};
   `;
 
   const input = css`
@@ -41,5 +46,5 @@ export const useStyles = () => {
     margin-top: 4px;
   `;
 
-  return { getLabel, getInputContainer, input, description };
+  return { getLabel, getInputContainer, leftIcon, input, description, theme };
 };

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -4,19 +4,21 @@ import { useTheme } from '@mui/material';
 export const useStyles = () => {
   const theme = useTheme();
 
-  const label = css`
+  const getLabel = ({ hasError }: { hasError: boolean }) => css`
     display: block;
     margin-bottom: 4px;
+
+    ${hasError && `color: ${theme.palette.error.main};`};
   `;
 
-  const inputContainer = css`
+  const getInputContainer = ({ hasError }: { hasError: boolean }) => css`
     display: flex;
     padding: ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(1)} ${theme.spacing(2)};
     border-radius: 12px;
     border: 2px solid transparent;
 
     &:focus-within {
-      border-color: ${theme.palette.text.secondary};
+      border-color: ${hasError ? theme.palette.error.main : theme.palette.text.secondary};
     }
   `;
 
@@ -39,5 +41,5 @@ export const useStyles = () => {
     margin-top: 4px;
   `;
 
-  return { label, inputContainer, input, description };
+  return { getLabel, getInputContainer, input, description };
 };

--- a/src/theme/MuiThemeProvider/muiTheme.ts
+++ b/src/theme/MuiThemeProvider/muiTheme.ts
@@ -13,7 +13,9 @@ export const PALETTE = {
   background: {
     default: '#090D27',
     paper: '#181C3A',
-    black: '#1F2028',
+    black: 'rgba(31, 32, 40, 1)',
+    asphaltGrey: 'rgba(40, 41, 49, 1)',
+    offWhite: 'rgba(255, 255, 255, 1)',
   },
   primary: {
     light: '#EBBF6E',

--- a/src/theme/MuiThemeProvider/muiTheme.ts
+++ b/src/theme/MuiThemeProvider/muiTheme.ts
@@ -90,9 +90,10 @@ export default createTheme({
       lineHeight: '24px',
     },
     body2: {},
-    caption: {
-      fontSize: '14px',
-      lineHeight: '21px',
+    small1: {
+      fontSize: '0.875rem',
+      lineHeight: '1.5',
+      fontWeight: 600,
     },
     button: {
       fontSize: '14px',

--- a/src/theme/MuiThemeProvider/muiTheme.ts
+++ b/src/theme/MuiThemeProvider/muiTheme.ts
@@ -34,7 +34,7 @@ export const PALETTE = {
     slider: '#18DF8B',
   },
   error: {
-    main: '#F9053E',
+    main: 'rgba(233, 61, 68, 1)',
     slider: 'rgba(233, 61, 68, 0.5)',
   },
 };

--- a/src/theme/MuiThemeProvider/muiTheme.ts
+++ b/src/theme/MuiThemeProvider/muiTheme.ts
@@ -95,6 +95,11 @@ export default createTheme({
       lineHeight: '1.5',
       fontWeight: 600,
     },
+    small2: {
+      fontSize: '0.875rem',
+      lineHeight: '1.5',
+      fontWeight: 400,
+    },
     button: {
       fontSize: '14px',
       lineHeight: '21px',

--- a/src/types/mui.d.ts
+++ b/src/types/mui.d.ts
@@ -8,10 +8,14 @@ declare module '@mui/material/styles' {
     slider?: string;
   }
 
+  // Add custom backgrounds
   interface TypeBackground extends MuiTypeBackground {
     black?: string;
+    asphaltGrey?: string;
+    offWhite?: string;
   }
 
+  // Add custom typography variants
   interface TypographyVariants {
     small1: React.CSSProperties;
     small2: React.CSSProperties;

--- a/src/types/mui.d.ts
+++ b/src/types/mui.d.ts
@@ -17,7 +17,6 @@ declare module '@mui/material/styles' {
     small2: React.CSSProperties;
   }
 
-  // allow configuration using `createTheme`
   interface TypographyVariantsOptions {
     small1?: React.CSSProperties;
     small2?: React.CSSProperties;

--- a/src/types/mui.d.ts
+++ b/src/types/mui.d.ts
@@ -11,4 +11,22 @@ declare module '@mui/material/styles' {
   interface TypeBackground extends MuiTypeBackground {
     black?: string;
   }
+
+  interface TypographyVariants {
+    small1: React.CSSProperties;
+    small2: React.CSSProperties;
+  }
+
+  // allow configuration using `createTheme`
+  interface TypographyVariantsOptions {
+    small1?: React.CSSProperties;
+    small2?: React.CSSProperties;
+  }
+}
+
+declare module '@mui/material/Typography' {
+  interface TypographyPropsVariantOverrides {
+    small1: true;
+    small2: true;
+  }
 }


### PR DESCRIPTION
Some context on the PR:
- I've updated some of the background colors present in the palette, as I needed to use them on the `TextField` component
- I've added a `rightAdornment` property on the component so that any React element can be appended to it. In the designs we're currently appending a button, and so that's what I added to the story. The reason I didn't add a button directly to the component, although it is the only case covered by the designs, is so that it makes it easy to use any button and pass it any props wanted
- I set the type of the "size" property wrong on the `Icon` component when I created it. Since it is used in this PR I updated it to a `string` (which it should be, so that we can pass a value returned by the theme like "24px")
- I tried to use as many components from MUI as possible, but their `TextField` is too different from our designs and so it was easier to use a basic `input` tag with custom styles
- In the designs, any number contained in the input gets a comma inserted after every 3 digits. I didn't add this behavior to the component, as it complicates things a lot (we can no longer use a `number` input type but instead have to use a text input with a custom handler on value change) for what I feel doesn't add real UX benefit. I also checked on other exchanges and they all use the default number input behavior, which means users are used to that UX.

### Previews:

Default:
<img width="673" alt="Screenshot 2022-03-05 at 15 40 07" src="https://user-images.githubusercontent.com/44675210/156890228-d1e9f3dd-76df-415d-a909-2077c90ca0f3.png">

With `label`:
<img width="702" alt="Screenshot 2022-03-05 at 15 40 03" src="https://user-images.githubusercontent.com/44675210/156890229-16670895-365f-4692-8956-21c8c2fad3bb.png">

With `description`:
<img width="694" alt="Screenshot 2022-03-05 at 15 40 12" src="https://user-images.githubusercontent.com/44675210/156890227-25d2037f-8859-4f56-a9b5-b342bac5d193.png">

With `hasError`:
<img width="678" alt="Screenshot 2022-03-05 at 15 40 26" src="https://user-images.githubusercontent.com/44675210/156890220-b816031a-1265-452f-a47a-37d7283d9d0f.png">

With `rightAdornment`:
<img width="686" alt="Screenshot 2022-03-05 at 15 40 21" src="https://user-images.githubusercontent.com/44675210/156890223-71c45107-fc32-4547-86eb-40d00f8a37b7.png">

With `leftIconName`:
<img width="688" alt="Screenshot 2022-03-05 at 15 40 17" src="https://user-images.githubusercontent.com/44675210/156890225-d08db4d8-0929-4141-8ffb-73ccdd762021.png">


