### PR TITLE
Return borrow balance and limit from user market info

### DIFF
--- a/src/hooks/useUserMarketInfo.ts
+++ b/src/hooks/useUserMarketInfo.ts
@@ -15,7 +15,11 @@ import {
   IGetVTokenBalancesAllOutput,
 } from 'clients/api';
 
-const useUserMarketInfo = ({ account }: { account: string | null | undefined }): Asset[] => {
+const useUserMarketInfo = ({
+  account,
+}: {
+  account: string | null | undefined;
+}): { assets: Asset[]; userTotalBorrowLimit: BigNumber; userTotalBorrowBalance: BigNumber } => {
   const { userVaiMinted } = useVaiUser();
 
   const vtAddresses = Object.values(VBEP_TOKENS)
@@ -160,7 +164,11 @@ const useUserMarketInfo = ({ account }: { account: string | null | undefined }):
           .dp(0, 1)
           .toString(10),
   }));
-  return assetList;
+  return {
+    assets: assetList,
+    userTotalBorrowLimit: totalBorrowLimit,
+    userTotalBorrowBalance: totalBorrowBalance,
+  };
 };
 
 export default useUserMarketInfo;

--- a/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
@@ -89,10 +89,10 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
 
 const BorrowMarket: React.FC = () => {
   const { account } = React.useContext(AuthContext);
-  const userMarketInfo = useUserMarketInfo({ account: account?.address });
+  const { assets } = useUserMarketInfo({ account: account?.address });
 
   // @TODO: set withXVS from WalletBalance
-  return <BorrowMarketUi borrowAssets={userMarketInfo} withXvs />;
+  return <BorrowMarketUi borrowAssets={assets} withXvs />;
 };
 
 export default BorrowMarket;

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -115,7 +115,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketUiProps> = ({
 
 const SupplyMarket: React.FC = () => {
   const { account = '' } = useWeb3Account();
-  const userMarketInfo = useUserMarketInfo({ account });
+  const { assets } = useUserMarketInfo({ account });
   const [confirmCollateral, setConfirmCollateral] = useState<Asset | undefined>(undefined);
   const { t } = useTranslation();
 
@@ -179,7 +179,7 @@ const SupplyMarket: React.FC = () => {
   // @TODO: set withXVS from WalletBalance
   return (
     <SupplyMarketUi
-      assets={userMarketInfo}
+      assets={assets}
       withXvs
       toggleAssetCollateral={toggleAssetCollateral}
       confirmCollateral={confirmCollateral}


### PR DESCRIPTION
We are calculating the users borrow limit and total borrow balance when setting up the asset list with the user's asset information. This PR updates useUserMarketInfo to return an object with the comprehensive asset list and users borrow balance and limit