### PR TITLE
Remove name in favor of symbol

### DIFF
--- a/src/__mocks__/models/asset.ts
+++ b/src/__mocks__/models/asset.ts
@@ -1,16 +1,15 @@
 import BigNumber from 'bignumber.js';
+import { Asset } from 'types';
 
-export const assetData = [
+export const assetData: Asset[] = [
   {
-    id: '1',
-    address: '1',
-    symbol: 'xvs',
+    id: 'xvs',
+    symbol: 'XVS',
     borrowApy: new BigNumber('3.14'),
     liquidity: new BigNumber('2151232133213'),
     tokenPrice: new BigNumber(123),
     borrowBalance: new BigNumber('123'),
     decimals: 18,
-    name: 'XVS',
     walletBalance: new BigNumber('444'),
     isEnabled: true,
     vtokenAddress: '0x123',
@@ -32,15 +31,13 @@ export const assetData = [
     hypotheticalLiquidity: ['1', '2', '3'] as [string, string, string],
   },
   {
-    id: '2',
-    address: '2',
-    symbol: 'usdc',
+    id: 'usdc',
+    symbol: 'USDC',
     borrowApy: new BigNumber('0.14'),
     liquidity: new BigNumber('2158192683'),
     tokenPrice: new BigNumber(123333),
     borrowBalance: new BigNumber('12333'),
     decimals: 18,
-    name: 'usdc',
     walletBalance: new BigNumber('444'),
     isEnabled: true,
     vtokenAddress: '0x123',
@@ -62,15 +59,13 @@ export const assetData = [
     hypotheticalLiquidity: ['1', '2', '3'] as [string, string, string],
   },
   {
-    id: '3',
-    address: '3',
-    symbol: 'bnb',
+    id: 'bnb',
+    symbol: 'BNB',
     borrowApy: new BigNumber('8.14'),
     liquidity: new BigNumber('918723'),
     tokenPrice: new BigNumber(123),
     borrowBalance: new BigNumber('13323'),
     decimals: 18,
-    name: 'bnb',
     walletBalance: new BigNumber('444'),
     isEnabled: true,
     vtokenAddress: '0x123',

--- a/src/clients/api/queries/useGetHypotheticalLiquidityQueries.ts
+++ b/src/clients/api/queries/useGetHypotheticalLiquidityQueries.ts
@@ -28,7 +28,7 @@ const useGetHypotheticalLiquidityQueries = (
           ? true
           : balances[asset.vtokenAddress.toLowerCase()]?.balanceOf !== undefined;
       return {
-        queryKey: [FunctionKey.GET_HYPOTHETICAL_LIQUIDITY, account, asset.name],
+        queryKey: [FunctionKey.GET_HYPOTHETICAL_LIQUIDITY, account, asset.symbol],
         queryFn: () =>
           getHypotheticalAccountLiquidity({
             comptrollerContract,

--- a/src/components/Basic/BorrowModal.tsx
+++ b/src/components/Basic/BorrowModal.tsx
@@ -229,7 +229,7 @@ function BorrowModal({ visible, asset, onCancel }: Props) {
         <img className="close-btn pointer" src={closeImg} alt="close" onClick={onCancel} />
         <div className="flex align-center just-center header-content">
           <img src={asset.img} alt="asset" />
-          <p className="title">{asset.name}</p>
+          <p className="title">{asset.symbol}</p>
         </div>
         {currentTab === 'borrow' && (
           <BorrowTab asset={asset} changeTab={setCurrentTab} onCancel={onCancel} />

--- a/src/components/Basic/BorrowTabs/RepayBorrowTab.tsx
+++ b/src/components/Basic/BorrowTabs/RepayBorrowTab.tsx
@@ -187,7 +187,7 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
           <>
             <img src={asset.img} alt="asset" />
             <p className="center warning-label">
-              To Repay {asset.name} to the Venus Protocol, you need to enable it first.
+              To Repay {asset.symbol} to the Venus Protocol, you need to enable it first.
             </p>
           </>
         )}

--- a/src/components/Basic/SupplyModal.tsx
+++ b/src/components/Basic/SupplyModal.tsx
@@ -221,7 +221,7 @@ function SupplyModal({ visible, asset, onCancel }: SupplyModalProps) {
         <img className="close-btn pointer" src={closeImg} alt="close" onClick={onCancel} />
         <div className="flex align-center just-center header-content">
           <img src={asset.img} alt="asset" />
-          <p className="title">{asset.name}</p>
+          <p className="title">{asset.symbol}</p>
         </div>
         {currentTab === 'supply' && (
           <SupplyTab asset={asset} changeTab={setCurrentTab} onCancel={onCancel} />

--- a/src/components/Basic/SupplyTabs/SupplyTab.tsx
+++ b/src/components/Basic/SupplyTabs/SupplyTab.tsx
@@ -180,7 +180,7 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: SupplyTabProps) {
           <>
             <img src={asset.img} alt="asset" />
             <p className="center warning-label">
-              To Supply {asset.name} to the Venus Protocol, you need to approve it first.
+              To Supply {asset.symbol} to the Venus Protocol, you need to approve it first.
             </p>
           </>
         )}

--- a/src/components/Dashboard/Market/BorrowMarket.tsx
+++ b/src/components/Dashboard/Market/BorrowMarket.tsx
@@ -48,7 +48,7 @@ function BorrowMarket({ borrowedAssets, remainAssets, settings }: Props & StateP
               <img src={asset.img} alt="ethereum" />
               <div className="flex flex-column align-start">
                 <Label size="14" primary>
-                  {asset.name}
+                  {asset.symbol}
                 </Label>
                 <Label size="14">{asset.borrowApy.dp(2, 1).toString(10)}%</Label>
               </div>
@@ -129,7 +129,7 @@ function BorrowMarket({ borrowedAssets, remainAssets, settings }: Props & StateP
               <img src={asset.img} alt="ethereum" />
               <div className="flex flex-column align-start">
                 <Label size="14" primary>
-                  {asset.name}
+                  {asset.symbol}
                 </Label>
                 <Label size="14">{asset.borrowApy.dp(2, 1).toString(10)}%</Label>
               </div>

--- a/src/components/Dashboard/Market/SupplyMarket.tsx
+++ b/src/components/Dashboard/Market/SupplyMarket.tsx
@@ -81,7 +81,7 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
               <img src={asset.img} alt="ethereum" />
               <div className="flex flex-column align-start">
                 <Label size="14" primary>
-                  {asset.name}
+                  {asset.symbol}
                 </Label>
                 <Label size="14">{asset.supplyApy.dp(2, 1).toString(10)}%</Label>
               </div>
@@ -151,7 +151,7 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
               <img src={asset.img} alt="ethereum" />
               <div className="flex flex-column align-start">
                 <Label size="14" primary>
-                  {asset.name}
+                  {asset.symbol}
                 </Label>
                 <Label size="14">{asset.supplyApy.dp(2, 1).toString(10)}%</Label>
               </div>

--- a/src/context/MarketContext.tsx
+++ b/src/context/MarketContext.tsx
@@ -164,7 +164,6 @@ const MarketContextProvider = ({ children }: $TSFixMe) => {
             id: item.id,
             img: item.asset,
             vimg: item.vasset,
-            name: market.underlyingSymbol || '',
             symbol: market.underlyingSymbol || '',
             decimals: item.decimals,
             tokenAddress: market.underlyingAddress,

--- a/src/hooks/useUserMarketInfo.ts
+++ b/src/hooks/useUserMarketInfo.ts
@@ -15,7 +15,7 @@ import {
   IGetVTokenBalancesAllOutput,
 } from 'clients/api';
 
-const useUserMarketInfo = ({ account }: { account: string | null | undefined }) => {
+const useUserMarketInfo = ({ account }: { account: string | null | undefined }): Asset[] => {
   const { userVaiMinted } = useVaiUser();
 
   const vtAddresses = Object.values(VBEP_TOKENS)
@@ -89,8 +89,7 @@ const useUserMarketInfo = ({ account }: { account: string | null | undefined }) 
       id: item.id,
       img: item.asset,
       vimg: item.vasset,
-      name: market.underlyingSymbol || item.id.toUpperCase(),
-      symbol: market.underlyingSymbol || '',
+      symbol: market.underlyingSymbol || item.id.toUpperCase(),
       decimals: item.decimals,
       tokenAddress: market.underlyingAddress,
       vsymbol: market.symbol,

--- a/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
@@ -44,8 +44,8 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
     return [
       {
         key: 'asset',
-        render: () => <Token symbol={asset.name as TokenId} />,
-        value: asset.name,
+        render: () => <Token symbol={asset.symbol as TokenId} />,
+        value: asset.id,
       },
       {
         key: 'apy',

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.stories.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentMeta } from '@storybook/react';
-import { withCenterStory } from 'stories/decorators';
 import noop from 'noop-ts';
+import { withCenterStory } from 'stories/decorators';
 import { assetData } from '__mocks__/models/asset';
 import { SupplyMarketUi } from '.';
 

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -59,8 +59,8 @@ export const SupplyMarketUi: React.FC<ISupplyMarketUiProps> = ({
   const rows: ITableProps['data'] = assets.map(asset => [
     {
       key: 'asset',
-      render: () => <Token symbol={asset.name as TokenId} />,
-      value: asset.name,
+      render: () => <Token symbol={asset.symbol as TokenId} />,
+      value: asset.id,
     },
     {
       key: 'apy',
@@ -156,7 +156,7 @@ const SupplyMarket: React.FC = () => {
       } catch (error) {
         throw new ToastError(
           t('markets.errors.collateralEnableError.title'),
-          t('markets.errors.collateralEnableError.description', { assetName: asset.name }),
+          t('markets.errors.collateralEnableError.description', { assetName: asset.symbol }),
         );
       }
     } else if (+asset.hypotheticalLiquidity['1'] > 0 || +asset.hypotheticalLiquidity['2'] === 0) {
@@ -166,7 +166,7 @@ const SupplyMarket: React.FC = () => {
       } catch (error) {
         throw new ToastError(
           t('markets.errors.collateralDisableError.title'),
-          t('markets.errors.collateralDisableError.description', { assetName: asset.name }),
+          t('markets.errors.collateralDisableError.description', { assetName: asset.symbol }),
         );
       }
     } else {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -6,8 +6,7 @@ export interface User {
 }
 
 export interface Asset {
-  id: string;
-  name: string;
+  id: TokenId;
   tokenPrice: BigNumber;
   symbol: string;
   borrowBalance: BigNumber;


### PR DESCRIPTION
To clarify the properties on the asset, this PR removes name in favor of using Id to identify the asset and symbol to display its ticket letters.

If we ever need to display the full name of an asset, we can add back name and use it to display the full name