### PR TITLE
Move contract argument to market hooks

### DIFF
--- a/src/hooks/operations/mutations/useEnterMarkets.ts
+++ b/src/hooks/operations/mutations/useEnterMarkets.ts
@@ -1,16 +1,28 @@
 import { useMutation, MutationObserverOptions } from 'react-query';
-
+import { useComptroller } from 'hooks/useContract';
 import { enterMarkets, IEnterMarketsInput, EnterMarketsOutput } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 
+type Options = MutationObserverOptions<
+  EnterMarketsOutput,
+  Error,
+  Omit<IEnterMarketsInput, 'comptrollerContract'>
+>;
+
 const useEnterMarkets = (
   // TODO: use custom error type
-  options?: MutationObserverOptions<EnterMarketsOutput, Error, IEnterMarketsInput>,
-) =>
-  useMutation<EnterMarketsOutput, Error, IEnterMarketsInput>(
+  options?: Options,
+) => {
+  const comptrollerContract = useComptroller();
+  return useMutation(
     FunctionKey.ENTER_MARKETS,
-    enterMarkets,
+    (params: Omit<IEnterMarketsInput, 'comptrollerContract'>) =>
+      enterMarkets({
+        comptrollerContract,
+        ...params,
+      }),
     options,
   );
+};
 
 export default useEnterMarkets;

--- a/src/hooks/operations/mutations/useExitMarket.ts
+++ b/src/hooks/operations/mutations/useExitMarket.ts
@@ -1,16 +1,28 @@
 import { useMutation, MutationObserverOptions } from 'react-query';
-
+import { useComptroller } from 'hooks/useContract';
 import { exitMarket, IExitMarketInput, ExitMarketOutput } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 
+type Options = MutationObserverOptions<
+  ExitMarketOutput,
+  Error,
+  Omit<IExitMarketInput, 'comptrollerContract'>
+>;
+
 const useExitMarket = (
   // TODO: use custom error type
-  options?: MutationObserverOptions<ExitMarketOutput, Error, IExitMarketInput>,
-) =>
-  useMutation<ExitMarketOutput, Error, IExitMarketInput>(
+  options?: Options,
+) => {
+  const comptrollerContract = useComptroller();
+  return useMutation(
     FunctionKey.EXIT_MARKET,
-    exitMarket,
+    (params: Omit<IExitMarketInput, 'comptrollerContract'>) =>
+      exitMarket({
+        comptrollerContract,
+        ...params,
+      }),
     options,
   );
+};
 
 export default useExitMarket;

--- a/src/pages/Dashboard/Markets/SupplyMarket.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket.tsx
@@ -7,7 +7,6 @@ import { Table, ITableProps } from 'components/v2/Table';
 import { ToastError } from 'utilities/errors';
 import toast from 'components/Basic/Toast';
 import { useWeb3Account } from 'clients/web3';
-import { useComptroller } from 'hooks/useContract';
 import useUserMarketInfo from 'hooks/useUserMarketInfo';
 import useExitMarket from 'hooks/operations/mutations/useExitMarket';
 import useEnterMarkets from 'hooks/operations/mutations/useEnterMarkets';
@@ -127,7 +126,6 @@ const SupplyMarket: React.FC = () => {
       throw error;
     },
   });
-  const comptrollerContract = useComptroller();
   const toggleAssetCollateral = (asset: Asset) => {
     if (!account) {
       throw new ToastError(
@@ -142,7 +140,7 @@ const SupplyMarket: React.FC = () => {
     } else if (!asset.collateral) {
       try {
         setConfirmCollateral(asset);
-        enterMarkets({ comptrollerContract, vtokenAddresses: [asset.vtokenAddress], account });
+        enterMarkets({ vtokenAddresses: [asset.vtokenAddress], account });
       } catch (error) {
         console.log('enter markets error :>> ', error);
         throw new ToastError(
@@ -153,7 +151,7 @@ const SupplyMarket: React.FC = () => {
     } else if (+asset.hypotheticalLiquidity['1'] > 0 || +asset.hypotheticalLiquidity['2'] === 0) {
       try {
         setConfirmCollateral(asset);
-        exitMarkets({ comptrollerContract, vtokenAddress: asset.vtokenAddress, account });
+        exitMarkets({ vtokenAddress: asset.vtokenAddress, account });
       } catch (error) {
         throw new ToastError(
           'Collateral Disable Error',


### PR DESCRIPTION
Move the contract argument to inside the market hook so that it doesn't have to be passed as an argument when using the hook