### PR TITLE
Update text color of button when disabled

### DIFF
--- a/src/components/v2/Button/styles.tsx
+++ b/src/components/v2/Button/styles.tsx
@@ -97,6 +97,7 @@ export const styles = ({
         color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
 
       :disabled {
+        color: ${theme.palette.text.secondary};
         background-color: ${theme.palette.secondary.light};
         border-color: ${theme.palette.secondary.light};
       }


### PR DESCRIPTION
The current disabled state looked similar to the secondary button variant, so Pavel updated it to be unique.

<img width="284" alt="Screenshot 2022-04-01 at 19 12 45" src="https://user-images.githubusercontent.com/44675210/161319246-68db6864-0584-400a-aa35-e8617aa19dd5.png">
