### PR TITLE
Update color of inline values on AccountHealth

### DIFF
--- a/src/components/v2/ProgressBar/AccountHealth/index.tsx
+++ b/src/components/v2/ProgressBar/AccountHealth/index.tsx
@@ -62,7 +62,7 @@ export const AccountHealth: React.FC<IAccountHealthProps> = ({
               : t('accountHealth.borrowLimitUsed')}
           </Typography>
 
-          <Typography component="span" variant="small1" color="text.borrowBalance">
+          <Typography component="span" variant="small1" css={styles.inlineValue}>
             {variant === 'borrowBalance'
               ? readableBorrowBalance
               : readableBorrowLimitUsedPercentage}
@@ -74,7 +74,7 @@ export const AccountHealth: React.FC<IAccountHealthProps> = ({
             {variant === 'borrowBalance' ? t('accountHealth.max') : t('accountHealth.limit')}
           </Typography>
 
-          <Typography component="span" variant="small1" color="text.borrowBalance">
+          <Typography component="span" variant="small1" css={styles.inlineValue}>
             {readableBorrowLimit}
           </Typography>
         </div>

--- a/src/components/v2/ProgressBar/AccountHealth/styles.ts
+++ b/src/components/v2/ProgressBar/AccountHealth/styles.ts
@@ -17,5 +17,8 @@ export const useStyles = () => {
     inlineLabel: css`
       margin-right: ${theme.spacing(1)};
     `,
+    inlineValue: css`
+      color: ${theme.palette.text.primary};
+    `,
   };
 };


### PR DESCRIPTION
The values were displayed in grey instead of white:
<img width="519" alt="Screen Shot 2022-04-27 at 09 44 18" src="https://user-images.githubusercontent.com/44675210/165478967-874b1ce6-f60f-45de-bd22-8de826dbedf9.png">
