### PR TITLE
remove the limit of XVS balance of vesting contract

### DIFF
--- a/src/components/Vault/BasicVault/CardContent.tsx
+++ b/src/components/Vault/BasicVault/CardContent.tsx
@@ -4,6 +4,7 @@ import { Row, Col, Icon } from 'antd';
 import BigNumber from 'bignumber.js';
 import { useWeb3React } from '@web3-react/core';
 import NumberFormat from 'react-number-format';
+import { commaFormat } from 'utilities/common';
 
 import { CardItemWrapper } from '../styles';
 
@@ -185,7 +186,7 @@ function CardContent({
               <div className="withdraw-request">
                 <div className="card-title">
                   Available {stakedToken} to stake:{' '}
-                  {userStakedTokenBalance.div(1e18).dp(4, 1).toString(10)}
+                  {commaFormat(userStakedTokenBalance.div(1e18).dp(4, 1).toString(10))}
                 </div>
                 <div className="input-wrapper">
                   <NumberFormat

--- a/src/components/Vault/BasicVault/VrtCard.tsx
+++ b/src/components/Vault/BasicVault/VrtCard.tsx
@@ -62,8 +62,6 @@ export default function VaultCard() {
       ]);
     }
 
-    console.log('interestRatePerBlockTemp', interestRatePerBlockTemp);
-
     if (isMounted) {
       // total info
       setDailyEmission(

--- a/src/components/Vault/BasicVault/VrtCard.tsx
+++ b/src/components/Vault/BasicVault/VrtCard.tsx
@@ -62,6 +62,8 @@ export default function VaultCard() {
       ]);
     }
 
+    console.log('interestRatePerBlockTemp', interestRatePerBlockTemp);
+
     if (isMounted) {
       // total info
       setDailyEmission(

--- a/src/components/VrtConversion/Convert.tsx
+++ b/src/components/VrtConversion/Convert.tsx
@@ -29,7 +29,6 @@ function formatCountdownInSeconds(seconds: number) {
 }
 
 export type ConvertPropsType = {
-  xvsVestingXvsBalance: BigNumber;
   userVrtBalance: BigNumber;
   userEnabled: boolean;
   conversionEndTime: BigNumber;
@@ -39,7 +38,6 @@ export type ConvertPropsType = {
 };
 
 export default ({
-  xvsVestingXvsBalance,
   userVrtBalance,
   userEnabled,
   conversionEndTime,
@@ -49,7 +47,6 @@ export default ({
 }: ConvertPropsType) => {
   const [convertInputAmount, setConvertInputAmount] = useState(new BigNumber(0));
   const [convertLoading, setConvertLoading] = useState(false);
-  const maxConvertAmountRegardingXvsBalance = xvsVestingXvsBalance.div(conversionRatio);
 
   let confirmButtonText = '';
   if (!account) {
@@ -66,11 +63,6 @@ export default ({
       <div className="ratio-text">
         Convert <span>1</span> VRT for <span>{conversionRatio.toFixed(6)}</span> XVS
       </div>
-      {/* display available XVS in pool */}
-      <div className="xvs-pool">
-        <div className="xvs-pool-line-1">{xvsVestingXvsBalance.toFixed(4)} XVS</div>
-        <div className="xvs-pool-line-2">Current available</div>
-      </div>
       {/* convert section */}
       <div className="convert-vrt">
         <div className="input-title">Convert VRT</div>
@@ -82,13 +74,7 @@ export default ({
             value={convertInputAmount.toFixed(4)}
             onValueChange={values => {
               const { value } = values;
-              setConvertInputAmount(
-                BigNumber.min(
-                  new BigNumber(value),
-                  userVrtBalance,
-                  maxConvertAmountRegardingXvsBalance,
-                ),
-              );
+              setConvertInputAmount(BigNumber.min(new BigNumber(value), userVrtBalance));
             }}
             thousandSeparator
             allowNegative={false}
@@ -98,9 +84,7 @@ export default ({
             <div
               className="button max-button"
               onClick={() => {
-                setConvertInputAmount(
-                  BigNumber.min(userVrtBalance, maxConvertAmountRegardingXvsBalance),
-                );
+                setConvertInputAmount(userVrtBalance);
               }}
             >
               {' '}

--- a/src/components/VrtConversion/Convert.tsx
+++ b/src/components/VrtConversion/Convert.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import BigNumber from 'bignumber.js';
 import NumberFormat from 'react-number-format';
 import { Button, Icon } from 'components';
+import { commaFormat } from 'utilities/common';
 
 import { ButtonWrapper, ConvertWrapper } from './styles';
 
@@ -94,7 +95,7 @@ export default ({
         </div>
         <div className="user-vrt-balance">
           Balance:
-          {account ? userVrtBalance.toFixed(4) : '-'} VRT
+          {account ? commaFormat(userVrtBalance.toFixed(4)) : '-'} VRT
         </div>
       </div>
       {/* recieve section */}
@@ -104,7 +105,7 @@ export default ({
           <img src={xvsImg} alt="xvs-icon" />
           <NumberFormat
             className="input recieve-xvs-input"
-            value={convertInputAmount.times(conversionRatio).toFixed(4)}
+            value={convertInputAmount.times(conversionRatio).toFixed(6)}
             disabled
             thousandSeparator
             placeholder="0"
@@ -128,6 +129,7 @@ export default ({
             setConvertLoading(true);
             await handleClickConvert(convertInputAmount);
             setConvertLoading(false);
+            setConvertInputAmount(new BigNumber(0));
           }}
         >
           {confirmButtonText}

--- a/src/config/contracts.ts
+++ b/src/config/contracts.ts
@@ -50,15 +50,16 @@ const contracts = {
   // vrt conversion
   xvsVestingProxy: {
     56: '',
-    97: '0x8e3C47924Abdd3fAf418B25edA08B6278F723Cd7',
+    97: '0xcfa3a6bc934EcA22fa39e854c823cD3dE79D9BC8',
   },
   vrtConverterProxy: {
     56: '',
-    97: '0x09e6cfe9F05De73C02F1b172c273087594A4bCc6',
+    97: '0xAb81e79F9607eC4C7b69Ab4f7cf6c0AF607aA131',
   },
+  // vrt vault
   vrtVaultProxy: {
     56: '',
-    97: '0x4DFf5578114a1fB6cF4a07E31AFe85a7BafB962a',
+    97: '0x1ffD1b8B67A1AE0C189c734B0F58B0954522FF71',
   },
 };
 

--- a/src/containers/Main/VrtConversion.tsx
+++ b/src/containers/Main/VrtConversion.tsx
@@ -47,7 +47,6 @@ export default () => {
   const [conversionRatio, setConversionRatio] = useState(new BigNumber(0));
   const [conversionEndTime, setConversionEndTime] = useState(new BigNumber(0));
   const [userVrtBalance, setUserVrtBalance] = useState(new BigNumber(0));
-  const [xvsVestingXvsBalance, setXvsVestingXvsBalance] = useState(new BigNumber(0));
   // user's allowance to VRT converter contracr
   const [userEnabled, setUserEnabled] = useState(false);
 
@@ -76,28 +75,22 @@ export default () => {
           console.log('no vestings');
         }
       }
-      const [
-        conversionRatioTemp,
-        conversionEndTimeTemp,
-        userVrtBalanceTemp,
-        userVrtAllowanceTemp,
-        xvsVestingXvsBalanceTemp,
-      ] = await Promise.all([
-        vrtConverterContract.methods.conversionRatio().call(),
-        vrtConverterContract.methods.conversionEndTime().call(),
-        account ? vrtTokenContract.methods.balanceOf(account).call() : Promise.resolve(0),
-        account
-          ? vrtTokenContract.methods.allowance(account, getVrtConverterProxyAddress()).call()
-          : Promise.resolve(0),
-        xvsTokenContract.methods.balanceOf(xvsVestingContract.options.address).call(),
-      ]);
+      const [conversionRatioTemp, conversionEndTimeTemp, userVrtBalanceTemp, userVrtAllowanceTemp] =
+        await Promise.all([
+          vrtConverterContract.methods.conversionRatio().call(),
+          vrtConverterContract.methods.conversionEndTime().call(),
+          account ? vrtTokenContract.methods.balanceOf(account).call() : Promise.resolve(0),
+          account
+            ? vrtTokenContract.methods.allowance(account, getVrtConverterProxyAddress()).call()
+            : Promise.resolve(0),
+          xvsTokenContract.methods.balanceOf(xvsVestingContract.options.address).call(),
+        ]);
       if (mounted) {
         setLoading(false);
         setConversionRatio(new BigNumber(conversionRatioTemp).div(CONVERSION_RATIO_DECIMAL));
         setConversionEndTime(new BigNumber(conversionEndTimeTemp)); // in seconds
         setUserVrtBalance(new BigNumber(userVrtBalanceTemp).div(VRT_DECIMAL));
         setUserEnabled(new BigNumber(userVrtAllowanceTemp).gt(0));
-        setXvsVestingXvsBalance(new BigNumber(xvsVestingXvsBalanceTemp).div(XVS_DECIMAL));
       }
     };
 
@@ -128,7 +121,6 @@ export default () => {
                   titles={['Convert', 'Withdraw']}
                 >
                   <Convert
-                    xvsVestingXvsBalance={xvsVestingXvsBalance}
                     userVrtBalance={userVrtBalance}
                     userEnabled={userEnabled}
                     conversionEndTime={conversionEndTime}

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -4,7 +4,7 @@ import { ethers } from 'ethers';
 import commaNumber from 'comma-number';
 import { getVaiTokenAddress } from './addressHelpers';
 
-const format = commaNumber.bindWith(',', '.');
+export const commaFormat = commaNumber.bindWith(',', '.');
 
 export const encodeParameters = (types: $TSFixMe, values: $TSFixMe) => {
   const abi = new ethers.utils.AbiCoder();
@@ -124,7 +124,7 @@ export const currencyFormatter = (labelValue: $TSFixMe) => {
     suffix = 'K';
     unit = 1.0e3;
   }
-  return `$${format(new BigNumber(`${abs / unit}`).dp(2, 1).toNumber())}${suffix}`;
+  return `$${commaFormat(new BigNumber(`${abs / unit}`).dp(2, 1).toNumber())}${suffix}`;
 };
 
 export const formatApy = (apy?: BigNumber | string | number): string => {


### PR DESCRIPTION
According to the mechanism of the vesting contract, users won't get the XVS for once, they can only withdraw the vested XVS tokens based on

- the ratio between their converted VRT tokens and total converted VRT
- remaining XVS in the pool

So there is no need to add a limit in frontend when there is no such limit on the contract side
Besides:
- testnet contract updated