### PR TITLE
Ignore built storybook dir when running eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules
 .eslintrc.js
 public
 build
+storybook-static


### PR DESCRIPTION
Sometimes it is necessary to build the storybooks locally in order to troubleshoot, if the storybooks are built locally we don't need to lint them