### PR TITLE
Add step to TokenTextField to allow decimals

### DIFF
--- a/src/components/v2/TokenTextField/index.spec.tsx
+++ b/src/components/v2/TokenTextField/index.spec.tsx
@@ -44,6 +44,26 @@ describe('components/TokenTextField', () => {
     expect(onChangeMock).toHaveBeenCalledTimes(1);
   });
 
+  it('passes the correct max and step values down to the TextField component', async () => {
+    const oneWeiInXvs = new BigNumber(ONE_XVS).dividedBy(new BigNumber(10).pow(18));
+
+    const onChangeMock = jest.fn();
+    const { getByTestId } = renderComponent(
+      <TokenTextField
+        tokenSymbol="xvs"
+        onChange={onChangeMock}
+        value=""
+        data-testid={testId}
+        max={ONE_XVS}
+      />,
+    );
+
+    const input = getByTestId(testId) as HTMLInputElement;
+
+    expect(input.max).toBe(ONE_XVS);
+    expect(input.step).toBe(oneWeiInXvs.toFixed());
+  });
+
   it('renders max button and updates value to maxWei when pressing on it', async () => {
     const onChangeMock = jest.fn();
     const rightMaxButtonLabel = 'Test max button label';

--- a/src/components/v2/TokenTextField/index.tsx
+++ b/src/components/v2/TokenTextField/index.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
+import BigNumber from 'bignumber.js';
 
 import { TokenId } from 'types';
 import { getToken } from 'utilities';
@@ -27,6 +28,15 @@ export const TokenTextField: React.FC<ITokenTextFieldProps> = ({
   max,
   ...otherProps
 }) => {
+  const tokenDecimals = getToken(tokenSymbol).decimals;
+
+  const step = React.useMemo(() => {
+    const tmpOneCoinInWei = new BigNumber(10).pow(tokenDecimals);
+    const tmpOneWeiInCoins = new BigNumber(1).dividedBy(tmpOneCoinInWei);
+
+    return tmpOneWeiInCoins.toFixed();
+  }, [tokenSymbol]);
+
   const setMaxValue = () => {
     if (onChange && max) {
       onChange(max);
@@ -34,8 +44,7 @@ export const TokenTextField: React.FC<ITokenTextFieldProps> = ({
   };
 
   const handleChange: ITextFieldProps['onChange'] = ({ currentTarget: { value } }) => {
-    // Format value so it doesn't have more decimals places than the token has
-    const tokenDecimals = getToken(tokenSymbol).decimals;
+    // Forbid values with more decimals than the token provided supports
     const valueDecimals = value.includes('.') ? value.split('.')[1].length : 0;
 
     if (valueDecimals <= tokenDecimals) {
@@ -48,6 +57,7 @@ export const TokenTextField: React.FC<ITokenTextFieldProps> = ({
       placeholder="0.00"
       min={0}
       max={max}
+      step={step}
       onChange={handleChange}
       type="number"
       leftIconName={tokenSymbol as IconName}


### PR DESCRIPTION
So it turns out adding a `min` prop to an input without a `step` forbids using decimal numbers. This PR fixes that.