### PR TITLE
Claim XVS updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,4 @@ public
 build
 storybook-static
 i18next-parser.config.js
+coverage

--- a/src/clients/api/mutations/useClaimXvsReward.ts
+++ b/src/clients/api/mutations/useClaimXvsReward.ts
@@ -29,10 +29,16 @@ const useClaimXvsReward = (options?: Options) => {
       }),
     {
       ...options,
-      onSuccess: (...onSuccessParams) => {
+      onSuccess: async (...onSuccessParams) => {
         // Trigger refetch of XVS reward
-        queryClient.invalidateQueries(FunctionKey.GET_MINTED_VAI);
-        queryClient.invalidateQueries(FunctionKey.GET_VENUS_ACCRUED);
+        await Promise.all([
+          queryClient.invalidateQueries(FunctionKey.GET_VENUS_VAI_MINTER_INDEX),
+          queryClient.invalidateQueries(FunctionKey.GET_VENUS_VAI_STATE),
+          queryClient.invalidateQueries(FunctionKey.GET_VENUS_ACCRUED),
+          queryClient.invalidateQueries(FunctionKey.GET_MINTED_VAI),
+          queryClient.invalidateQueries(FunctionKey.GET_VENUS_INITIAL_INDEX),
+        ]);
+
         queryClient.invalidateQueries(FunctionKey.GET_XVS_REWARD);
 
         if (options?.onSuccess) {

--- a/src/components/v2/BscLink/index.tsx
+++ b/src/components/v2/BscLink/index.tsx
@@ -20,7 +20,7 @@ export const BscLink: React.FC<IBscLinkProps> = ({ hash, className }) => {
     <div css={styles.container} className={className}>
       <Typography
         component="a"
-        href={generateBscScanUrl(hash)}
+        href={generateBscScanUrl(hash, 'tx')}
         target="_blank"
         rel="noreferrer"
         variant="small1"

--- a/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
+++ b/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
@@ -3,15 +3,15 @@ import { waitFor, fireEvent } from '@testing-library/react';
 import BigNumber from 'bignumber.js';
 
 import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
-import toast from 'components/Basic/Toast';
 import fakeAddress from '__mocks__/models/address';
 import renderComponent from 'testUtils/renderComponent';
 import { AuthContext } from 'context/AuthContext';
+import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { getXvsReward, claimXvsReward } from 'clients/api';
 import ClaimXvsRewardButton, { TEST_ID } from '.';
 
 jest.mock('clients/api');
-jest.mock('components/Basic/Toast');
+jest.mock('hooks/useSuccessfulTransactionModal');
 
 describe('pages/Dashboard/MintRepayVai', () => {
   it('renders without crashing', () => {
@@ -67,11 +67,11 @@ describe('pages/Dashboard/MintRepayVai', () => {
     expect(getByTestId(TEST_ID).textContent).toContain('10,000 XVS');
   });
 
-  it('it claims XVS reward on click and displays toast on success', async () => {
-    (getXvsReward as jest.Mock).mockImplementationOnce(
-      async () => new BigNumber('10000000000000000000000'),
-    );
+  it('it claims XVS reward on click and displays successful transaction modal on success', async () => {
+    const fakeXvsReward = new BigNumber('10000000000000000000000');
 
+    const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+    (getXvsReward as jest.Mock).mockImplementationOnce(async () => fakeXvsReward);
     (claimXvsReward as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
     const { getByTestId } = renderComponent(
@@ -97,6 +97,15 @@ describe('pages/Dashboard/MintRepayVai', () => {
 
     // Check claimXvsReward was called and success toast was displayed
     await waitFor(() => expect(claimXvsReward).toHaveBeenCalledTimes(1));
-    await waitFor(() => expect(toast.success).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(openSuccessfulTransactionModal).toHaveBeenCalledTimes(1));
+    expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
+      transactionHash: fakeTransactionReceipt.transactionHash,
+      amount: {
+        tokenSymbol: 'xvs',
+        valueWei: fakeXvsReward,
+      },
+      message: expect.any(String),
+      title: expect.any(String),
+    });
   });
 });

--- a/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
+++ b/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
@@ -4,6 +4,7 @@ import BigNumber from 'bignumber.js';
 
 import toast from 'components/Basic/Toast';
 import { AuthContext } from 'context/AuthContext';
+import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { useGetXvsReward, useClaimXvsReward } from 'clients/api';
 import { useTranslation } from 'translation';
 import { convertWeiToCoins } from 'utilities/common';
@@ -15,20 +16,45 @@ const XVS_SYMBOL = 'xvs';
 
 export const TEST_ID = 'claim-xvs-reward-button';
 
-export interface IClaimXvsRewardButton extends IButtonProps {
+export interface IClaimXvsRewardButton extends Omit<IButtonProps, 'onClick'> {
+  onClaim: () => Promise<string>;
   amountWei?: BigNumber;
 }
 
 export const ClaimXvsRewardButtonUi: React.FC<IClaimXvsRewardButton> = ({
   amountWei,
+  onClaim,
   ...otherProps
 }) => {
-  const { Trans } = useTranslation();
+  const { t, Trans } = useTranslation();
   const styles = useStyles();
+
+  const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
 
   if (!amountWei || amountWei.isEqualTo(0)) {
     return null;
   }
+
+  const handleClick = async () => {
+    try {
+      const transactionHash = await onClaim();
+
+      // Display successful transaction modal
+      openSuccessfulTransactionModal({
+        title: t('claimXvsRewardButton.successfulTransactionModal.title'),
+        message: t('claimXvsRewardButton.successfulTransactionModal.message'),
+        amount: {
+          valueWei: amountWei,
+          tokenSymbol: 'xvs',
+        },
+        transactionHash,
+      });
+    } catch (error) {
+      toast.error({
+        title: (error as Error).message,
+      });
+    }
+  };
 
   const readableAmount = convertWeiToCoins({
     value: amountWei,
@@ -37,7 +63,12 @@ export const ClaimXvsRewardButtonUi: React.FC<IClaimXvsRewardButton> = ({
   });
 
   return (
-    <SecondaryButton data-testid={TEST_ID} css={styles.button} {...otherProps}>
+    <SecondaryButton
+      data-testid={TEST_ID}
+      css={styles.button}
+      onClick={handleClick}
+      {...otherProps}
+    >
       <Trans
         i18nKey="claimXvsRewardButton.title"
         components={{
@@ -56,34 +87,25 @@ export const ClaimXvsRewardButton: React.FC<IButtonProps> = props => {
   const { data: xvsRewardWei } = useGetXvsReward(account?.address);
   const { t } = useTranslation();
 
-  const { mutate: claimXvsReward, isLoading: isClaimXvsRewardLoading } = useClaimXvsReward({
-    onError: error => {
-      toast.error({
-        title: error.message,
-      });
-    },
-    onSuccess: () => {
-      // @TODO: display success modal instead of toast once it's been
-      // implemented (see https://app.clickup.com/t/2849k4u)
-      toast.success({
-        title: t('claimXvsRewardButton.successMessage'),
-      });
-    },
-  });
+  const { mutateAsync: claimXvsReward, isLoading: isClaimXvsRewardLoading } = useClaimXvsReward();
 
-  const handleClick = () => {
-    if (account?.address) {
-      claimXvsReward({
-        fromAccountAddress: account.address,
-      });
+  const handleClaim = async () => {
+    if (!account?.address) {
+      throw new Error(t('claimXvsRewardButton.walletNotConnectedError'));
     }
+
+    const res = await claimXvsReward({
+      fromAccountAddress: account.address,
+    });
+
+    return res.transactionHash;
   };
 
   return (
     <ClaimXvsRewardButtonUi
       amountWei={xvsRewardWei}
       loading={isClaimXvsRewardLoading}
-      onClick={handleClick}
+      onClaim={handleClaim}
       {...props}
     />
   );

--- a/src/context/SuccessfulTransactionModalContext.tsx
+++ b/src/context/SuccessfulTransactionModalContext.tsx
@@ -1,7 +1,10 @@
 import React from 'react';
 import noop from 'noop-ts';
 
-import { SuccessfulTransactionModal, ISuccessfulTransactionModalProps } from 'components';
+import {
+  SuccessfulTransactionModal,
+  ISuccessfulTransactionModalProps,
+} from 'components/v2/SuccessfulTransactionModal';
 
 type OpenSuccessfulTransactionModalInput = Pick<
   ISuccessfulTransactionModalProps,
@@ -51,7 +54,7 @@ export const SuccessfulTransactionModalProvider: React.FC = ({ children }) => {
         closeSuccessfulTransactionModal,
       }}
     >
-      {!!modalProps && (
+      {modalProps && (
         <SuccessfulTransactionModal
           isOpened={isOpened}
           handleClose={closeSuccessfulTransactionModal}

--- a/src/hooks/__mocks__/useSuccessfulTransactionModal.ts
+++ b/src/hooks/__mocks__/useSuccessfulTransactionModal.ts
@@ -1,0 +1,7 @@
+const openSuccessfulTransactionModal = jest.fn();
+const closeSuccessfulTransactionModal = jest.fn();
+
+export default () => ({
+  openSuccessfulTransactionModal,
+  closeSuccessfulTransactionModal,
+});

--- a/src/hooks/useSuccessfulTransactionModal.ts
+++ b/src/hooks/useSuccessfulTransactionModal.ts
@@ -1,0 +1,5 @@
+import { useContext } from 'react';
+import { SuccessfulTransactionModalContext } from 'context/SuccessfulTransactionModalContext';
+
+const useSuccessfulTransactionModal = () => useContext(SuccessfulTransactionModalContext);
+export default useSuccessfulTransactionModal;

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -16,8 +16,12 @@
     "content": "View on bscscan.com<Icon/>"
   },
   "claimXvsRewardButton": {
-    "successMessage": "You've successfully claimed your XVS reward",
-    "title": "Claim <Icon/> {{amount}}"
+    "successfulTransactionModal": {
+      "message": "You successfully claimed",
+      "title": "Your claim was successful"
+    },
+    "title": "Claim <Icon/> {{amount}}",
+    "walletNotConnectedError": "Wallet not connected"
   },
   "connectButton": {
     "title": "Connect wallet"

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -129,7 +129,7 @@ export const formatCoinsToReadableValue = ({
 }) =>
   value === undefined
     ? PLACEHOLDER_KEY
-    : `${formatCommaThousandsPeriodDecimal(value.toString())} ${tokenSymbol.toUpperCase()}`;
+    : `${formatCommaThousandsPeriodDecimal(value.toFixed())} ${tokenSymbol.toUpperCase()}`;
 
 type IConvertWeiToCoinsOutput<T> = T extends true ? string : BigNumber;
 

--- a/src/utilities/generateBscScanUrl.ts
+++ b/src/utilities/generateBscScanUrl.ts
@@ -14,7 +14,7 @@ export const generateBscScanUrl = <T extends UrlType = 'address'>(
     suffix = getToken(identifier as TokenId).address;
   }
 
-  return `${BASE_BSC_SCAN_URL}/${urlType}/${suffix}`;
+  return `${BASE_BSC_SCAN_URL}/${urlType || 'address'}/${suffix}`;
 };
 
 export default generateBscScanUrl;

--- a/src/utilities/generateBscScanUrl.ts
+++ b/src/utilities/generateBscScanUrl.ts
@@ -8,13 +8,14 @@ export const generateBscScanUrl = <T extends UrlType = 'address'>(
   identifier: T extends 'token' ? TokenId : string,
   urlType?: T,
 ) => {
-  let suffix: string = identifier;
+  const safeUrlType = urlType || 'address';
 
-  if (urlType === 'token') {
+  let suffix: string = identifier;
+  if (safeUrlType === 'token') {
     suffix = getToken(identifier as TokenId).address;
   }
 
-  return `${BASE_BSC_SCAN_URL}/${urlType || 'address'}/${suffix}`;
+  return `${BASE_BSC_SCAN_URL}/${safeUrlType}/${suffix}`;
 };
 
 export default generateBscScanUrl;


### PR DESCRIPTION
- create `useSuccessfulTransactionModal` hook
- use `SuccessfulTransactionModal` to display success state after claiming XVS reward
- update invalidated queries list after claiming XVS reward
- fix default `urlType` param of `generateBscScanUrl`