### PR TITLE
Fix tests (internationalization library not being initialized in tests)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -13,6 +13,9 @@ import GovernanceResponse from '../src/__mocks__/api/governance.json';
 import VoteReponse from '../src/__mocks__/api/vote.json';
 import TransactionResponse from '../src/__mocks__/api/transactions.json';
 import vaiControllerResponses from '../src/__mocks__/contracts/vaiController.json';
+import { init as initTranslationLibrary } from '../src/translation';
+
+initTranslationLibrary();
 
 initialize({
   onUnhandledRequest: 'bypass',

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -10,7 +10,7 @@ import { AuthProvider } from 'context/AuthContext';
 // import { isOnTestnet } from 'config';
 import { store } from 'core';
 import { Layout } from 'components';
-import { init as initTranslationClient } from 'translation';
+import { init as initTranslationLibrary } from 'translation';
 import Dashboard from 'pages/Dashboard';
 // import Faucet from 'pages/Faucet';
 // import Vote from 'pages/Vote';
@@ -30,7 +30,7 @@ import { VaiContextProvider } from 'context/VaiContext';
 import { MuiThemeProvider } from 'theme/MuiThemeProvider/MuiThemeProvider';
 import 'assets/styles/App.scss';
 
-initTranslationClient();
+initTranslationLibrary();
 
 const App = () => (
   <Theme>

--- a/src/testUtils/renderComponent.tsx
+++ b/src/testUtils/renderComponent.tsx
@@ -7,11 +7,15 @@ import 'react-toastify/dist/ReactToastify.min.css';
 
 import { Web3Wrapper } from 'clients/web3';
 import { AuthProvider } from 'context/AuthContext';
+import { init as initTranslationLibrary } from 'translation';
 import Theme from 'theme';
 import { RefreshContextProvider } from 'context/RefreshContext';
 import { MarketContextProvider } from 'context/MarketContext';
 import { VaiContextProvider } from 'context/VaiContext';
 import { MuiThemeProvider } from 'theme/MuiThemeProvider/MuiThemeProvider';
+
+// Initialize internationalization library
+initTranslationLibrary();
 
 const renderComponent = (children: any) => {
   const queryClient = new QueryClient({


### PR DESCRIPTION
The tests are currently breaking because I moved the initialization of the internationalization service outside of the translation library, but forgot to initialize it inside the tests.
This PR fixes that.