### PR TITLE
Fix size of icon in TextField

### DIFF
--- a/src/components/v2/TextField/index.tsx
+++ b/src/components/v2/TextField/index.tsx
@@ -64,7 +64,7 @@ export const TextField: React.FC<ITextFieldProps> = ({
 
       <Box css={styles.getInputContainer({ hasError })}>
         {!!leftIconName && (
-          <Icon name={leftIconName} size={styles.theme.spacing(3)} css={styles.leftIcon} />
+          <Icon name={leftIconName} size={styles.theme.spacing(6)} css={styles.leftIcon} />
         )}
 
         <input


### PR DESCRIPTION
Following the update of the `spacing` constant, the size of the icon in the `TextField` component needed to be doubled.