### PR TITLE
Fix how last tab is defined on Tabs component

### DIFF
--- a/src/components/v2/Tabs/index.tsx
+++ b/src/components/v2/Tabs/index.tsx
@@ -54,7 +54,7 @@ export const Tabs = ({
             onClick={() => handleChange(index)}
             css={styles.getButton({
               active: index === activeTabIndex,
-              last: index === title.length - 1,
+              last: index === tabsContent.length - 1,
               fullWidth: !componentTitle,
             })}
           >


### PR DESCRIPTION
The `Tabs` component was using the wrong prop to define which tab is the last.