### PR TITLE
Update GitHub actions config to run checks on PRs only

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,6 @@
 name: Tests and Checks
 
-on: [push]
+on: [pull_request]
 
 env:
   REACT_APP_CHAIN_ID: 97


### PR DESCRIPTION
As Corey proposed a few days ago, this should help decluttering our pipelines.