### PR TITLE
Add shorthand readable value for tables

### DIFF
--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -45,6 +45,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketUiProps> = ({ assets, isXvsEnable
           formatCoinsToReadableValue({
             value: asset.walletBalance,
             tokenId: asset.id as TokenId,
+            shorthand: true,
           }),
         value: asset.walletBalance.toString(),
       },

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
@@ -63,6 +63,7 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
               {formatCoinsToReadableValue({
                 value: asset.borrowBalance,
                 tokenId: asset.id as TokenId,
+                shorthand: true,
               })}
             </Typography>
           </span>

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -52,6 +52,7 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
         formatCoinsToReadableValue({
           value: asset.supplyBalance,
           tokenId: asset.symbol as TokenId,
+          shorthand: true,
         }),
       value: asset.supplyBalance.toString(),
     },

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -52,6 +52,7 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
         formatCoinsToReadableValue({
           value: asset.walletBalance,
           tokenId: asset.symbol as TokenId,
+          shorthand: true,
         }),
       value: asset.walletBalance.toString(),
     },

--- a/src/utilities/common.spec.ts
+++ b/src/utilities/common.spec.ts
@@ -1,0 +1,30 @@
+import BigNumber from 'bignumber.js';
+import { formatCoinsToReadableValue } from './common';
+
+describe('utilities/formatCoinsToReadableValue', () => {
+  test('formats longhand value correctly', () => {
+    const value = formatCoinsToReadableValue({
+      value: new BigNumber(100000.12333334),
+      tokenId: 'busd',
+    });
+    expect(value).toBe('100,000.12333334 BUSD');
+  });
+
+  test('formats shorthand value correctly great than 1', () => {
+    const value = formatCoinsToReadableValue({
+      value: new BigNumber(1000.1234),
+      tokenId: 'eth',
+      shorthand: true,
+    });
+    expect(value).toBe('1,000.12 ETH');
+  });
+
+  test('formats shorthand value correctly less than 1', () => {
+    const value = formatCoinsToReadableValue({
+      value: new BigNumber(0.1234),
+      tokenId: 'ada',
+      shorthand: true,
+    });
+    expect(value).toBe('0.1234 ADA');
+  });
+});

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -123,13 +123,21 @@ export const format = (bigNumber: BigNumber, dp = 2) =>
 export const formatCoinsToReadableValue = ({
   value,
   tokenId,
+  shorthand = false,
 }: {
   value: BigNumber | undefined;
   tokenId: TokenId;
-}) =>
-  value === undefined
-    ? PLACEHOLDER_KEY
-    : `${formatCommaThousandsPeriodDecimal(value.toFixed())} ${tokenId.toUpperCase()}`;
+  shorthand?: boolean;
+}) => {
+  if (value === undefined) {
+    return PLACEHOLDER_KEY;
+  }
+  let valueString = parseFloat(value.toFixed(8)).toString();
+  if (shorthand && value.gt(1)) {
+    valueString = parseFloat(value.toFixed(2)).toString();
+  }
+  return `${formatCommaThousandsPeriodDecimal(valueString)} ${tokenId.toUpperCase()}`;
+};
 
 type IConvertWeiToCoinsOutput<T> = T extends true ? string : BigNumber;
 


### PR DESCRIPTION
Updated formatCoinsToReadableValue to take a shorthand boolean param and formats per the following rules.

If the value is inferior to 1, we display it with up to 8 decimals.
If the value is superior or equal to 1, we display with 2 decimals only. e.g.: 26,667.87 XVS