### PR TITLE
Prefer typescript no unused vars

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -4,14 +4,12 @@ module.exports = {
     node: true,
   },
   parser: '@typescript-eslint/parser',
-  plugins: ['import', 'react', 'jsx-a11y', 'prettier', 'unused-imports'],
+  plugins: ['import', 'react', 'jsx-a11y', 'prettier'],
   extends: ['airbnb', 'airbnb-typescript', 'plugin:@typescript-eslint/recommended'],
   parserOptions: {
     project: './tsconfig.eslint.json',
   },
   rules: {
-    'unused-imports/no-unused-imports': 2,
-    'unused-imports/no-unused-vars': 2,
     // handled by prettier
     '@typescript-eslint/space-before-blocks': 0,
     '@typescript-eslint/indent': 0,
@@ -51,6 +49,7 @@ module.exports = {
     ],
     // Custom
     'import/no-named-as-default': 0,
+    '@typescript-eslint/no-unused-vars': 2,
     '@typescript-eslint/member-delimiter-style': [
       'error',
       {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,6 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.28.0",
-    "eslint-plugin-unused-imports": "^2.0.0",
     "husky": "^7.0.4",
     "i18next-parser": "^6.3.0",
     "lint-staged": "^12.3.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9979,18 +9979,6 @@ eslint-plugin-testing-library@^3.9.2:
   dependencies:
     "@typescript-eslint/experimental-utils" "^3.10.1"
 
-eslint-plugin-unused-imports@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unused-imports/-/eslint-plugin-unused-imports-2.0.0.tgz#d8db8c4d0cfa0637a8b51ce3fd7d1b6bc3f08520"
-  integrity sha512-3APeS/tQlTrFa167ThtP0Zm0vctjr4M44HMpeg1P4bK6wItarumq0Ma82xorMKdFsWpphQBlRPzw/pxiVELX1A==
-  dependencies:
-    eslint-rule-composer "^0.3.0"
-
-eslint-rule-composer@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/eslint-rule-composer/-/eslint-rule-composer-0.3.0.tgz#79320c927b0c5c0d3d3d2b76c8b4a488f25bbaf9"
-  integrity sha512-bt+Sh8CtDmn2OajxvNO+BX7Wn4CIWMpTRm3MaiKPCQcnnlm0CS2mhui6QaoeQugs+3Kj2ESKEEGJUdVafwhiCg==
-
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
This PR removes `unused-imports` in favor of the built in typescript rules