### PR TITLE
Fix redirection from / to /dashboard

### DIFF
--- a/src/containers/App.tsx
+++ b/src/containers/App.tsx
@@ -79,10 +79,10 @@ class App extends React.Component {
                           <Route exact path="/vote/proposal/:id" component={VoteOverview} />
                           <Route exact path="/vote/address/:address" component={ProposerDetail} />
                           {process.env.REACT_APP_CHAIN_ID === '97' && (
-                            <>
-                              <Route exact path="/convert-vrt" component={VrtConversion} />
-                              <Route exact path="/faucet" component={Faucet} />
-                            </>
+                            <Route exact path="/convert-vrt" component={VrtConversion} />
+                          )}
+                          {process.env.REACT_APP_CHAIN_ID === '97' && (
+                            <Route exact path="/faucet" component={Faucet} />
                           )}
                           <Redirect from="/" to="/dashboard" />
                         </Switch>


### PR DESCRIPTION
I recently introduced a change to not include the VRT converter route in prod. However, it seems that using a fragment to group both the Faucet and VRT converter routes and conditionally render them has caused the `Redirect` component rendered right after not to work anymore. This bug isn't present in `v0.1.1` (the change was introduced later).

Duplicating the `IF` condition used to determine rendering in order to remove the fragment fixes the issue.