### PR TITLE
Re-enable XVS reward claim

### DIFF
--- a/src/components/Vault/VestingVault/CardContent.tsx
+++ b/src/components/Vault/VestingVault/CardContent.tsx
@@ -165,15 +165,7 @@ function CardContent({
               <button
                 type="button"
                 className="button claim-button"
-                disabled={
-                  !pendingReward.gt(0) ||
-                  !account ||
-                  claimLoading ||
-                  // We're temporarily disabling reward claiming because of a
-                  // current issue with the smart contract
-                  // @TODO: re-enable once issue is fixed
-                  stakedToken === 'xvs'
-                }
+                disabled={!pendingReward.gt(0) || !account || claimLoading}
                 onClick={async () => {
                   setClaimLoading(true);
                   try {


### PR DESCRIPTION
This reverts commit `e6a37bfb56ece6c7cfea37e0e911144cf71e3492`, which was disabling the "Claim" button for the XVS vault. Now that the reserve has been replenished, it can be enabled again (although it never was deployed anyway..).
