### PR TITLE
Disable reward claiming for XVS vault

### DIFF
--- a/src/components/Vault/VestingVault/CardContent.tsx
+++ b/src/components/Vault/VestingVault/CardContent.tsx
@@ -165,7 +165,15 @@ function CardContent({
               <button
                 type="button"
                 className="button claim-button"
-                disabled={!pendingReward.gt(0) || !account || claimLoading}
+                disabled={
+                  !pendingReward.gt(0) ||
+                  !account ||
+                  claimLoading ||
+                  // We're temporarily disabling reward claiming because of a
+                  // current issue with the smart contract
+                  // @TODO: re-enable once issue is fixed
+                  stakedToken === 'xvs'
+                }
                 onClick={async () => {
                   setClaimLoading(true);
                   try {


### PR DESCRIPTION
The XVS reserve is currently empty, leading to users claiming their rewards from the vault but receiving no funds.
For that reason, we're temporarily disabling reward claiming from the dApp.