### PR TITLE
ProgressBar - add secondary rail when tooltip is present

### DIFF
--- a/src/components/v2/ProgressBar/index.stories.tsx
+++ b/src/components/v2/ProgressBar/index.stories.tsx
@@ -49,6 +49,8 @@ export const SecondaryValueOverProgressBar = () => (
     step={10}
     mark={75}
     ariaLabel="Storybook slider"
+    trackTooltip="Storybook tooltip text for Track"
+    markTooltip="Storybook tooltip text for Mark"
     min={0}
     max={100}
   />

--- a/src/components/v2/ProgressBar/index.tsx
+++ b/src/components/v2/ProgressBar/index.tsx
@@ -34,9 +34,11 @@ export const ProgressBar = ({
   className,
   tooltipPlacement = 'top',
 }: IProgressBarProps) => {
+  const safeValue = value < max ? value : max;
+
   const marks = mark ? [{ value: mark }] : undefined;
   const styles = useStyles({
-    over: mark ? value > mark : false,
+    over: mark ? safeValue > mark : false,
     secondaryOver: mark ? !!(secondaryValue && secondaryValue > mark) : false,
   });
 
@@ -69,7 +71,14 @@ export const ProgressBar = ({
     return (
       <>
         {primaryRail}
-        <Box css={styles.secondaryRail(secondaryValue)} {...props} style={undefined} />
+
+        {secondaryValue !== undefined && (
+          <Box
+            css={styles.secondaryRail(secondaryValue < max ? secondaryValue : max)}
+            {...props}
+            style={undefined}
+          />
+        )}
       </>
     );
   };
@@ -83,7 +92,7 @@ export const ProgressBar = ({
         Mark: mark ? renderMark : undefined,
         Track: renderTrack,
       }}
-      value={value}
+      value={safeValue}
       marks={marks}
       step={step}
       aria-label={ariaLabel}

--- a/src/components/v2/ProgressBar/index.tsx
+++ b/src/components/v2/ProgressBar/index.tsx
@@ -55,20 +55,20 @@ export const ProgressBar = ({
   };
 
   const renderTrack = (props?: NonNullable<SliderTypeMap['props']['componentsProps']>['track']) => {
-    if (trackTooltip) {
-      return (
-        <div style={props?.style} css={[styles.trackWrapper, styles.hasTooltip]}>
-          <Tooltip placement={tooltipPlacement} title={trackTooltip}>
-            {/* passed styles undefined here because wrapper is now handling this part */}
-            <Box {...props} style={undefined} />
-          </Tooltip>
-        </div>
-      );
-    }
+    const primaryRail = trackTooltip ? (
+      <div style={props?.style} css={[styles.trackWrapper, styles.hasTooltip]}>
+        <Tooltip placement={tooltipPlacement} title={trackTooltip}>
+          {/* passed styles undefined here because wrapper is now handling this part */}
+          <Box {...props} style={undefined} />
+        </Tooltip>
+      </div>
+    ) : (
+      <Box css={styles.trackWrapper} {...props} />
+    );
 
     return (
       <>
-        <Box css={styles.trackWrapper} {...props} />
+        {primaryRail}
         <Box css={styles.secondaryRail(secondaryValue)} {...props} style={undefined} />
       </>
     );


### PR DESCRIPTION
The track tooltip was not being displayed when a secondary trail was present.
This PR also adds a safety guard for `value` and `secondaryValue` so they don't overflow.