### PR TITLE
Update TokenTextField to use string value + fix success messages of MintRepayVai

### DIFF
--- a/src/components/v2/TokenTextField/index.stories.tsx
+++ b/src/components/v2/TokenTextField/index.stories.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { State } from 'react-powerplug';
-import BigNumber from 'bignumber.js';
 import { ComponentMeta } from '@storybook/react';
 
 import { withCenterStory } from 'stories/decorators';
@@ -17,28 +16,28 @@ export default {
   },
 } as ComponentMeta<typeof TokenTextField>;
 
-const initialData: { valueWei: BigNumber | '' } = { valueWei: '' };
+const initialData: { value: string } = { value: '' };
 
 export const Default = () => (
   <State initial={initialData}>
     {({ state, setState }) => (
       <TokenTextField
         tokenSymbol="usdt"
-        value={state.valueWei}
-        onChange={valueWei => setState({ valueWei })}
+        value={state.value}
+        onChange={value => setState({ value })}
       />
     )}
   </State>
 );
 
-export const WithMaxWei = () => (
+export const WithMaxTokens = () => (
   <State initial={initialData}>
     {({ state, setState }) => (
       <TokenTextField
         tokenSymbol="xvs"
-        value={state.valueWei}
-        onChange={valueWei => setState({ valueWei })}
-        maxWei={new BigNumber(10).pow(18).multipliedBy(10000)}
+        value={state.value}
+        onChange={value => setState({ value })}
+        max="10"
       />
     )}
   </State>
@@ -49,9 +48,9 @@ export const WithRightMaxButtonLabel = () => (
     {({ state, setState }) => (
       <TokenTextField
         tokenSymbol="usdt"
-        value={state.valueWei}
-        onChange={valueWei => setState({ valueWei })}
-        maxWei={new BigNumber(10).pow(6).multipliedBy(80)}
+        value={state.value}
+        onChange={value => setState({ value })}
+        max="10"
         rightMaxButtonLabel="80% limit"
       />
     )}

--- a/src/containers/AmountForm/index.tsx
+++ b/src/containers/AmountForm/index.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
-import BigNumber from 'bignumber.js';
 import { Formik, Form, FormikProps, FormikConfig } from 'formik';
 
 import validationSchema, { FormValues } from './validationSchema';
@@ -11,7 +10,7 @@ export const initialValues: FormValues = {
 
 export interface IAmountFormProps
   extends Omit<FormikConfig<FormValues>, 'onSubmit' | 'initialValues'> {
-  onSubmit: (value: BigNumber) => Promise<void> | void;
+  onSubmit: (value: string) => Promise<void> | void;
   children: (formProps: FormikProps<FormValues>) => React.ReactNode;
   initialValues?: FormikConfig<FormValues>['initialValues'];
   className?: string;

--- a/src/containers/AmountForm/validationSchema.ts
+++ b/src/containers/AmountForm/validationSchema.ts
@@ -1,17 +1,12 @@
-import BigNumber from 'bignumber.js';
 import * as yup from 'yup';
 
 export type FormValues = yup.InferType<typeof validationSchema>;
 
 const validationSchema = yup.object({
   amount: yup
-    .mixed<'' | BigNumber>()
+    .string()
     .required()
-    .test(
-      'isPositiveBigNumber',
-      'value must be positive',
-      value => value instanceof BigNumber && value.isGreaterThan(0),
-    ),
+    .test('isPositive', 'value must be positive', value => !!value && +value > 0),
 });
 
 export default validationSchema;

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -4,6 +4,7 @@ import { waitFor, fireEvent } from '@testing-library/react';
 
 import { mintVai, getVaiTreasuryPercentage } from 'clients/api';
 import toast from 'components/Basic/Toast';
+import { formatCoinsToReadableValue } from 'utilities/common';
 import { AuthContext } from 'context/AuthContext';
 import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
@@ -12,7 +13,11 @@ import RepayVai from '.';
 jest.mock('clients/api');
 jest.mock('components/Basic/Toast');
 
-const fakeMintableVai = new BigNumber('100');
+const fakeMintableVai = new BigNumber('1000');
+const formattedFakeUserVaiMinted = formatCoinsToReadableValue({
+  value: fakeMintableVai,
+  tokenSymbol: 'vai',
+});
 const fakeVaiTreasuryPercentage = 7.19;
 
 describe('pages/Dashboard/MintRepayVai/MintVai', () => {
@@ -41,7 +46,7 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
     await waitFor(() => getByText('Available VAI limit'));
 
     // Check available VAI limit displays correctly
-    await waitFor(() => getByText(`${fakeMintableVai.toString()} VAI`));
+    await waitFor(() => getByText(formattedFakeUserVaiMinted));
     // Check mint fee displays correctly
     await waitFor(() => getByText(`0 VAI (${fakeVaiTreasuryPercentage.toString()}%)`));
   });
@@ -100,7 +105,7 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
     // Check success toast is requested
     expect(toast.success).toHaveBeenCalledTimes(1);
     expect(toast.success).toHaveBeenCalledWith({
-      title: `You successfully minted\u00A0${fakeMintableVai.toString()} VAI`,
+      title: `You successfully minted ${formattedFakeUserVaiMinted}`,
     });
   });
 

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -4,6 +4,7 @@ import { waitFor, fireEvent } from '@testing-library/react';
 
 import { repayVai } from 'clients/api';
 import toast from 'components/Basic/Toast';
+import { formatCoinsToReadableValue } from 'utilities/common';
 import { AuthContext } from 'context/AuthContext';
 import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
@@ -12,7 +13,11 @@ import RepayVai from '.';
 jest.mock('clients/api');
 jest.mock('components/Basic/Toast');
 
-const fakeUserVaiMinted = new BigNumber('100');
+const fakeUserVaiMinted = new BigNumber('1000000');
+const formattedFakeUserVaiMinted = formatCoinsToReadableValue({
+  value: fakeUserVaiMinted,
+  tokenSymbol: 'vai',
+});
 
 describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
   it('renders without crashing', async () => {
@@ -36,7 +41,7 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
     await waitFor(() => getByText('Repay VAI balance'));
 
     // Check user repay VAI balance displays correctly
-    await waitFor(() => getByText(`${fakeUserVaiMinted.toString()} VAI`));
+    await waitFor(() => getByText(formattedFakeUserVaiMinted));
   });
 
   it('lets user repay their VAI balance', async () => {
@@ -92,7 +97,7 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
     // Check success toast is requested
     expect(toast.success).toHaveBeenCalledTimes(1);
     expect(toast.success).toHaveBeenCalledWith({
-      title: `You successfully repaid\u00A0${fakeUserVaiMinted.toString()} VAI`,
+      title: `You successfully repaid ${formattedFakeUserVaiMinted}`,
     });
   });
 

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -80,7 +80,7 @@
       "btnMintVai": "Mint VAI",
       "mintFeeLabel": "Mint fee",
       "rightMaxButtonLabel": "SAFE MAX",
-      "successMessage": "You successfully minted\u00a0{{coin}}",
+      "successMessage": "You successfully minted {{tokens}}",
       "undefinedAccountErrorMessage": "account undefined",
       "vaiLimitLabel": "Available VAI limit"
     },
@@ -88,7 +88,7 @@
       "btnRepayVai": "Repay VAI",
       "repayVaiBalance": "Repay VAI balance",
       "rightMaxButtonLabel": "MAX",
-      "successMessage": "You successfully repaid\u00a0{{coin}}",
+      "successMessage": "You successfully repaid {{tokens}}",
       "undefinedAccountErrorMessage": "account undefined"
     },
     "tabMint": "Mint VAI",


### PR DESCRIPTION
I originally wanted `TokenTextField` to use a `BigNumber` value in wei of the token provided, but this unfortunately makes it impossible to enter values such as 0.01 (the value automatically gets formatted to 0 when typing 0.0).
For that reason, I had to update the implementation of the component so it uses strings, with a safeguard on the change handler so values with more decimals than the token associated to the token symbol provided has can't be entered.

Because of this change, I had to update the `MintRepayVai` component. I also spotted that the value displayed in the success message after minting or repaying VAI wasn't formatted properly, so I made the update.