### PR TITLE
Prevent mobile menu from closing itself when clicking anywhere

### DIFF
--- a/src/components/v2/Layout/Sidebar/index.tsx
+++ b/src/components/v2/Layout/Sidebar/index.tsx
@@ -84,7 +84,6 @@ export const SidebarUi: React.FC<ISidebarProps> = () => {
           id="account-menu"
           open={open}
           onClose={closeMenu}
-          onClick={closeMenu}
           transitionDuration={0}
           marginThreshold={0}
           TransitionProps={{ style: { transition: 'background 0.2s linear' } }}
@@ -107,7 +106,7 @@ export const SidebarUi: React.FC<ISidebarProps> = () => {
                 css={[styles.listItem, styles.mobileListItem]}
                 disableRipple
               >
-                <NavLink to={href} activeClassName="active-mobile-menu-item">
+                <NavLink onClick={closeMenu} to={href} activeClassName="active-mobile-menu-item">
                   <div css={styles.mobileLabel}>
                     <ListItemIcon css={styles.listItemIcon}>
                       <Icon name={icon} />


### PR DESCRIPTION
This PR changes the UX of the mobile menu so that it closes itself when pressing on a navigation item only.
This is needed because currently it's closing itself when clicking anywhere, which has some unwanted behavior such as unmounting the "Claim XVS reward" and "Connect wallet" buttons when pressing on them, which cancels the queries the asynchronous functions they call and so prevents them from working.