### PR TITLE
Add GITHUB_TOKEN for auth to push to gh-pages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,7 +78,9 @@ jobs:
 
       - name: Deploy
         if: github.ref == 'refs/heads/develop'
-        run: yarn deploy-storybook
+        run: yarn deploy-storybook --ci
+        env:
+          GH_TOKEN: ${{ github.actor }}:${{ secrets.GITHUB_TOKEN }}
 
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Storybook deployer requires [GH_TOKEN](https://github.com/storybookjs/storybook-deployer#storybook-deployer) var

This [issue](https://github.com/storybookjs/storybook-deployer/issues/77) reccomend scoping it to the current actor