### PR TITLE
Disable "space before blocks" rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,6 +11,7 @@ module.exports = {
   },
   rules: {
     // handled by prettier
+    '@typescript-eslint/space-before-blocks': 0,
     '@typescript-eslint/indent': 0,
     'arrow-parens': 0,
     'object-curly-newline': 0,


### PR DESCRIPTION
This rule was preventing Jenkins from building. Since we anyway handle this case through Prettier, I've disabled it.