### PR TITLE
Cherry pick package version update (0.2.0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "venus",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "private": true,
   "engines": {
     "node": ">=12.19.x"


### PR DESCRIPTION
I forgot to update the package version when I merged `0.2.0` to `master`, so I opened a PR that would update it on the `master` branch. This PR cherry picks this commit so the update is ported onto `develop` as well.