### PR TITLE
Custom contract error

### DIFF
--- a/src/clients/contracts/getters.ts
+++ b/src/clients/contracts/getters.ts
@@ -36,12 +36,15 @@ import {
   VrtVault,
   VrtConverter,
 } from 'types/contracts';
-import { getContractAddress, getToken, getVBepToken } from 'utilities';
+import { getContractAddress, getToken, getVBepToken, setupContractErrorHandling } from 'utilities';
 import { TokenContract, VTokenContract } from './types';
 
-const getContract = <T>(abi: AbiItem | AbiItem[], address: string, web3Instance: Web3) => {
+const getContract = <T>(abi: AbiItem[], address: string, web3Instance: Web3) => {
   const web3 = web3Instance ?? getWeb3NoAccount();
-  return new web3.eth.Contract(abi, address) as unknown as T;
+  // @ts-expect-error There is a clash between this base class and the extended class we return
+  const Contract = setupContractErrorHandling(web3.eth.Contract);
+  const contract = new Contract(abi, address) as unknown as T;
+  return contract;
 };
 
 export const getTokenContract = <T extends TokenId>(tokenId: T, web3: Web3): TokenContract<T> => {

--- a/src/utilities/errors.ts
+++ b/src/utilities/errors.ts
@@ -9,3 +9,59 @@ export class ToastError extends Error {
     this.description = description;
   }
 }
+
+interface ContractRequest {
+  arguments: Record<string, string>;
+}
+interface ContractResponse {
+  receipt: string | undefined;
+  reason: string | undefined;
+  signature: string | undefined;
+}
+
+/**
+ * Create an Error modeled after the Axios error with the specified message, config, error code, request and response.
+ *
+ * @param {string} message The error message.
+ * @param {string} [code] The error code.
+ * @param {Object} [config] The config.
+ * @param {Object} [request] The request.
+ * @param {Object} [response] The response.
+ */
+export class ContractError extends Error {
+  config: Record<string, unknown> | undefined;
+
+  code?: string | undefined;
+
+  request?: ContractRequest;
+
+  response?: ContractResponse;
+  // isAxiosError: boolean;
+
+  constructor(
+    message: string,
+    code: string | undefined,
+    config?: Record<string, unknown>,
+    request?: ContractRequest,
+    response?: ContractResponse,
+  ) {
+    super(message);
+    this.message = message;
+    this.code = code;
+    this.config = config;
+    this.request = request;
+    this.response = response;
+  }
+
+  toJSON = () => ({
+    // Standard
+    message: this.message,
+    name: this.name,
+    stack: this.stack,
+    // Contract
+    config: this.config,
+    code: this.code,
+    request: this.request,
+    response: this.response,
+  });
+}

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -10,3 +10,4 @@ export {
   calculateYearlyEarningsForAssets,
   calculateYearlyEarningsCents,
 } from './calculateYearlyEarnings';
+export { default as setupContractErrorHandling } from './setupContractErrorHandling';

--- a/src/utilities/setupContractErrorHandling.ts
+++ b/src/utilities/setupContractErrorHandling.ts
@@ -1,0 +1,69 @@
+import type { Contract } from 'web3-eth-contract';
+import { AbiItem } from 'web3-utils';
+import { ContractError } from './errors';
+
+interface TransactionError {
+  receipt: string;
+  message: string;
+}
+
+interface ConnectionError {
+  message: string;
+  code: string;
+  reason: string;
+}
+
+interface RevertInstructionError {
+  message: string;
+  signature: string;
+  reason: string;
+}
+
+interface TransactionRevertInstructionError {
+  message: string;
+  signature: string;
+  reason: string;
+  receipt: string;
+}
+
+const setupContractErrorHandling = (DefaultContract: typeof Contract) => {
+  class ExecuteContract extends DefaultContract {
+    _options: Record<string, unknown> | undefined; // eslint-disable-line no-underscore-dangle
+
+    constructor(jsonInterface: AbiItem[], address: string, options?: Record<string, unknown>) {
+      // eslint-disable-line @typescript-eslint/no-useless-constructor
+      super(jsonInterface, address, options);
+      this._options = options; // eslint-disable-line no-underscore-dangle
+    }
+
+    // eslint-disable-next-line no-underscore-dangle
+    _executeMethod(...args: any) {
+      // @ts-expect-error _executeMethod is set on Web3.eth.Contract Function
+      const oldExecute = DefaultContract.prototype._executeMethod; // eslint-disable-line no-underscore-dangle
+      try {
+        return oldExecute.call(this, ...args);
+      } catch (err) {
+        const e = err as
+          | Error
+          | TransactionError
+          | ConnectionError
+          | RevertInstructionError
+          | TransactionRevertInstructionError;
+        const request = {
+          // @ts-expect-error property setup on the Web3.eth.Contract Function
+          arguments: this.arguments,
+        };
+        const response = {
+          receipt: 'receipt' in e ? e.receipt : undefined,
+          reason: 'reason' in e ? e.reason : undefined,
+          signature: 'signature' in e ? e.signature : undefined,
+        };
+        const code = 'code' in e ? e.code : undefined;
+        throw new ContractError(e.message, code, this._options, request, response); // eslint-disable-line no-underscore-dangle
+      }
+    }
+  }
+  return ExecuteContract;
+};
+
+export default setupContractErrorHandling;


### PR DESCRIPTION
This PR moves us in the direction of creating a standard error to be used by the application for all services. Since we plan on using axios for http requests in the future, this PR adds an custom error for contracts modeled after Axios

The call to contracts is done through the `_exectuteMethod` functions. To create a custom error decorate (override) this function by wrapping it in a try catch and creating our custom error from a thrown error