### PR TITLE
Add Repay tab to BorrowRepay modal

### DIFF
--- a/src/clients/api/__mocks__/index.ts
+++ b/src/clients/api/__mocks__/index.ts
@@ -85,7 +85,7 @@ export const repayNonBnbVToken = jest.fn();
 export const useRepayNonBnbVToken = () =>
   useMutation(FunctionKey.REPAY_NON_BNB_V_TOKEN, repayNonBnbVToken);
 
-export const useRepayVToken = () => jest.fn();
+export const useRepayVToken = useRepayNonBnbVToken;
 
 export const supply = jest.fn();
 export const useSupply = () => useMutation(FunctionKey.SUPPLY, supply);

--- a/src/clients/api/index.ts
+++ b/src/clients/api/index.ts
@@ -48,8 +48,6 @@ export { default as repayBnb } from './mutations/repayBnb';
 export * from './mutations/repayBnb';
 export { default as useRepayBnb } from './mutations/useRepayBnb';
 
-export { default as useRepayVToken } from './mutations/useRepayVToken';
-
 export { default as redeemUnderlying } from './mutations/redeemUnderlying';
 export * from './mutations/redeemUnderlying';
 export { default as useRedeemUnderlying } from './mutations/useRedeemUnderlying';
@@ -62,6 +60,9 @@ export { default as useClaimXvsReward } from './mutations/useClaimXvsReward';
 export { default as borrowVToken } from './mutations/borrowVToken';
 export * from './mutations/borrowVToken';
 export { default as useBorrowVToken } from './mutations/useBorrowVToken';
+
+export { default as useUserMarketInfo } from './queries/useUserMarketInfo';
+export { default as useRepayVToken } from './mutations/useRepayVToken';
 
 // Queries
 export { default as getVaiTreasuryPercentage } from './queries/getVaiTreasuryPercentage';
@@ -115,5 +116,3 @@ export { default as useGetXvsReward } from './queries/useGetXvsReward';
 export { default as getVTokenBorrowBalance } from './queries/getVTokenBorrowBalance';
 export * from './queries/getVTokenBorrowBalance';
 export { default as useGetVTokenBorrowBalance } from './queries/useGetVTokenBorrowBalance';
-
-export { default as useUserMarketInfo } from './queries/useUserMarketInfo';

--- a/src/clients/api/queryClient.ts
+++ b/src/clients/api/queryClient.ts
@@ -1,4 +1,13 @@
 import { QueryClient } from 'react-query';
 
-const queryClient = new QueryClient();
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Set a stale time of 10 seconds so query results don't get wiped out of
+      // the cache instantly after their hook unmounts (see documentation for
+      // more info: https://react-query.tanstack.com/guides/important-defaults)
+      staleTime: 10000,
+    },
+  },
+});
 export default queryClient;

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -27,7 +27,6 @@ export const useStyles = () => {
           : theme.palette.interactive.primary};
       }
     `,
-
     leftIcon: css`
       margin-right: ${theme.spacing(2)};
     `,

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -17,7 +17,8 @@ export const useStyles = () => {
       align-items: center;
       padding: ${theme.spacing(2, 2, 2, 4)};
       border-radius: ${theme.spacing(3)};
-      border: 2px solid ${hasError ? theme.palette.interactive.error : 'transparent'};
+      border: ${theme.spacing(0.5)} solid
+        ${hasError ? theme.palette.interactive.error : 'transparent'};
       background-color: ${theme.palette.background.default};
 
       &:focus-within {

--- a/src/components/v2/TextField/styles.ts
+++ b/src/components/v2/TextField/styles.ts
@@ -17,7 +17,7 @@ export const useStyles = () => {
       align-items: center;
       padding: ${theme.spacing(2, 2, 2, 4)};
       border-radius: ${theme.spacing(3)};
-      border: 2px solid transparent;
+      border: 2px solid ${hasError ? theme.palette.interactive.error : 'transparent'};
       background-color: ${theme.palette.background.default};
 
       &:focus-within {

--- a/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
@@ -63,7 +63,11 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
       </Paper>
 
       {selectedAsset && (
-        <BorrowRepayModal asset={selectedAsset} onClose={() => setSelectedAsset(undefined)} />
+        <BorrowRepayModal
+          asset={selectedAsset}
+          onClose={() => setSelectedAsset(undefined)}
+          isXvsEnabled={isXvsEnabled}
+        />
       )}
     </>
   );

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { Paper } from '@mui/material';
 import { Asset } from 'types';
-import { ToastError } from 'utilities/errors';
+import { UiError } from 'utilities/errors';
 import toast from 'components/Basic/Toast';
 import { useExitMarket, useEnterMarkets } from 'clients/api';
 import { useTranslation } from 'translation';
@@ -39,7 +39,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
     try {
       toggleAssetCollateral(asset);
     } catch (e) {
-      if (e instanceof ToastError) {
+      if (e instanceof UiError) {
         toast.error({
           title: e.title,
           description: e.description,
@@ -118,12 +118,12 @@ const SupplyMarket: React.FC<
 
   const toggleAssetCollateral = (asset: Asset) => {
     if (!accountAddress) {
-      throw new ToastError(
+      throw new UiError(
         t('markets.errors.accountError.title'),
         t('markets.errors.accountError.description'),
       );
     } else if (!asset || !asset.borrowBalance.isZero()) {
-      throw new ToastError(
+      throw new UiError(
         t('markets.errors.collateralRequired.title'),
         t('markets.errors.collateralRequired.description'),
       );
@@ -132,7 +132,7 @@ const SupplyMarket: React.FC<
         setConfirmCollateral(asset);
         enterMarkets({ vtokenAddresses: [asset.vtokenAddress], accountAddress });
       } catch (error) {
-        throw new ToastError(
+        throw new UiError(
           t('markets.errors.collateralEnableError.title'),
           t('markets.errors.collateralEnableError.description', { assetName: asset.symbol }),
         );
@@ -142,13 +142,13 @@ const SupplyMarket: React.FC<
         setConfirmCollateral(asset);
         exitMarkets({ vtokenAddress: asset.vtokenAddress, accountAddress });
       } catch (error) {
-        throw new ToastError(
+        throw new UiError(
           t('markets.errors.collateralDisableError.title'),
           t('markets.errors.collateralDisableError.description', { assetName: asset.symbol }),
         );
       }
     } else {
-      throw new ToastError(
+      throw new UiError(
         t('markets.errors.collateralRequired.title'),
         t('markets.errors.collateralRequired.description'),
       );

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
@@ -5,7 +5,7 @@ import type { TransactionReceipt } from 'web3-core';
 
 import { AuthContext } from 'context/AuthContext';
 import { convertCoinsToWei, convertWeiToCoins, formatCoinsToReadableValue } from 'utilities/common';
-import { internalError } from 'utilities/getError';
+import { InternalError } from 'utilities/errors';
 import { AmountForm, IAmountFormProps } from 'containers/AmountForm';
 import { SecondaryButton, LabeledInlineContent, TokenTextField } from 'components';
 import { useVaiUser } from 'hooks/useVaiUser';
@@ -162,7 +162,7 @@ const MintVai: React.FC = () => {
       const errorMessage = t('mintRepayVai.mintVai.undefinedAccountErrorMessage');
       // This error should never happen, since the form inside the UI component
       // is disabled if there's no logged in account
-      throw internalError(errorMessage);
+      throw new InternalError(errorMessage);
     }
 
     return contractMintVai({

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import type { TransactionReceipt } from 'web3-core';
 
 import { convertCoinsToWei, convertWeiToCoins, formatCoinsToReadableValue } from 'utilities/common';
-import { internalError } from 'utilities/getError';
+import { InternalError } from 'utilities/errors';
 import { AmountForm, IAmountFormProps } from 'containers/AmountForm';
 import { AuthContext } from 'context/AuthContext';
 import { SecondaryButton, LabeledInlineContent, TokenTextField } from 'components';
@@ -147,7 +147,7 @@ const RepayVai: React.FC = () => {
       const errorMessage = t('mintRepayVai.repayVai.undefinedAccountErrorMessage');
       // This error should never happen, since the form inside the UI component
       // is disabled if there's no logged in account
-      throw internalError(errorMessage);
+      throw new InternalError(errorMessage);
     }
 
     return contractRepayVai({

--- a/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
@@ -22,9 +22,14 @@ import { useStyles } from '../../styles';
 export interface IAccountDataProps {
   asset: Asset;
   hypotheticalBorrowAmountTokens: number;
+  isXvsEnabled: boolean;
 }
 
-const AccountData: React.FC<IAccountDataProps> = ({ asset, hypotheticalBorrowAmountTokens }) => {
+const AccountData: React.FC<IAccountDataProps> = ({
+  asset,
+  hypotheticalBorrowAmountTokens,
+  isXvsEnabled,
+}) => {
   const { t } = useTranslation();
   const styles = useStyles();
   const { account } = React.useContext(AuthContext);
@@ -74,7 +79,7 @@ const AccountData: React.FC<IAccountDataProps> = ({ asset, hypotheticalBorrowAmo
 
       const yearlyEarningsCents = calculateYearlyEarningsForAssets({
         assets: updatedAssets,
-        isXvsEnabled: true,
+        isXvsEnabled,
       });
 
       return yearlyEarningsCents

--- a/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
@@ -1,12 +1,10 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
-import { FormikProps } from 'formik';
 import BigNumber from 'bignumber.js';
 
 import { SAFE_BORROW_LIMIT_PERCENTAGE } from 'config';
 import { Asset } from 'types';
 import { AuthContext } from 'context/AuthContext';
-import { FormValues } from 'containers/AmountForm';
 import { useUserMarketInfo } from 'clients/api';
 import { formatToReadablePercentage } from 'utilities/common';
 import calculateDailyEarningsCentsUtil from 'utilities/calculateDailyEarningsCents';
@@ -23,10 +21,10 @@ import { useStyles } from '../../styles';
 
 export interface IAccountDataProps {
   asset: Asset;
-  amount: FormikProps<FormValues>['values']['amount'];
+  hypotheticalBorrowAmountTokens?: number;
 }
 
-const AccountData: React.FC<IAccountDataProps> = ({ asset, amount }) => {
+const AccountData: React.FC<IAccountDataProps> = ({ asset, hypotheticalBorrowAmountTokens }) => {
   const { t } = useTranslation();
   const styles = useStyles();
   const { account } = React.useContext(AuthContext);
@@ -38,11 +36,11 @@ const AccountData: React.FC<IAccountDataProps> = ({ asset, amount }) => {
   const totalBorrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
   const borrowLimitCents = userTotalBorrowLimit.multipliedBy(100);
 
-  const isAmountPositive = amount && +amount > 0;
+  const isAmountPositive = hypotheticalBorrowAmountTokens && hypotheticalBorrowAmountTokens > 0;
   const hypotheticalTotalBorrowBalanceCents = isAmountPositive
     ? totalBorrowBalanceCents.plus(
         asset.tokenPrice
-          .multipliedBy(amount)
+          .multipliedBy(hypotheticalBorrowAmountTokens)
           // Convert dollars to cents
           .multipliedBy(100),
       )
@@ -88,7 +86,7 @@ const AccountData: React.FC<IAccountDataProps> = ({ asset, amount }) => {
 
   const dailyEarningsCents = React.useMemo(() => calculateDailyEarningsCents(new BigNumber(0)), []);
   const hypotheticalDailyEarningsCents = isAmountPositive
-    ? calculateDailyEarningsCents(new BigNumber(amount))
+    ? calculateDailyEarningsCents(new BigNumber(hypotheticalBorrowAmountTokens))
     : undefined;
 
   const readableBorrowApy = React.useMemo(

--- a/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
@@ -21,7 +21,7 @@ import { useStyles } from '../../styles';
 
 export interface IAccountDataProps {
   asset: Asset;
-  hypotheticalBorrowAmountTokens?: number;
+  hypotheticalBorrowAmountTokens: number;
 }
 
 const AccountData: React.FC<IAccountDataProps> = ({ asset, hypotheticalBorrowAmountTokens }) => {
@@ -36,15 +36,15 @@ const AccountData: React.FC<IAccountDataProps> = ({ asset, hypotheticalBorrowAmo
   const totalBorrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
   const borrowLimitCents = userTotalBorrowLimit.multipliedBy(100);
 
-  const isAmountPositive = hypotheticalBorrowAmountTokens && hypotheticalBorrowAmountTokens > 0;
-  const hypotheticalTotalBorrowBalanceCents = isAmountPositive
-    ? totalBorrowBalanceCents.plus(
-        asset.tokenPrice
-          .multipliedBy(hypotheticalBorrowAmountTokens)
-          // Convert dollars to cents
-          .multipliedBy(100),
-      )
-    : undefined;
+  const hypotheticalTotalBorrowBalanceCents =
+    hypotheticalBorrowAmountTokens !== 0
+      ? totalBorrowBalanceCents.plus(
+          asset.tokenPrice
+            .multipliedBy(hypotheticalBorrowAmountTokens)
+            // Convert dollars to cents
+            .multipliedBy(100),
+        )
+      : undefined;
 
   const borrowLimitUsedPercentage = React.useMemo(
     () =>
@@ -85,9 +85,10 @@ const AccountData: React.FC<IAccountDataProps> = ({ asset, hypotheticalBorrowAmo
   );
 
   const dailyEarningsCents = React.useMemo(() => calculateDailyEarningsCents(new BigNumber(0)), []);
-  const hypotheticalDailyEarningsCents = isAmountPositive
-    ? calculateDailyEarningsCents(new BigNumber(hypotheticalBorrowAmountTokens))
-    : undefined;
+  const hypotheticalDailyEarningsCents =
+    hypotheticalBorrowAmountTokens !== 0
+      ? calculateDailyEarningsCents(new BigNumber(hypotheticalBorrowAmountTokens))
+      : undefined;
 
   const readableBorrowApy = React.useMemo(
     () => formatToReadablePercentage(asset.borrowApy.toFixed(2)),

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -30,7 +30,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
   });
 
   it('renders without crashing', () => {
-    renderComponent(<Borrow asset={fakeAsset} onClose={noop} />);
+    renderComponent(<Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />);
   });
 
   it('disables submit button if an incorrect amount is entered in input', async () => {
@@ -46,7 +46,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
           },
         }}
       >
-        <Borrow asset={fakeAsset} onClose={noop} />
+        <Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />
       </AuthContext.Provider>,
     );
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));
@@ -89,7 +89,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
           },
         }}
       >
-        <Borrow asset={fakeAsset} onClose={onCloseMock} />
+        <Borrow asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />
       </AuthContext.Provider>,
     );
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -36,6 +36,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
   isBorrowLoading,
 }) => {
   const { t } = useTranslation();
+
   const sharedStyles = useStyles();
   const borrowStyles = useBorrowStyles();
   const styles = {

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -11,6 +11,7 @@ import { AmountForm, IAmountFormProps, ErrorCode } from 'containers/AmountForm';
 import { formatApy, convertCoinsToWei } from 'utilities/common';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import toast from 'components/Basic/Toast';
+import { UiError } from 'utilities/errors';
 import { useUserMarketInfo, useBorrowVToken } from 'clients/api';
 import { PrimaryButton, TokenTextField, Icon, ConnectWallet, EnableToken } from 'components';
 import { useTranslation } from 'translation';
@@ -69,7 +70,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
         transactionHash,
       });
     } catch (error) {
-      toast.error({ title: (error as Error).message });
+      toast.error(error as UiError);
     }
   };
 
@@ -148,7 +149,7 @@ const Borrow: React.FC<IBorrowProps> = ({ asset, onClose }) => {
 
   const handleBorrow: IBorrowFormProps['borrow'] = async amountWei => {
     if (!account?.address) {
-      throw new Error(t('errors.walletNotConnected'));
+      throw new UiError(t('errors.walletNotConnected'));
     }
 
     const res = await borrow({

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -54,7 +54,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
     });
 
     try {
-      // Send request to borrow asset
+      // Send request to borrow tokens
       const transactionHash = await borrow(amountWei);
 
       // Display successful transaction modal
@@ -106,7 +106,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
             )}
           </div>
 
-          <AccountData amount={values.amount} asset={asset} />
+          <AccountData hypotheticalBorrowAmountTokens={+values.amount} asset={asset} />
 
           <PrimaryButton
             type="submit"

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -26,6 +26,7 @@ export interface IBorrowFormProps {
   safeLimitTokens: string;
   borrow: (amountWei: BigNumber) => Promise<string>;
   isBorrowLoading: boolean;
+  isXvsEnabled: boolean;
 }
 
 export const BorrowForm: React.FC<IBorrowFormProps> = ({
@@ -34,6 +35,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
   safeBorrowLimitPercentage,
   safeLimitTokens,
   borrow,
+  isXvsEnabled,
   isBorrowLoading,
 }) => {
   const { t } = useTranslation();
@@ -108,7 +110,11 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
             )}
           </div>
 
-          <AccountData hypotheticalBorrowAmountTokens={+values.amount} asset={asset} />
+          <AccountData
+            hypotheticalBorrowAmountTokens={+values.amount}
+            asset={asset}
+            isXvsEnabled={isXvsEnabled}
+          />
 
           <PrimaryButton
             type="submit"
@@ -128,10 +134,11 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
 
 export interface IBorrowProps {
   asset: Asset;
+  isXvsEnabled: boolean;
   onClose: () => void;
 }
 
-const Borrow: React.FC<IBorrowProps> = ({ asset, onClose }) => {
+const Borrow: React.FC<IBorrowProps> = ({ asset, onClose, isXvsEnabled }) => {
   const { t } = useTranslation();
   const { account } = React.useContext(AuthContext);
 
@@ -210,6 +217,7 @@ const Borrow: React.FC<IBorrowProps> = ({ asset, onClose }) => {
         >
           <BorrowForm
             asset={asset}
+            isXvsEnabled={isXvsEnabled}
             limitTokens={limitTokens}
             safeBorrowLimitPercentage={SAFE_BORROW_LIMIT_PERCENTAGE}
             safeLimitTokens={safeLimitTokens}

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -1,0 +1,141 @@
+import React from 'react';
+import noop from 'noop-ts';
+import BigNumber from 'bignumber.js';
+import { waitFor, fireEvent } from '@testing-library/react';
+
+import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
+import fakeAccountAddress from '__mocks__/models/address';
+import { assetData } from '__mocks__/models/asset';
+import { useUserMarketInfo, repayNonBnbVToken } from 'clients/api';
+import { AuthContext } from 'context/AuthContext';
+import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
+import renderComponent from 'testUtils/renderComponent';
+import en from 'translation/translations/en.json';
+import Repay from '.';
+
+const fakeTokenBorrowBalanceTokens = new BigNumber('10000');
+const fakeAssets = assetData.map((asset, index) => ({
+  ...asset,
+  isEnabled: true,
+  walletBalance: index === 3 ? fakeTokenBorrowBalanceTokens : asset.walletBalance,
+  borrowBalance: index === 3 ? fakeTokenBorrowBalanceTokens : asset.borrowBalance,
+}));
+const fakeAsset = fakeAssets[3];
+
+jest.mock('clients/api');
+jest.mock('hooks/useSuccessfulTransactionModal');
+
+describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
+  beforeEach(() => {
+    (useUserMarketInfo as jest.Mock).mockImplementation(() => ({
+      assets: fakeAssets,
+      userTotalBorrowLimit: new BigNumber('111'),
+      userTotalBorrowBalance: new BigNumber('91'),
+    }));
+  });
+
+  it('renders without crashing', () => {
+    renderComponent(<Repay asset={fakeAsset} onClose={noop} />);
+  });
+
+  it('disables submit button if an incorrect amount is entered in input', async () => {
+    const { getByText, getByTestId } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <Repay asset={fakeAsset} onClose={noop} />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
+
+    expect(
+      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
+    ).toHaveAttribute('disabled');
+
+    // Enter amount in input
+    fireEvent.change(getByTestId('token-text-field'), {
+      target: { value: fakeAsset.borrowBalance.toFixed() },
+    });
+
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButton));
+    expect(getByText(en.borrowRepayModal.repay.submitButton).closest('button')).not.toHaveAttribute(
+      'disabled',
+    );
+
+    // Enter amount higher than maximum borrow limit in input
+    fireEvent.change(getByTestId('token-text-field'), {
+      target: { value: fakeAsset.borrowBalance.plus(1).toFixed() },
+    });
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
+    expect(
+      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
+    ).toHaveAttribute('disabled');
+  });
+
+  it('lets user repay borrowed tokens, then displays successful transaction modal and calls onClose callback on success', async () => {
+    const onCloseMock = jest.fn();
+    const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+    (repayNonBnbVToken as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
+
+    const { getByText, getByTestId } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <Repay asset={fakeAsset} onClose={onCloseMock} />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
+
+    expect(
+      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
+    ).toHaveAttribute('disabled');
+
+    // Enter amount in input
+    fireEvent.change(getByTestId('token-text-field'), {
+      target: { value: fakeAsset.borrowBalance.toFixed() },
+    });
+
+    // Click on submit button
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButton));
+    fireEvent.click(getByText(en.borrowRepayModal.repay.submitButton));
+
+    const expectedAmountWei = fakeAsset.borrowBalance.multipliedBy(
+      new BigNumber(10).pow(fakeAsset.decimals),
+    );
+
+    await waitFor(() => expect(repayNonBnbVToken).toHaveBeenCalledTimes(1));
+    expect(repayNonBnbVToken).toHaveBeenCalledWith({
+      amountWei: expectedAmountWei,
+      fromAccountAddress: fakeAccountAddress,
+    });
+
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+
+    expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
+      transactionHash: fakeTransactionReceipt.transactionHash,
+      amount: {
+        tokenId: fakeAsset.id,
+        valueWei: expectedAmountWei,
+      },
+      message: expect.any(String),
+      title: expect.any(String),
+    });
+  });
+});

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -35,7 +35,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
   });
 
   it('renders without crashing', () => {
-    renderComponent(<Repay asset={fakeAsset} onClose={noop} />);
+    renderComponent(<Repay asset={fakeAsset} onClose={noop} isXvsEnabled />);
   });
 
   it('disables submit button if an incorrect amount is entered in input', async () => {
@@ -51,7 +51,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
           },
         }}
       >
-        <Repay asset={fakeAsset} onClose={noop} />
+        <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />
       </AuthContext.Provider>,
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
@@ -98,7 +98,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
           },
         }}
       >
-        <Repay asset={fakeAsset} onClose={onCloseMock} />
+        <Repay asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />
       </AuthContext.Provider>,
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -13,6 +13,7 @@ import {
   formatToReadablePercentage,
 } from 'utilities/common';
 import { useRepayVToken } from 'clients/api';
+import { UiError } from 'utilities/errors';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import toast from 'components/Basic/Toast';
 import {
@@ -98,7 +99,7 @@ export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoad
         transactionHash,
       });
     } catch (error) {
-      toast.error({ title: (error as Error).message });
+      toast.error(error as UiError);
     }
   };
 
@@ -193,7 +194,7 @@ const Repay: React.FC<IRepayProps> = ({ asset, onClose }) => {
 
   const handleRepay: IRepayFormProps['repay'] = async amountWei => {
     if (!account?.address) {
-      throw new Error(t('errors.walletNotConnected'));
+      throw new UiError(t('errors.walletNotConnected'));
     }
 
     const res = await repay({

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -33,9 +33,15 @@ export interface IRepayFormProps {
   asset: Asset;
   repay: (amountWei: BigNumber) => Promise<string>;
   isRepayLoading: boolean;
+  isXvsEnabled: boolean;
 }
 
-export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoading }) => {
+export const RepayForm: React.FC<IRepayFormProps> = ({
+  asset,
+  repay,
+  isRepayLoading,
+  isXvsEnabled,
+}) => {
   const { t, Trans } = useTranslation();
 
   const sharedStyles = useStyles();
@@ -161,7 +167,11 @@ export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoad
             </div>
           </div>
 
-          <AccountData hypotheticalBorrowAmountTokens={-values.amount} asset={asset} />
+          <AccountData
+            hypotheticalBorrowAmountTokens={-values.amount}
+            asset={asset}
+            isXvsEnabled={isXvsEnabled}
+          />
 
           <PrimaryButton
             type="submit"
@@ -181,10 +191,11 @@ export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoad
 
 export interface IRepayProps {
   asset: Asset;
+  isXvsEnabled: boolean;
   onClose: () => void;
 }
 
-const Repay: React.FC<IRepayProps> = ({ asset, onClose }) => {
+const Repay: React.FC<IRepayProps> = ({ asset, onClose, isXvsEnabled }) => {
   const { t } = useTranslation();
   const { account } = React.useContext(AuthContext);
 
@@ -229,7 +240,12 @@ const Repay: React.FC<IRepayProps> = ({ asset, onClose }) => {
           isEnabled={asset.isEnabled}
           vtokenAddress={asset.vtokenAddress}
         >
-          <RepayForm asset={asset} repay={handleRepay} isRepayLoading={isRepayLoading} />
+          <RepayForm
+            asset={asset}
+            repay={handleRepay}
+            isXvsEnabled={isXvsEnabled}
+            isRepayLoading={isRepayLoading}
+          />
         </EnableToken>
       )}
     </ConnectWallet>

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -1,0 +1,171 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import BigNumber from 'bignumber.js';
+
+import { Asset } from 'types';
+import { AuthContext } from 'context/AuthContext';
+import { AmountForm, IAmountFormProps, ErrorCode } from 'containers/AmountForm';
+import { formatApy, convertCoinsToWei } from 'utilities/common';
+import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
+import toast from 'components/Basic/Toast';
+import { PrimaryButton, TokenTextField, ConnectWallet, EnableToken } from 'components';
+import { useTranslation } from 'translation';
+import { useStyles } from '../../styles';
+import AccountData from '../AccountData';
+
+export interface IRepayFormProps {
+  asset: Asset;
+  limitTokens: string;
+  repay: (amountWei: BigNumber) => Promise<string>;
+  isRepayLoading: boolean;
+}
+
+export const RepayForm: React.FC<IRepayFormProps> = ({
+  asset,
+  limitTokens,
+  repay,
+  isRepayLoading,
+}) => {
+  const { t } = useTranslation();
+  const styles = useStyles();
+
+  const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+  const onSubmit: IAmountFormProps['onSubmit'] = async amountTokens => {
+    const formattedAmountTokens = new BigNumber(amountTokens);
+
+    const amountWei = convertCoinsToWei({
+      value: formattedAmountTokens,
+      tokenId: asset.id,
+    });
+
+    try {
+      // Send request to repay tokens
+      const transactionHash = await repay(amountWei);
+
+      // Display successful transaction modal
+      openSuccessfulTransactionModal({
+        title: t('borrowRepayModal.repay.successfulTransactionModal.title'),
+        message: t('borrowRepayModal.repay.successfulTransactionModal.message'),
+        amount: {
+          valueWei: amountWei,
+          tokenId: asset.id,
+        },
+        transactionHash,
+      });
+    } catch (error) {
+      toast.error({ title: (error as Error).message });
+    }
+  };
+
+  return (
+    <AmountForm onSubmit={onSubmit} maxAmount={limitTokens}>
+      {({ values, setFieldValue, handleBlur, dirty, isValid, errors }) => (
+        <>
+          <div css={[styles.getRow({ isLast: true })]}>
+            <TokenTextField
+              name="amount"
+              tokenId={asset.id}
+              value={values.amount}
+              onChange={amount => setFieldValue('amount', amount, true)}
+              disabled={isRepayLoading}
+              onBlur={handleBlur}
+              rightMaxButton={{
+                label: t('borrowRepayModal.repay.rightMaxButtonLabel', {
+                  limitPercentage: limitTokens,
+                }),
+                valueOnClick: limitTokens,
+              }}
+              data-testid="token-text-field"
+              // Only display error state if amount is higher than limit
+              hasError={errors.amount === ErrorCode.HIGHER_THAN_MAX}
+            />
+          </div>
+
+          {/* @TODO: add buttons */}
+
+          <AccountData asset={asset} />
+
+          <PrimaryButton
+            type="submit"
+            loading={isRepayLoading}
+            disabled={!isValid || !dirty || isRepayLoading}
+            fullWidth
+          >
+            {dirty && isValid
+              ? t('borrowRepayModal.repay.submitButton')
+              : t('borrowRepayModal.repay.submitButtonDisabled')}
+          </PrimaryButton>
+        </>
+      )}
+    </AmountForm>
+  );
+};
+
+export interface IRepayProps {
+  asset: Asset;
+  onClose: () => void;
+}
+
+const Repay: React.FC<IRepayProps> = ({ asset, onClose }) => {
+  const { t } = useTranslation();
+  const { account } = React.useContext(AuthContext);
+
+  // TODO: calculate limit tokens
+  const limitTokens = '100';
+
+  // TODO: use repay VToken mutation
+  const isRepayLoading = false;
+  const handleRepay: IRepayFormProps['repay'] = async amountWei => {
+    if (!account?.address) {
+      throw new Error(t('errors.walletNotConnected'));
+    }
+
+    console.log('amountWei', amountWei.toFixed());
+
+    // const res = await borrow({
+    //   amountWei,
+    //   fromAccountAddress: account.address,
+    // });
+
+    // Close modal on success
+    onClose();
+
+    // return res.transactionHash;
+    return 'TODO: return hash';
+  };
+
+  return (
+    <ConnectWallet message={t('borrowRepayModal.repay.connectWalletMessage')}>
+      {asset && (
+        <EnableToken
+          symbol={asset.id}
+          title={t('borrowRepayModal.repay.enableToken.title', { symbol: asset.symbol })}
+          tokenInfo={[
+            {
+              label: t('borrowRepayModal.repay.enableToken.borrowInfo'),
+              iconName: asset.id,
+              children: formatApy(asset.borrowApy),
+            },
+            {
+              label: t('borrowRepayModal.repay.enableToken.distributionInfo'),
+              iconName: 'xvs',
+              children: formatApy(asset.xvsBorrowApy),
+            },
+          ]}
+          isEnabled={asset.isEnabled}
+          vtokenAddress={asset.vtokenAddress}
+        >
+          <RepayForm
+            asset={asset}
+            limitTokens={limitTokens}
+            repay={handleRepay}
+            isRepayLoading={isRepayLoading}
+          />
+        </EnableToken>
+      )}
+    </ConnectWallet>
+  );
+};
+
+export default Repay;

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
 import BigNumber from 'bignumber.js';
+import { Typography } from '@mui/material';
 
 import { Asset } from 'types';
 import { AuthContext } from 'context/AuthContext';
@@ -26,12 +27,13 @@ export interface IRepayFormProps {
 }
 
 export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoading }) => {
-  const { t } = useTranslation();
+  const { t, Trans } = useTranslation();
   const styles = useStyles();
 
   const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
 
-  const limitTokens = asset.borrowBalance.toFixed();
+  const limitTokens = asset.walletBalance.toFixed();
+
   const readableTokenBorrowBalance = React.useMemo(
     () =>
       formatCoinsToReadableValue({
@@ -39,6 +41,15 @@ export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoad
         tokenId: asset.id,
       }),
     [asset.borrowBalance.toFixed(), asset.id],
+  );
+
+  const readableTokenWalletBalance = React.useMemo(
+    () =>
+      formatCoinsToReadableValue({
+        value: asset.walletBalance,
+        tokenId: asset.id,
+      }),
+    [asset.walletBalance.toFixed(), asset.id],
   );
 
   const onSubmit: IAmountFormProps['onSubmit'] = async amountTokens => {
@@ -83,6 +94,7 @@ export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoad
             <TokenTextField
               name="amount"
               tokenId={asset.id}
+              css={styles.input}
               value={values.amount}
               onChange={amount => setFieldValue('amount', amount, true)}
               disabled={isRepayLoading}
@@ -96,7 +108,15 @@ export const RepayForm: React.FC<IRepayFormProps> = ({ asset, repay, isRepayLoad
               hasError={errors.amount === ErrorCode.HIGHER_THAN_MAX}
             />
 
-            {/* @TODO: add wallet balance */}
+            <Typography component="div" variant="small1" css={styles.greyLabel}>
+              <Trans
+                i18nKey="borrowRepayModal.repay.walletBalance"
+                components={{
+                  White: <Typography component="span" variant="small1" css={styles.whiteLabel} />,
+                }}
+                values={{ balance: readableTokenWalletBalance }}
+              />
+            </Typography>
           </div>
 
           {/* @TODO: add buttons */}

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/styles.ts
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/styles.ts
@@ -1,0 +1,26 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  return {
+    walletBalance: css`
+      margin-bottom: ${theme.spacing(3)};
+    `,
+    selectButtonsContainer: css`
+      display: flex;
+      flex-direction: row;
+    `,
+    selectButton: css`
+      flex: 1;
+      border-radius: ${theme.spacing(13)};
+      padding-left: ${theme.spacing(2)};
+      padding-right: ${theme.spacing(2)};
+
+      &:not(:last-child) {
+        margin-right: ${theme.spacing(4)};
+      }
+    `,
+  };
+};

--- a/src/pages/Dashboard/Modals/BorrowRepay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/index.spec.tsx
@@ -22,7 +22,9 @@ describe('pages/Dashboard/BorrowRepayModal', () => {
   });
 
   it('renders without crashing', async () => {
-    const { getByText } = renderComponent(<BorrowRepay onClose={jest.fn()} asset={asset} />);
+    const { getByText } = renderComponent(
+      <BorrowRepay onClose={jest.fn()} asset={asset} isXvsEnabled />,
+    );
     await waitFor(() => expect(getByText(en.borrowRepayModal.borrowTabTitle)));
   });
 });

--- a/src/pages/Dashboard/Modals/BorrowRepay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/index.tsx
@@ -10,10 +10,11 @@ import Repay from './Repay';
 
 export interface IBorrowRepayProps {
   onClose: IModalProps['handleClose'];
+  isXvsEnabled: boolean;
   asset: Asset;
 }
 
-const BorrowRepay: React.FC<IBorrowRepayProps> = ({ onClose, asset }) => {
+const BorrowRepay: React.FC<IBorrowRepayProps> = ({ onClose, asset, isXvsEnabled }) => {
   const { t } = useTranslation();
   const styles = useStyles();
 
@@ -22,7 +23,7 @@ const BorrowRepay: React.FC<IBorrowRepayProps> = ({ onClose, asset }) => {
       title: t('borrowRepayModal.borrowTabTitle'),
       content: (
         <div css={styles.container}>
-          <Borrow asset={asset} onClose={onClose} />
+          <Borrow asset={asset} onClose={onClose} isXvsEnabled={isXvsEnabled} />
         </div>
       ),
     },
@@ -30,7 +31,7 @@ const BorrowRepay: React.FC<IBorrowRepayProps> = ({ onClose, asset }) => {
       title: t('borrowRepayModal.repayTabTitle'),
       content: (
         <div css={styles.container}>
-          <Repay asset={asset} onClose={onClose} />
+          <Repay asset={asset} onClose={onClose} isXvsEnabled={isXvsEnabled} />
         </div>
       ),
     },

--- a/src/pages/Dashboard/Modals/BorrowRepay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/index.tsx
@@ -6,6 +6,7 @@ import { Tabs, Modal, IModalProps, Token } from 'components';
 import { useTranslation } from 'translation';
 import { useStyles } from '../styles';
 import Borrow from './Borrow';
+import Repay from './Repay';
 
 export interface IBorrowRepayProps {
   onClose: IModalProps['handleClose'];
@@ -29,7 +30,7 @@ const BorrowRepay: React.FC<IBorrowRepayProps> = ({ onClose, asset }) => {
       title: t('borrowRepayModal.repayTabTitle'),
       content: (
         <div css={styles.container}>
-          <>Repay</>
+          <Repay asset={asset} onClose={onClose} />
         </div>
       ),
     },

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -134,13 +134,13 @@ export const SupplyWithdrawContent: React.FC<
       />
       <Typography
         component="div"
-        variant="small1"
+        variant="small2"
         css={[styles.greyLabel, styles.getRow({ isLast: true })]}
       >
         <Trans
           i18nKey={inputLabel}
           components={{
-            White: <Typography component="span" variant="small1" css={styles.whiteLabel} />,
+            White: <span css={styles.whiteLabel} />,
           }}
           values={{ amount: format(maxInput), symbol: assetId?.toUpperCase() }}
         />

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -44,6 +44,21 @@
       }
     },
     "borrowTabTitle": "Borrow",
+    "repay": {
+      "connectWalletMessage": "Please connect your wallet to repay",
+      "enableToken": {
+        "borrowInfo": "Borrow APY",
+        "distributionInfo": "Distribution APY",
+        "title": "To repay {{symbol}} to the Venus Protocol, you need to enable it first."
+      },
+      "rightMaxButtonLabel": "MAX",
+      "submitButton": "Repay",
+      "submitButtonDisabled": "Enter a valid amount to repay",
+      "successfulTransactionModal": {
+        "message": "You successfully repaid",
+        "title": "Your repayment was successful"
+      }
+    },
     "repayTabTitle": "Repay"
   },
   "bscLink": {

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -46,6 +46,7 @@
     "borrowTabTitle": "Borrow",
     "repay": {
       "connectWalletMessage": "Please connect your wallet to repay",
+      "currentlyBorrowing": "Currently borrowing",
       "enableToken": {
         "borrowInfo": "Borrow APY",
         "distributionInfo": "Distribution APY",

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -58,7 +58,8 @@
       "successfulTransactionModal": {
         "message": "You successfully repaid",
         "title": "Your repayment was successful"
-      }
+      },
+      "walletBalance": "Wallet balance: <White>{{balance}}</White>"
     },
     "repayTabTitle": "Repay"
   },
@@ -87,7 +88,7 @@
   },
   "errors": {
     "internal": "An internal error occurred: {{errorMessage}}. Please try again later.",
-    "walletNotConnected": "TRANSLATION NEEDED"
+    "walletNotConnected": "Wallet not connected"
   },
   "footer": {
     "latestNumber": "Latest Block:\u00a0"

--- a/src/utilities/errors.ts
+++ b/src/utilities/errors.ts
@@ -1,11 +1,23 @@
-export class ToastError extends Error {
+export class UiError extends Error {
   title: string;
 
-  description: string;
+  description?: string;
 
-  constructor(title: string, description: string) {
+  constructor(title: string, description?: string) {
     super(title);
     this.title = title;
-    this.description = description;
+
+    if (description) {
+      this.description = description;
+    }
+  }
+}
+
+export class InternalError extends Error {
+  message: string;
+
+  constructor(message: string) {
+    super(message);
+    this.message = message;
   }
 }

--- a/src/utilities/getError.ts
+++ b/src/utilities/getError.ts
@@ -1,4 +1,0 @@
-import { t } from 'translation';
-
-export const internalError = (errorMessage: string) =>
-  new Error(t('errors.internal', { errorMessage }));


### PR DESCRIPTION
- add default `staleTime` of 10 seconds on query client, so query hooks that are unmounted then quickly after mounted again don't trigger a refetch
- always display red border on `TextField` when `hasError` is `true`
- rename `amount` to `hypotheticalBorrowAmountTokens` on `AccountData`
- add `Repay` tab to `BorrowRepay modal`
- add text for global error `errors.walletNotConnected` in English translation file
- move `InternalError` to `errors` util
- rename `ToastError` to `UiError`