### PR TITLE
Cast string to number instead of using parseInt

### DIFF
--- a/src/components/Basic/Style.ts
+++ b/src/components/Basic/Style.ts
@@ -12,7 +12,7 @@ export const Row = styled.div`
 function getWidthString(span: string) {
   if (!span) return '';
 
-  const width = (parseInt(span, 10) / 12) * 100;
+  const width = (Number(span) / 12) * 100;
   return `width: ${width}%;`;
 }
 


### PR DESCRIPTION
Cast string to a number so string decimals are not rounded to an integer before doing calculations 