### PR TITLE
Refetch assets on collateral retoggle

### DIFF
--- a/src/clients/api/mutations/useEnterMarkets.ts
+++ b/src/clients/api/mutations/useEnterMarkets.ts
@@ -1,6 +1,6 @@
 import { useMutation, MutationObserverOptions } from 'react-query';
 
-import { enterMarkets, IEnterMarketsInput, EnterMarketsOutput } from 'clients/api';
+import { queryClient, enterMarkets, IEnterMarketsInput, EnterMarketsOutput } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useComptroller } from 'hooks/useContract';
 
@@ -22,7 +22,19 @@ const useEnterMarkets = (
         comptrollerContract,
         ...params,
       }),
-    options,
+    {
+      ...options,
+      onSuccess: (
+        data: void,
+        variables: Omit<IEnterMarketsInput, 'comptrollerContract'>,
+        context: unknown,
+      ) => {
+        queryClient.invalidateQueries(FunctionKey.GET_ASSETS_IN_ACCOUNT);
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+    },
   );
 };
 

--- a/src/clients/api/mutations/useExitMarket.ts
+++ b/src/clients/api/mutations/useExitMarket.ts
@@ -1,6 +1,6 @@
 import { useMutation, MutationObserverOptions } from 'react-query';
 
-import { exitMarket, IExitMarketInput, ExitMarketOutput } from 'clients/api';
+import { queryClient, exitMarket, IExitMarketInput, ExitMarketOutput } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useComptroller } from 'hooks/useContract';
 
@@ -22,7 +22,19 @@ const useExitMarket = (
         comptrollerContract,
         ...params,
       }),
-    options,
+    {
+      ...options,
+      onSuccess: (
+        data: void,
+        variables: Omit<IExitMarketInput, 'comptrollerContract'>,
+        context: unknown,
+      ) => {
+        queryClient.invalidateQueries(FunctionKey.GET_ASSETS_IN_ACCOUNT);
+        if (options?.onSuccess) {
+          options.onSuccess(data, variables, context);
+        }
+      },
+    },
   );
 };
 

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -6,6 +6,7 @@ import { Token, Toggle } from 'components';
 import { Table, ITableProps } from 'components/v2/Table';
 import { ToastError } from 'utilities/errors';
 import toast from 'components/Basic/Toast';
+import FunctionKey from 'constants/functionKey';
 import { useWeb3Account } from 'clients/web3';
 import useUserMarketInfo from 'hooks/useUserMarketInfo';
 import { useExitMarket, useEnterMarkets } from 'clients/api';
@@ -113,14 +114,18 @@ const SupplyMarket: React.FC = () => {
   const [confirmCollateral, setConfirmCollateral] = useState<Asset | undefined>(undefined);
 
   const { mutate: enterMarkets } = useEnterMarkets({
-    onSuccess: () => setConfirmCollateral(undefined),
+    onSuccess: () => {
+      setConfirmCollateral(undefined);
+    },
     onError: error => {
       setConfirmCollateral(undefined);
       throw error;
     },
   });
   const { mutate: exitMarkets } = useExitMarket({
-    onSuccess: () => setConfirmCollateral(undefined),
+    onSuccess: () => {
+      setConfirmCollateral(undefined);
+    },
     onError: error => {
       setConfirmCollateral(undefined);
       throw error;


### PR DESCRIPTION
When we toggle collateral refetch the users assets so we can check that the token is added to their wallet.