### PR TITLE
Pass MaterialUI props to Material UI component

### DIFF
--- a/src/components/v2/ProgressBarHorizontal/index.tsx
+++ b/src/components/v2/ProgressBarHorizontal/index.tsx
@@ -40,15 +40,15 @@ export const ProgressBarHorizontal = ({
   const renderMark = (props?: NonNullable<SliderTypeMap['props']['componentsProps']>['mark']) => {
     if (markTooltip) {
       return (
-        <span {...props} css={[styles.mark, styles.hasTooltip]}>
+        <Box component="span" css={[styles.mark, styles.hasTooltip]}>
           <Tooltip placement={tooltipPlacement} title={markTooltip}>
             <span css={styles.tooltipHelper}>.</span>
           </Tooltip>
-        </span>
+        </Box>
       );
     }
 
-    return <span {...props} css={styles.mark} />;
+    return <Box component="span" {...props} css={styles.mark} />;
   };
 
   const renderTrack = (props?: NonNullable<SliderTypeMap['props']['componentsProps']>['track']) => {


### PR DESCRIPTION
We were spreading props created by MaterialUI to the dom resulting in warnings that we were setting non-existant dom attributes.

This PR updates to spread the MaterialUI props to a Material UI component so they get used properly.