### PR TITLE
Fix supply APY displayed in SupplyMarket

### DIFF
--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -59,10 +59,10 @@ export const SupplyMarketUi: React.FC<ISupplyMarketUiProps> = ({
     {
       key: 'apy',
       render: () => {
-        const apy = withXvs ? asset.xvsBorrowApy.plus(asset.borrowApy) : asset.borrowApy;
+        const apy = withXvs ? asset.xvsSupplyApy.plus(asset.supplyApy) : asset.supplyApy;
         return formatApy(apy);
       },
-      value: asset.borrowApy.toString(),
+      value: asset.supplyApy.toString(),
     },
     {
       key: 'wallet',


### PR DESCRIPTION
The `SupplyMarket` table currently displays the borrow APY instead of the supply APY, hence this fix.