### PR TITLE
Fix label of liquidity column on BorrowMarket

### DIFF
--- a/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
@@ -32,7 +32,7 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
       { key: 'asset', label: t('markets.columns.asset'), orderable: false },
       { key: 'apy', label: t('markets.columns.apy'), orderable: true },
       { key: 'wallet', label: t('markets.columns.wallet'), orderable: true },
-      { key: 'collateral', label: t('markets.columns.collateral'), orderable: true },
+      { key: 'liquidity', label: t('markets.columns.liquidity'), orderable: true },
     ],
     [],
   );

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -53,6 +53,7 @@
       "apy": "APY",
       "asset": "Asset",
       "collateral": "Collateral",
+      "liquidity": "Liquidity",
       "wallet": "Wallet"
     },
     "errors": {


### PR DESCRIPTION
The column header said "Collateral" instead of "Liquidity".