### PR TITLE
Use exponential notation for large APYs

### DIFF
--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -132,7 +132,7 @@ export const formatApy = (apy?: BigNumber | string | number): string => {
   if (apyBN.absoluteValue().isLessThan(100000000)) {
     return `${apyBN.dp(2, 1).toString(10)}%`;
   }
-  return 'Infinity';
+  return `${apyBN.toExponential(2, 1)}%`;
 };
 
 /**

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -97,7 +97,7 @@ export const addToken = async ({
   }
 };
 
-export const getBigNumber = (value: $TSFixMe) => {
+export const getBigNumber = (value?: BigNumber | string | number): BigNumber => {
   if (!value) {
     return new BigNumber(0);
   }
@@ -127,7 +127,7 @@ export const currencyFormatter = (labelValue: $TSFixMe) => {
   return `$${format(new BigNumber(`${abs / unit}`).dp(2, 1).toNumber())}${suffix}`;
 };
 
-export const formatApy = (apy: $TSFixMe) => {
+export const formatApy = (apy?: BigNumber | string | number): string => {
   const apyBN = getBigNumber(apy);
   if (apyBN.absoluteValue().isLessThan(100000000)) {
     return `${apyBN.dp(2, 1).toString(10)}%`;


### PR DESCRIPTION
**Problem:** Currently we show the word "Infinity" when APYs are too large. This may happen when a new market is deployed, and the compound yield from XVS distribution is far above any sane values. This doesn't last long, but this is perfectly valid (e.g. if you supply 1 cent and you're the only supplier, you will receive the full distribution per day). Showing "Infinity" in this case is misleading.
    
**Solution:** Display large APYs in exponential notation (e.g., 1.22e+800%).