### PR TITLE
Convert coins to wei when calculating collateral value

### DIFF
--- a/src/clients/api/queries/useUserMarketInfo.ts
+++ b/src/clients/api/queries/useUserMarketInfo.ts
@@ -4,7 +4,7 @@ import { GetMarketsOutput } from 'clients/api/queries/getMarkets';
 import { TREASURY_ADDRESS } from 'config';
 import { useVaiUser } from 'hooks/useVaiUser';
 import { Asset, Market } from 'types';
-import { indexBy } from 'utilities/common';
+import { indexBy, convertCoinsToWei } from 'utilities/common';
 import { calculateCollateralValue, getVBepToken } from 'utilities';
 import { VBEP_TOKENS, TOKENS } from 'constants/tokens';
 import {
@@ -143,7 +143,12 @@ const useUserMarketInfo = ({
       const borrowBalanceUSD = asset.borrowBalance.times(asset.tokenPrice);
       acc[0] = acc[0].plus(borrowBalanceUSD);
       if (asset.collateral) {
-        acc[1] = acc[1].plus(calculateCollateralValue({ amountWei: asset.supplyBalance, asset }));
+        acc[1] = acc[1].plus(
+          calculateCollateralValue({
+            amountWei: convertCoinsToWei({ value: asset.supplyBalance, tokenId: asset.id }),
+            asset,
+          }),
+        );
       }
       return acc;
     },

--- a/src/components/Basic/SupplyTabs/WithdrawTab.tsx
+++ b/src/components/Basic/SupplyTabs/WithdrawTab.tsx
@@ -11,7 +11,7 @@ import arrowRightImg from 'assets/img/arrow-right.png';
 import vaiImg from 'assets/img/coins/vai.svg';
 import feeImg from 'assets/img/fee.png';
 import { TabSection, Tabs, TabContent } from 'components/Basic/SupplyModal';
-import { getBigNumber, formatApy, format } from 'utilities/common';
+import { getBigNumber, formatApy, format, convertCoinsToWei } from 'utilities/common';
 import { useComptrollerContract, useVTokenContract } from 'clients/contracts/hooks';
 import { AuthContext } from 'context/AuthContext';
 import { useMarketsUser } from 'hooks/useMarketsUser';
@@ -169,7 +169,12 @@ function WithdrawTab({ asset, changeTab, onCancel, setSetting }: WithdrawTabProp
               return (
                 temp.isLessThanOrEqualTo(asset.supplyBalance) &&
                 (!collateral ||
-                  userTotalBorrowLimit.gte(calculateCollateralValue({ amountWei: temp, asset })))
+                  userTotalBorrowLimit.gte(
+                    calculateCollateralValue({
+                      amountWei: convertCoinsToWei({ value: temp, tokenId: asset.id }),
+                      asset,
+                    }),
+                  ))
               );
             }}
             thousandSeparator

--- a/src/context/MarketContext.tsx
+++ b/src/context/MarketContext.tsx
@@ -7,7 +7,7 @@ import { Asset, Market } from 'types';
 import { VBEP_TOKENS, TOKENS } from 'constants/tokens';
 import { getVBepToken, getToken, calculateCollateralValue } from 'utilities';
 import { fetchMarkets } from 'utilities/api';
-import { indexBy, notNull } from 'utilities/common';
+import { indexBy, notNull, convertCoinsToWei } from 'utilities/common';
 import useRefresh from 'hooks/useRefresh';
 import { useVaiUser } from 'hooks/useVaiUser';
 import { useComptrollerContract, useVenusLensContract } from 'clients/contracts/hooks';
@@ -229,7 +229,12 @@ const MarketContextProvider = ({ children }: $TSFixMe) => {
 
         const totalBorrowLimit = assetList.reduce((acc, asset) => {
           if (asset.collateral) {
-            return acc.plus(calculateCollateralValue({ amountWei: asset.supplyBalance, asset }));
+            return acc.plus(
+              calculateCollateralValue({
+                amountWei: convertCoinsToWei({ value: asset.supplyBalance, tokenId: asset.id }),
+                asset,
+              }),
+            );
           }
           return acc;
         }, new BigNumber(0));

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -17,7 +17,12 @@ import {
 import { SAFE_BORROW_LIMIT_PERCENTAGE } from 'config';
 import { useTranslation } from 'translation';
 import { Asset, TokenId } from 'types';
-import { getBigNumber, formatCentsToReadableValue, format } from 'utilities/common';
+import {
+  getBigNumber,
+  formatCentsToReadableValue,
+  format,
+  convertCoinsToWei,
+} from 'utilities/common';
 import { calculateCollateralValue } from 'utilities';
 import { useStyles } from '../styles';
 
@@ -66,7 +71,7 @@ export const SupplyWithdrawContent: React.FC<
 
     if (tokenPrice && validAmount) {
       const amountInUsd = calculateCollateralValue({
-        amountWei: amount,
+        amountWei: convertCoinsToWei({ value: amount, tokenId: asset.id }),
         asset,
       });
       const temp = calculateNewBalance(amountInUsd);


### PR DESCRIPTION
The updated function was using coins instead of wei resulting in incorrect collateral values.

This PR updates the function to use wei