### PR TITLE
Switch from tokenSymbol name to tokenId 

### DIFF
--- a/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
+++ b/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
@@ -101,7 +101,7 @@ describe('pages/Dashboard/MintRepayVai', () => {
     expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
       transactionHash: fakeTransactionReceipt.transactionHash,
       amount: {
-        tokenSymbol: 'xvs',
+        tokenId: 'xvs',
         valueWei: fakeXvsReward,
       },
       message: expect.any(String),

--- a/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
+++ b/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
@@ -7,6 +7,7 @@ import { AuthContext } from 'context/AuthContext';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { useGetXvsReward, useClaimXvsReward } from 'clients/api';
 import { useTranslation } from 'translation';
+import { TokenId } from 'types';
 import { convertWeiToCoins } from 'utilities/common';
 import { Icon } from '../../Icon';
 import { SecondaryButton, IButtonProps } from '../../Button';
@@ -45,7 +46,7 @@ export const ClaimXvsRewardButtonUi: React.FC<IClaimXvsRewardButton> = ({
         message: t('claimXvsRewardButton.successfulTransactionModal.message'),
         amount: {
           valueWei: amountWei,
-          tokenSymbol: 'xvs',
+          tokenId: 'xvs' as TokenId,
         },
         transactionHash,
       });
@@ -58,7 +59,7 @@ export const ClaimXvsRewardButtonUi: React.FC<IClaimXvsRewardButton> = ({
 
   const readableAmount = convertWeiToCoins({
     value: amountWei,
-    tokenSymbol: XVS_SYMBOL,
+    tokenId: XVS_SYMBOL,
     returnInReadableFormat: true,
   });
 

--- a/src/components/v2/SuccessfulTransactionModal/index.stories.tsx
+++ b/src/components/v2/SuccessfulTransactionModal/index.stories.tsx
@@ -3,7 +3,7 @@ import noop from 'noop-ts';
 
 import BigNumber from 'bignumber.js';
 import { ComponentMeta } from '@storybook/react';
-
+import { TokenId } from 'types';
 import { withCenterStory, withThemeProvider } from 'stories/decorators';
 import { SuccessfulTransactionModal } from '.';
 
@@ -22,7 +22,7 @@ export const InModal = () => (
     transactionHash="0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63"
     amount={{
       valueWei: new BigNumber('100000000000000000000'),
-      tokenSymbol: 'xvs',
+      tokenId: 'xvs' as TokenId,
     }}
   />
 );

--- a/src/components/v2/SuccessfulTransactionModal/index.tsx
+++ b/src/components/v2/SuccessfulTransactionModal/index.tsx
@@ -15,7 +15,7 @@ export interface ISuccessfulTransactionModalProps extends Omit<IModalProps, 'chi
   message: string;
   transactionHash: string;
   amount?: {
-    tokenSymbol: TokenId;
+    tokenId: TokenId;
     valueWei: BigNumber;
   };
   className?: string;
@@ -46,12 +46,12 @@ export const SuccessfulTransactionModal: React.FC<ISuccessfulTransactionModalPro
 
           {amount && (
             <div css={styles.amountContainer}>
-              <Icon name={amount.tokenSymbol as IconName} css={styles.amountTokenIcon} />
+              <Icon name={amount.tokenId as IconName} css={styles.amountTokenIcon} />
 
               <Typography variant="small1" component="span">
                 {convertWeiToCoins({
                   value: amount.valueWei,
-                  tokenSymbol: amount.tokenSymbol,
+                  tokenId: amount.tokenId,
                   returnInReadableFormat: true,
                 })}
               </Typography>

--- a/src/components/v2/TokenTextField/index.spec.tsx
+++ b/src/components/v2/TokenTextField/index.spec.tsx
@@ -12,13 +12,13 @@ const testId = 'token-text-field-input';
 
 describe('components/TokenTextField', () => {
   it('renders without crashing', async () => {
-    renderComponent(<TokenTextField tokenSymbol="xvs" onChange={noop} value="" />);
+    renderComponent(<TokenTextField tokenId="xvs" onChange={noop} value="" />);
   });
 
   it('does not let user enter value with more decimal places than token associated to tokenSymbol provided has', async () => {
     const onChangeMock = jest.fn();
     const { getByTestId } = renderComponent(
-      <TokenTextField tokenSymbol="xvs" onChange={onChangeMock} value="" data-testid={testId} />,
+      <TokenTextField tokenId="xvs" onChange={onChangeMock} value="" data-testid={testId} />,
     );
 
     const input = getByTestId(testId) as HTMLInputElement;
@@ -50,7 +50,7 @@ describe('components/TokenTextField', () => {
     const onChangeMock = jest.fn();
     const { getByTestId } = renderComponent(
       <TokenTextField
-        tokenSymbol="xvs"
+        tokenId="xvs"
         onChange={onChangeMock}
         value=""
         data-testid={testId}
@@ -70,7 +70,7 @@ describe('components/TokenTextField', () => {
 
     const { getByText } = renderComponent(
       <TokenTextField
-        tokenSymbol="xvs"
+        tokenId="xvs"
         onChange={onChangeMock}
         value=""
         data-testid={testId}

--- a/src/components/v2/TokenTextField/index.stories.tsx
+++ b/src/components/v2/TokenTextField/index.stories.tsx
@@ -21,11 +21,7 @@ const initialData: { value: string } = { value: '' };
 export const Default = () => (
   <State initial={initialData}>
     {({ state, setState }) => (
-      <TokenTextField
-        tokenSymbol="usdt"
-        value={state.value}
-        onChange={value => setState({ value })}
-      />
+      <TokenTextField tokenId="usdt" value={state.value} onChange={value => setState({ value })} />
     )}
   </State>
 );
@@ -34,7 +30,7 @@ export const WithMaxTokens = () => (
   <State initial={initialData}>
     {({ state, setState }) => (
       <TokenTextField
-        tokenSymbol="xvs"
+        tokenId="xvs"
         value={state.value}
         onChange={value => setState({ value })}
         max="10"
@@ -47,7 +43,7 @@ export const WithRightMaxButtonLabel = () => (
   <State initial={initialData}>
     {({ state, setState }) => (
       <TokenTextField
-        tokenSymbol="usdt"
+        tokenId="usdt"
         value={state.value}
         onChange={value => setState({ value })}
         max="10"

--- a/src/components/v2/TokenTextField/index.tsx
+++ b/src/components/v2/TokenTextField/index.tsx
@@ -13,7 +13,7 @@ import { TextField, ITextFieldProps } from '../TextField';
 // expressed in wei to make them easier to use with contracts
 export interface ITokenTextFieldProps
   extends Omit<ITextFieldProps, 'onChange' | 'value' | 'max' | 'min'> {
-  tokenSymbol: TokenId;
+  tokenId: TokenId;
   value: string;
   onChange: (newValue: string) => void;
   rightMaxButtonLabel?: string;
@@ -21,21 +21,21 @@ export interface ITokenTextFieldProps
 }
 
 export const TokenTextField: React.FC<ITokenTextFieldProps> = ({
-  tokenSymbol,
+  tokenId,
   rightMaxButtonLabel,
   onChange,
   disabled,
   max,
   ...otherProps
 }) => {
-  const tokenDecimals = getToken(tokenSymbol).decimals;
+  const tokenDecimals = getToken(tokenId).decimals;
 
   const step = React.useMemo(() => {
     const tmpOneCoinInWei = new BigNumber(10).pow(tokenDecimals);
     const tmpOneWeiInCoins = new BigNumber(1).dividedBy(tmpOneCoinInWei);
 
     return tmpOneWeiInCoins.toFixed();
-  }, [tokenSymbol]);
+  }, [tokenId]);
 
   const setMaxValue = () => {
     if (onChange && max) {
@@ -60,7 +60,7 @@ export const TokenTextField: React.FC<ITokenTextFieldProps> = ({
       step={step}
       onChange={handleChange}
       type="number"
-      leftIconName={tokenSymbol as IconName}
+      leftIconName={tokenId as IconName}
       rightAdornment={
         rightMaxButtonLabel && onChange && max ? (
           <TertiaryButton onClick={setMaxValue} small disabled={disabled}>

--- a/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
@@ -57,7 +57,7 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
         render: () =>
           formatCoinsToReadableValue({
             value: asset.walletBalance,
-            tokenSymbol: asset.symbol as TokenId,
+            tokenId: asset.id as TokenId,
           }),
         value: asset.walletBalance.toString(),
       },

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -77,7 +77,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketUiProps> = ({
       render: () =>
         formatCoinsToReadableValue({
           value: asset.walletBalance,
-          tokenSymbol: asset.symbol as TokenId,
+          tokenId: asset.symbol as TokenId,
         }),
       value: asset.walletBalance.toString(),
     },

--- a/src/pages/Dashboard/MintRepayVai/MintVai/getReadableFeeVai.ts
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/getReadableFeeVai.ts
@@ -1,7 +1,7 @@
 import BigNumber from 'bignumber.js';
 
 import { convertWeiToCoins } from 'utilities/common';
-import { VAI_SYMBOL } from '../constants';
+import { VAI_ID } from '../constants';
 
 const getReadableFeeVai = ({
   valueWei,
@@ -13,7 +13,7 @@ const getReadableFeeVai = ({
   const feeWei = new BigNumber(valueWei || 0).multipliedBy(mintFeePercentage).dividedBy(100);
   return convertWeiToCoins({
     value: feeWei,
-    tokenSymbol: VAI_SYMBOL,
+    tokenId: VAI_ID,
     returnInReadableFormat: true,
   });
 };

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('components/Basic/Toast');
 const fakeMintableVai = new BigNumber('1000');
 const formattedFakeUserVaiMinted = formatCoinsToReadableValue({
   value: fakeMintableVai,
-  tokenSymbol: 'vai',
+  tokenId: 'vai',
 });
 const fakeVaiTreasuryPercentage = 7.19;
 

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
@@ -12,7 +12,7 @@ import { useGetVaiTreasuryPercentage, useMintVai } from 'clients/api';
 import toast from 'components/Basic/Toast';
 import { useTranslation } from 'translation';
 import useConvertToReadableCoinString from '../useConvertToReadableCoinString';
-import { VAI_SYMBOL } from '../constants';
+import { VAI_ID } from '../constants';
 import getReadableFeeVai from './getReadableFeeVai';
 import { useStyles } from '../styles';
 
@@ -35,15 +35,14 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
   const { t } = useTranslation();
 
   const limitTokens = React.useMemo(
-    () =>
-      limitWei ? convertWeiToCoins({ value: limitWei, tokenSymbol: VAI_SYMBOL }).toString() : '0',
+    () => (limitWei ? convertWeiToCoins({ value: limitWei, tokenId: VAI_ID }).toString() : '0'),
     [limitWei?.toString()],
   );
 
   // Convert limit into VAI
   const readableVaiLimit = useConvertToReadableCoinString({
     valueWei: limitWei,
-    tokenSymbol: VAI_SYMBOL,
+    tokenId: VAI_ID,
   });
 
   const hasMintableVai = limitWei?.isGreaterThan(0) || false;
@@ -68,7 +67,7 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
 
     const amountWei = convertCoinsToWei({
       value: formattedAmountTokens,
-      tokenSymbol: VAI_SYMBOL,
+      tokenId: VAI_ID,
     });
 
     try {
@@ -79,7 +78,7 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
       // implemented
       const readableAmountTokens = formatCoinsToReadableValue({
         value: formattedAmountTokens,
-        tokenSymbol: VAI_SYMBOL,
+        tokenId: VAI_ID,
       });
 
       toast.success({
@@ -98,7 +97,7 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
             <TokenTextField
               name="amount"
               css={styles.textField}
-              tokenSymbol={VAI_SYMBOL}
+              tokenId={VAI_ID}
               value={values.amount}
               onChange={amount => setFieldValue('amount', amount, true)}
               onBlur={handleBlur}
@@ -109,7 +108,7 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
 
             <LabeledInlineContent
               css={styles.getRow({ isLast: false })}
-              iconName={VAI_SYMBOL}
+              iconName={VAI_ID}
               label={t('mintRepayVai.mintVai.vaiLimitLabel')}
             >
               {readableVaiLimit}
@@ -150,7 +149,7 @@ const MintVai: React.FC = () => {
 
   // Convert limit into wei of VAI
   const limitWei = React.useMemo(
-    () => convertCoinsToWei({ value: mintableVai, tokenSymbol: VAI_SYMBOL }),
+    () => convertCoinsToWei({ value: mintableVai, tokenId: VAI_ID }),
     [mintableVai.toString()],
   );
 

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -16,7 +16,7 @@ jest.mock('components/Basic/Toast');
 const fakeUserVaiMinted = new BigNumber('1000000');
 const formattedFakeUserVaiMinted = formatCoinsToReadableValue({
   value: fakeUserVaiMinted,
-  tokenSymbol: 'vai',
+  tokenId: 'vai',
 });
 
 describe('pages/Dashboard/MintRepayVai/RepayVai', () => {

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
@@ -12,7 +12,7 @@ import { useRepayVai } from 'clients/api';
 import toast from 'components/Basic/Toast';
 import { useTranslation } from 'translation';
 import useConvertToReadableCoinString from '../useConvertToReadableCoinString';
-import { VAI_SYMBOL } from '../constants';
+import { VAI_ID } from '../constants';
 import { useStyles } from '../styles';
 
 export interface IRepayVaiUiProps {
@@ -39,13 +39,13 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
         ? BigNumber.minimum(userBalanceWei, userMintedWei)
         : new BigNumber(0);
 
-    return convertWeiToCoins({ value: limitWei, tokenSymbol: VAI_SYMBOL }).toString();
+    return convertWeiToCoins({ value: limitWei, tokenId: VAI_ID }).toString();
   }, [userBalanceWei?.toString(), userMintedWei?.toString()]);
 
   // Convert minted wei into VAI
   const readableRepayableVai = useConvertToReadableCoinString({
     valueWei: userMintedWei,
-    tokenSymbol: VAI_SYMBOL,
+    tokenId: VAI_ID,
   });
 
   const hasRepayableVai = userMintedWei?.isGreaterThan(0) || false;
@@ -55,7 +55,7 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
 
     const amountWei = convertCoinsToWei({
       value: formattedAmountTokens,
-      tokenSymbol: VAI_SYMBOL,
+      tokenId: VAI_ID,
     });
 
     try {
@@ -66,7 +66,7 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
       // implemented
       const readableAmountTokens = formatCoinsToReadableValue({
         value: formattedAmountTokens,
-        tokenSymbol: VAI_SYMBOL,
+        tokenId: VAI_ID,
       });
 
       toast.success({
@@ -87,7 +87,7 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
             <TokenTextField
               name="amount"
               css={styles.textField}
-              tokenSymbol={VAI_SYMBOL}
+              tokenId={VAI_ID}
               value={values.amount}
               onChange={amount => setFieldValue('amount', amount, true)}
               onBlur={handleBlur}
@@ -98,7 +98,7 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
 
             <LabeledInlineContent
               css={styles.getRow({ isLast: true })}
-              iconName={VAI_SYMBOL}
+              iconName={VAI_ID}
               label={t('mintRepayVai.repayVai.repayVaiBalance')}
             >
               {readableRepayableVai}
@@ -128,13 +128,13 @@ const RepayVai: React.FC = () => {
 
   // Convert minted VAI balance into wei of VAI
   const userMintedWei = React.useMemo(
-    () => convertCoinsToWei({ value: userVaiMinted, tokenSymbol: VAI_SYMBOL }),
+    () => convertCoinsToWei({ value: userVaiMinted, tokenId: VAI_ID }),
     [userVaiMinted.toString()],
   );
 
   // Convert user VAI balance into wei of VAI
   const userBalanceWei = React.useMemo(
-    () => convertCoinsToWei({ value: userVaiBalance, tokenSymbol: VAI_SYMBOL }),
+    () => convertCoinsToWei({ value: userVaiBalance, tokenId: VAI_ID }),
     [userVaiBalance.toString()],
   );
 

--- a/src/pages/Dashboard/MintRepayVai/constants.ts
+++ b/src/pages/Dashboard/MintRepayVai/constants.ts
@@ -1,1 +1,1 @@
-export const VAI_SYMBOL = 'vai';
+export const VAI_ID = 'vai';

--- a/src/pages/Dashboard/MintRepayVai/useConvertToReadableCoinString.ts
+++ b/src/pages/Dashboard/MintRepayVai/useConvertToReadableCoinString.ts
@@ -5,10 +5,10 @@ import { TokenId } from 'types';
 import { convertWeiToCoins } from 'utilities/common';
 
 const useConvertToReadableCoinString = ({
-  tokenSymbol,
+  tokenId,
   valueWei,
 }: {
-  tokenSymbol: TokenId;
+  tokenId: TokenId;
   valueWei?: BigNumber;
 }) =>
   useMemo(
@@ -16,7 +16,7 @@ const useConvertToReadableCoinString = ({
       valueWei
         ? convertWeiToCoins({
             value: valueWei,
-            tokenSymbol,
+            tokenId,
             returnInReadableFormat: true,
           }).toString()
         : '-',

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -71,7 +71,7 @@ export const SupplyWithdrawContent: React.FC<
     if (tokenPrice && validAmount) {
       const amountInUsd = convertWeiToCoins({
         value: amount as BigNumber,
-        tokenSymbol: asset.id,
+        tokenId: asset.id,
       })
         .times(tokenPrice)
         .times(collateralFactor);
@@ -86,7 +86,7 @@ export const SupplyWithdrawContent: React.FC<
     <>
       <TokenTextField
         name="amount"
-        tokenSymbol={assetId as TokenId}
+        tokenId={assetId as TokenId}
         value={amountString}
         onChange={amt => setFieldValue('amount', amt, true)}
         max={maxInput.toString()}

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -122,46 +122,38 @@ export const format = (bigNumber: BigNumber, dp = 2) =>
 
 export const formatCoinsToReadableValue = ({
   value,
-  tokenSymbol,
+  tokenId,
 }: {
   value: BigNumber | undefined;
-  tokenSymbol: TokenId;
+  tokenId: TokenId;
 }) =>
   value === undefined
     ? PLACEHOLDER_KEY
-    : `${formatCommaThousandsPeriodDecimal(value.toFixed())} ${tokenSymbol.toUpperCase()}`;
+    : `${formatCommaThousandsPeriodDecimal(value.toFixed())} ${tokenId.toUpperCase()}`;
 
 type IConvertWeiToCoinsOutput<T> = T extends true ? string : BigNumber;
 
 export function convertWeiToCoins<T extends boolean | undefined = false>({
   value,
-  tokenSymbol,
+  tokenId,
   returnInReadableFormat = false,
 }: {
   value: BigNumber;
-  tokenSymbol: TokenId;
+  tokenId: TokenId;
   returnInReadableFormat?: T;
 }): IConvertWeiToCoinsOutput<T> {
-  const tokenDecimals = getToken(tokenSymbol).decimals;
+  const tokenDecimals = getToken(tokenId).decimals;
   const valueCoins = value
     .dividedBy(new BigNumber(10).pow(tokenDecimals))
     .decimalPlaces(tokenDecimals);
 
   return (
-    returnInReadableFormat
-      ? formatCoinsToReadableValue({ value: valueCoins, tokenSymbol })
-      : valueCoins
+    returnInReadableFormat ? formatCoinsToReadableValue({ value: valueCoins, tokenId }) : valueCoins
   ) as IConvertWeiToCoinsOutput<T>;
 }
 
-export const convertCoinsToWei = ({
-  value,
-  tokenSymbol,
-}: {
-  value: BigNumber;
-  tokenSymbol: TokenId;
-}) => {
-  const tokenDecimals = getToken(tokenSymbol).decimals;
+export const convertCoinsToWei = ({ value, tokenId }: { value: BigNumber; tokenId: TokenId }) => {
+  const tokenDecimals = getToken(tokenId).decimals;
   return value.multipliedBy(new BigNumber(10).pow(tokenDecimals));
 };
 


### PR DESCRIPTION
This Pr cleans up argument label `tokenSymbol` to be more accurately named `tokenId` since we use `asset.id` to identify the asset and `token.symbol` to display it