### PR TITLE
Supply withdraw updates

### DIFF
--- a/src/clients/api/mutations/supplyNonBnb.ts
+++ b/src/clients/api/mutations/supplyNonBnb.ts
@@ -7,7 +7,7 @@ export interface ISupplyNonBnbInput {
   amount: string;
 }
 
-export type SupplyNonBnbOutput = void | TransactionReceipt;
+export type SupplyNonBnbOutput = TransactionReceipt;
 
 const supplyNonBnb = async ({
   tokenContract,

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -40,11 +40,11 @@ const App = () => (
     <Web3Wrapper>
       <QueryClientProvider client={queryClient}>
         <Provider store={store}>
-          <AuthProvider>
+          <MuiThemeProvider>
             <RefreshContextProvider>
-              <VaiContextProvider>
-                <MarketContextProvider>
-                  <MuiThemeProvider>
+              <AuthProvider>
+                <VaiContextProvider>
+                  <MarketContextProvider>
                     <SuccessfulTransactionModalProvider>
                       <BrowserRouter>
                         <ToastContainer
@@ -77,11 +77,11 @@ const App = () => (
                         </Layout>
                       </BrowserRouter>
                     </SuccessfulTransactionModalProvider>
-                  </MuiThemeProvider>
-                </MarketContextProvider>
-              </VaiContextProvider>
+                  </MarketContextProvider>
+                </VaiContextProvider>
+              </AuthProvider>
             </RefreshContextProvider>
-          </AuthProvider>
+          </MuiThemeProvider>
         </Provider>
       </QueryClientProvider>
     </Web3Wrapper>

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -3,14 +3,13 @@ import React, { useMemo } from 'react';
 import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { formatCoinsToReadableValue, formatApy } from 'utilities/common';
 import { Asset, TokenId } from 'types';
-import { switchAriaLabel, Token, Toggle } from 'components';
-import { Table, ITableProps } from 'components/v2/Table';
+import { Table, ITableProps, Token, Toggle } from 'components';
 import { useTranslation } from 'translation';
 
 export interface ISuppliedTableUiProps {
   assets: Asset[];
   isXvsEnabled: boolean;
-  setSelectedAsset: (asset: Asset | undefined) => void;
+  rowOnClick: (e: React.MouseEvent<HTMLElement>, row: ITableProps['data'][number]) => void;
   collateralOnChange: (asset: Asset) => void;
 }
 
@@ -18,7 +17,7 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
   assets,
   isXvsEnabled,
   collateralOnChange,
-  setSelectedAsset,
+  rowOnClick,
 }) => {
   const { t } = useTranslation();
 
@@ -67,14 +66,6 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
         ),
     },
   ]);
-  const rowOnClick = (e: React.MouseEvent<HTMLElement>, row: ITableProps['data'][number]) => {
-    if ((e.target as HTMLElement).ariaLabel !== switchAriaLabel) {
-      const asset = assets.find((value: Asset) => value.id === row[0].value);
-      if (asset) {
-        setSelectedAsset(asset);
-      }
-    }
-  };
   return (
     <Table
       title={t('markets.suppliedTableTitle')}

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -3,14 +3,13 @@ import React, { useMemo } from 'react';
 import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { formatCoinsToReadableValue, formatApy } from 'utilities/common';
 import { Asset, TokenId } from 'types';
-import { switchAriaLabel, Token, Toggle } from 'components';
-import { Table, ITableProps } from 'components/v2/Table';
+import { Table, ITableProps, Token, Toggle } from 'components';
 import { useTranslation } from 'translation';
 
 export interface ISupplyMarketTableUiProps {
   assets: Asset[];
   isXvsEnabled: boolean;
-  setSelectedAsset: (asset: Asset | undefined) => void;
+  rowOnClick: (e: React.MouseEvent<HTMLElement>, row: ITableProps['data'][number]) => void;
   collateralOnChange: (asset: Asset) => void;
 }
 
@@ -18,7 +17,7 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
   assets,
   isXvsEnabled,
   collateralOnChange,
-  setSelectedAsset,
+  rowOnClick,
 }) => {
   const { t } = useTranslation();
 
@@ -67,14 +66,6 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
         ),
     },
   ]);
-  const rowOnClick = (e: React.MouseEvent<HTMLElement>, row: ITableProps['data'][number]) => {
-    if ((e.target as HTMLElement).ariaLabel !== switchAriaLabel) {
-      const asset = assets.find((value: Asset) => value.id === row[0].value);
-      if (asset) {
-        setSelectedAsset(asset);
-      }
-    }
-  };
   return (
     <Table
       title={t('markets.supplyMarketTableTitle')}

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -71,7 +71,11 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
         handleClose={() => setConfirmCollateral(undefined)}
       />
       {selectedAsset && (
-        <SupplyWithdrawModal asset={selectedAsset} onClose={() => setSelectedAsset(undefined)} />
+        <SupplyWithdrawModal
+          asset={selectedAsset}
+          isXvsEnabled={isXvsEnabled}
+          onClose={() => setSelectedAsset(undefined)}
+        />
       )}
     </Paper>
   );

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -6,7 +6,7 @@ import { ToastError } from 'utilities/errors';
 import toast from 'components/Basic/Toast';
 import { useExitMarket, useEnterMarkets } from 'clients/api';
 import { useTranslation } from 'translation';
-import { Delimiter } from 'components';
+import { switchAriaLabel, Delimiter, ITableProps } from 'components';
 import { SupplyWithdrawModal } from '../../Modals';
 import { CollateralConfirmModal } from './CollateralConfirmModal';
 import SupplyMarketTable from './SupplyMarketTable';
@@ -47,6 +47,16 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
       }
     }
   };
+  const rowOnClick = (e: React.MouseEvent<HTMLElement>, row: ITableProps['data'][number]) => {
+    if ((e.target as HTMLElement).ariaLabel !== switchAriaLabel) {
+      const asset = [...suppliedAssets, ...supplyMarketAssets].find(
+        (value: Asset) => value.id === row[0].value,
+      );
+      if (asset) {
+        setSelectedAsset(asset);
+      }
+    }
+  };
   return (
     <Paper className={className} css={styles.tableContainer}>
       {suppliedAssets.length > 0 && (
@@ -54,7 +64,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
           <SuppliedTable
             isXvsEnabled={isXvsEnabled}
             assets={suppliedAssets}
-            setSelectedAsset={setSelectedAsset}
+            rowOnClick={rowOnClick}
             collateralOnChange={collateralOnChange}
           />
           <Delimiter css={styles.delimiter} />
@@ -63,7 +73,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
       <SupplyMarketTable
         isXvsEnabled={isXvsEnabled}
         assets={supplyMarketAssets}
-        setSelectedAsset={setSelectedAsset}
+        rowOnClick={rowOnClick}
         collateralOnChange={collateralOnChange}
       />
       <CollateralConfirmModal

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -73,6 +73,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
       {selectedAsset && (
         <SupplyWithdrawModal
           asset={selectedAsset}
+          assets={[...suppliedAssets, ...supplyMarketAssets]}
           isXvsEnabled={isXvsEnabled}
           onClose={() => setSelectedAsset(undefined)}
         />

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -54,7 +54,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
     });
 
     try {
-      // Send request to repay VAI
+      // Send request to borrow asset
       const transactionHash = await borrow(amountWei);
 
       // Display successful transaction modal

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -5,7 +5,7 @@ import { FormikProps } from 'formik';
 import { Typography } from '@mui/material';
 import toast from 'components/Basic/Toast';
 import { FormValues } from 'containers/AmountForm/validationSchema';
-import { AmountForm, IAmountFormProps } from 'containers/AmountForm';
+import { AmountForm, IAmountFormProps, ErrorCode } from 'containers/AmountForm';
 import {
   TokenTextField,
   Delimiter,
@@ -45,6 +45,7 @@ export const SupplyWithdrawContent: React.FC<
   ISupplyWithdrawFormUiProps & FormikProps<FormValues>
 > = ({
   values,
+  errors,
   setFieldValue,
   asset,
   tokenInfo,
@@ -124,12 +125,14 @@ export const SupplyWithdrawContent: React.FC<
         tokenId={assetId as TokenId}
         value={amountString}
         onChange={amt => setFieldValue('amount', amt, true)}
-        max={maxInput.toFixed()}
+        disabled={isTransactionLoading}
         rightMaxButton={{
           label: t('supplyWithdraw.max').toUpperCase(),
           valueOnClick: maxInput.toFixed(),
         }}
         css={styles.input}
+        // Only display error state if amount is higher than borrow limit
+        hasError={errors.amount === ErrorCode.HIGHER_THAN_MAX}
       />
       <Typography
         component="div"

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -14,6 +14,7 @@ import {
   BorrowBalanceAccountHealth,
   ValueUpdate,
 } from 'components';
+import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { SAFE_BORROW_LIMIT_PERCENTAGE } from 'config';
 import { useTranslation } from 'translation';
 import { Asset, TokenId } from 'types';
@@ -31,7 +32,7 @@ interface ISupplyWithdrawFormUiProps {
   tokenInfo: ILabeledInlineContentProps[];
   userTotalBorrowBalance: BigNumber;
   userTotalBorrowLimit: BigNumber;
-  dailyEarningsCents: BigNumber;
+  dailyEarningsCents: BigNumber | undefined;
   inputLabel: string;
   enabledButtonKey: string;
   disabledButtonKey: string;
@@ -142,7 +143,9 @@ export const SupplyWithdrawContent: React.FC<
         css={styles.getRow({ isLast: false })}
         className="info-row"
       >
-        {formatCentsToReadableValue({ value: dailyEarningsCents })}
+        {dailyEarningsCents
+          ? formatCentsToReadableValue({ value: dailyEarningsCents })
+          : PLACEHOLDER_KEY}
       </LabeledInlineContent>
       <LabeledInlineContent
         label={t('supplyWithdraw.supplyBalance')}

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -59,6 +59,7 @@ export const SupplyWithdrawContent: React.FC<
   calculateNewBalance,
   isTransactionLoading,
   isXvsEnabled,
+  isValid,
 }) => {
   const styles = useStyles();
   const { t, Trans } = useTranslation();
@@ -66,7 +67,7 @@ export const SupplyWithdrawContent: React.FC<
   const { id: assetId } = asset;
   const { amount: amountString } = values;
   const amount = new BigNumber(amountString || 0);
-  const validAmount = amount && !amount.isZero() && !amount.isNaN();
+  const validAmount = amount && !amount.isZero() && !amount.isNaN() && isValid;
   const userTotalBorrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
   const userTotalBorrowLimitCents = userTotalBorrowLimit.multipliedBy(100);
 

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -64,6 +64,8 @@ export const SupplyWithdrawContent: React.FC<
   const { amount: amountString } = values;
   const amount = new BigNumber(amountString || 0);
   const validAmount = amount && !amount.isZero() && !amount.isNaN();
+  const userTotalBorrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
+  const userTotalBorrowLimitCents = userTotalBorrowLimit.multipliedBy(100);
 
   const [newBorrowLimit] = useMemo(() => {
     const tokenPrice = getBigNumber(asset?.tokenPrice);
@@ -122,8 +124,8 @@ export const SupplyWithdrawContent: React.FC<
 
       <BorrowBalanceAccountHealth
         css={styles.getRow({ isLast: true })}
-        borrowBalanceCents={userTotalBorrowBalance.toNumber()}
-        borrowLimitCents={userTotalBorrowLimit.toNumber()}
+        borrowBalanceCents={userTotalBorrowBalanceCents.toNumber()}
+        borrowLimitCents={userTotalBorrowLimitCents.toNumber()}
         safeBorrowLimitPercentage={SAFE_BORROW_LIMIT_PERCENTAGE}
       />
 
@@ -135,7 +137,6 @@ export const SupplyWithdrawContent: React.FC<
         <ValueUpdate original={userTotalBorrowLimit} update={newBorrowLimit} />
       </LabeledInlineContent>
       <Delimiter css={styles.getRow({ isLast: true })} />
-      {/* @TODO add daily earnings calculations https://app.clickup.com/t/24quhp4 */}
       <LabeledInlineContent
         label={t('supplyWithdraw.dailyEarnings')}
         css={styles.getRow({ isLast: false })}

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -34,7 +34,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
   });
 
   it('renders without crashing', async () => {
-    renderComponent(<SupplyWithdraw onClose={jest.fn()} asset={asset} />);
+    renderComponent(
+      <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
+    );
   });
 
   it('asks the user to connect if wallet is not connected', async () => {
@@ -48,7 +50,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           account: undefined,
         }}
       >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} />
+        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
       </AuthContext.Provider>,
     );
 
@@ -74,7 +76,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         }}
       >
-        <SupplyWithdraw onClose={jest.fn()} asset={disabledAsset} />
+        <SupplyWithdraw onClose={jest.fn()} asset={disabledAsset} isXvsEnabled assets={assetData} />
       </AuthContext.Provider>,
     );
     const enableToSupplyText = en.supplyWithdraw.enableToSupply.replace(
@@ -106,7 +108,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         }}
       >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} />
+        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
       </AuthContext.Provider>,
     );
 
@@ -136,7 +138,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         }}
       >
-        <SupplyWithdraw onClose={jest.fn()} asset={bnbAsset} />
+        <SupplyWithdraw onClose={jest.fn()} asset={bnbAsset} isXvsEnabled assets={assetData} />
       </AuthContext.Provider>,
     );
     const tokenTextInput = document.querySelector('input') as HTMLInputElement;
@@ -169,7 +171,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         }}
       >
-        <SupplyWithdraw onClose={jest.fn()} asset={nonBnbAsset} />
+        <SupplyWithdraw onClose={jest.fn()} asset={nonBnbAsset} isXvsEnabled assets={assetData} />
       </AuthContext.Provider>,
     );
     const tokenTextInput = document.querySelector('input') as HTMLInputElement;
@@ -196,7 +198,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         }}
       >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} />
+        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
       </AuthContext.Provider>,
     );
 
@@ -227,7 +229,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         }}
       >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} />
+        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
       </AuthContext.Provider>,
     );
     const withdrawButton = getByText(en.supplyWithdraw.withdraw);

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.stories.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.stories.tsx
@@ -37,7 +37,6 @@ DisconnectedSupply.args = {
   onClose: noop,
   userTotalBorrowBalance: new BigNumber('16'),
   userTotalBorrowLimit: new BigNumber('42.38'),
-  dailyEarningsCents: new BigNumber('238'),
   isSupplyLoading: false,
   isWithdrawLoading: false,
 };
@@ -49,7 +48,6 @@ DisabledSupply.args = {
   onClose: noop,
   userTotalBorrowBalance: new BigNumber('16'),
   userTotalBorrowLimit: new BigNumber('42.38'),
-  dailyEarningsCents: new BigNumber('238'),
   onSubmitSupply: noop,
   onSubmitWithdraw: noop,
   isSupplyLoading: false,
@@ -63,7 +61,6 @@ Supply.args = {
   onClose: noop,
   userTotalBorrowBalance: new BigNumber('16'),
   userTotalBorrowLimit: new BigNumber('42.38'),
-  dailyEarningsCents: new BigNumber('238'),
   onSubmitSupply: noop,
   onSubmitWithdraw: noop,
   isSupplyLoading: false,

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.stories.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.stories.tsx
@@ -34,6 +34,7 @@ const context = {
 export const DisconnectedSupply = Template.bind({});
 DisconnectedSupply.args = {
   asset: assetData[0],
+  assets: assetData,
   onClose: noop,
   userTotalBorrowBalance: new BigNumber('16'),
   userTotalBorrowLimit: new BigNumber('42.38'),
@@ -45,6 +46,7 @@ export const DisabledSupply = Template.bind({});
 DisabledSupply.decorators = [withAuthContext(context)];
 DisabledSupply.args = {
   asset: { ...assetData[0], isEnabled: false },
+  assets: assetData,
   onClose: noop,
   userTotalBorrowBalance: new BigNumber('16'),
   userTotalBorrowLimit: new BigNumber('42.38'),
@@ -58,6 +60,7 @@ export const Supply = Template.bind({});
 Supply.decorators = [withAuthContext(context)];
 Supply.args = {
   asset: assetData[0],
+  assets: assetData,
   onClose: noop,
   userTotalBorrowBalance: new BigNumber('16'),
   userTotalBorrowLimit: new BigNumber('42.38'),

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -187,17 +187,17 @@ export const SupplyWithdrawUi: React.FC<
 
 const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
   const { asset, isXvsEnabled, ...rest } = props;
-  const { account } = useContext(AuthContext);
+  const { account: { address: accountAddress = '' } = {} } = useContext(AuthContext);
   const { t } = useTranslation();
   const { userTotalBorrowBalance, userTotalBorrowLimit } = useUserMarketInfo({
-    accountAddress: account?.address,
+    accountAddress,
   });
   const { data: vTokenBalance } = useGetVTokenBalance(
-    { account: account?.address || '', vTokenId: asset.id as VTokenId },
-    { enabled: !!account },
+    { account: accountAddress, vTokenId: asset.id as VTokenId },
+    { enabled: !!accountAddress },
   );
   const { mutate: supply, isLoading: isSupplyLoading } = useSupply(
-    { asset, account: account?.address || '' },
+    { asset, account: accountAddress },
     {
       onError: () => {
         toast.error({
@@ -211,7 +211,7 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
   const { mutate: redeem, isLoading: isRedeemLoading } = useRedeem(
     {
       assetId: asset?.id as VTokenId,
-      account: account?.address || '',
+      account: accountAddress,
     },
     {
       onError: () => {
@@ -225,7 +225,7 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
   const { mutate: redeemUnderlying, isLoading: isRedeemUnderlyingLoading } = useRedeemUnderlying(
     {
       assetId: asset?.id as VTokenId,
-      account: account?.address || '',
+      account: accountAddress,
     },
     {
       onError: () => {

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -24,7 +24,7 @@ import useSupply from 'clients/api/mutations/useSupply';
 import { useTranslation } from 'translation';
 import { Asset, TokenId, VTokenId } from 'types';
 import { formatApy, getBigNumber } from 'utilities/common';
-import { calculateYearlyEarningsCents, calculateDailyEarningsCents } from 'utilities';
+import { calculateYearlyEarningsForAssets, calculateDailyEarningsCents } from 'utilities';
 import SupplyWithdrawForm from './SupplyWithdrawForm';
 import { useStyles } from '../styles';
 
@@ -32,13 +32,14 @@ export interface ISupplyWithdrawUiProps {
   className?: string;
   onClose: IModalProps['handleClose'];
   asset: Asset;
+  assets: Asset[];
   isXvsEnabled: boolean;
 }
 
 export interface ISupplyWithdrawProps {
   userTotalBorrowBalance: BigNumber;
   userTotalBorrowLimit: BigNumber;
-  dailyEarningsCents: BigNumber;
+  dailyEarningsCents: BigNumber | undefined;
   onSubmitSupply: IAmountFormProps['onSubmit'];
   onSubmitWithdraw: IAmountFormProps['onSubmit'];
   isSupplyLoading: boolean;
@@ -50,7 +51,7 @@ export interface ISupplyWithdrawProps {
  * when closing the modal.
  */
 export const SupplyWithdrawUi: React.FC<
-  Omit<ISupplyWithdrawUiProps, 'isXvsEnabled'> & ISupplyWithdrawProps
+  Omit<ISupplyWithdrawUiProps, 'isXvsEnabled' | 'assets'> & ISupplyWithdrawProps
 > = ({
   className,
   onClose,
@@ -186,7 +187,7 @@ export const SupplyWithdrawUi: React.FC<
 };
 
 const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
-  const { asset, isXvsEnabled, ...rest } = props;
+  const { asset, assets, isXvsEnabled, ...rest } = props;
   const { account: { address: accountAddress = '' } = {} } = useContext(AuthContext);
   const { t } = useTranslation();
   const { userTotalBorrowBalance, userTotalBorrowLimit } = useUserMarketInfo({
@@ -257,9 +258,8 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
     }
   };
   const borrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
-  // @TODO: include all assets in calculation of yearly earnings
-  const { yearlyEarningsCents } = calculateYearlyEarningsCents({
-    asset,
+  const { yearlyEarningsCents } = calculateYearlyEarningsForAssets({
+    assets,
     borrowBalanceCents,
     isXvsEnabled,
   });

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -83,10 +83,9 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
   const calculateNewSupplyAmount = (amount: BigNumber) => userTotalBorrowLimit.plus(amount);
   const calculateNewBorrowAmount = (amount: BigNumber) => userTotalBorrowLimit.minus(amount);
 
-  const renderTabContent = ({
+  const TabContent = ({
     message,
     title,
-    key,
     inputLabel,
     enabledButtonKey,
     disabledButtonKey,
@@ -97,7 +96,6 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
   }: {
     message: string;
     title: string;
-    key: string;
     inputLabel: string;
     enabledButtonKey: string;
     disabledButtonKey: string;
@@ -117,7 +115,6 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
             vtokenAddress={asset.vtokenAddress}
           >
             <SupplyWithdrawForm
-              key={key}
               asset={asset}
               tokenInfo={tokenInfo}
               userTotalBorrowBalance={userTotalBorrowBalance}
@@ -140,33 +137,37 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
   const tabsContent = [
     {
       title: t('supplyWithdraw.supply'),
-      content: renderTabContent({
-        message: t('supplyWithdraw.connectWalletToSupply'),
-        title: t('supplyWithdraw.enableToSupply', { symbol }),
-        key: 'supply',
-        inputLabel: t('supplyWithdraw.walletBalance'),
-        enabledButtonKey: t('supplyWithdraw.supply'),
-        disabledButtonKey: t('supplyWithdraw.enterValidAmountSupply'),
-        maxInputKey: 'walletBalance',
-        calculateNewBalance: calculateNewSupplyAmount,
-        isTransactionLoading: isSupplyLoading,
-        onSubmit: onSubmitSupply,
-      }),
+      content: (
+        <TabContent
+          message={t('supplyWithdraw.connectWalletToSupply')}
+          title={t('supplyWithdraw.enableToSupply', { symbol })}
+          key="supply"
+          inputLabel={t('supplyWithdraw.walletBalance')}
+          enabledButtonKey={t('supplyWithdraw.supply')}
+          disabledButtonKey={t('supplyWithdraw.enterValidAmountSupply')}
+          maxInputKey="walletBalance"
+          calculateNewBalance={calculateNewSupplyAmount}
+          isTransactionLoading={isSupplyLoading}
+          onSubmit={onSubmitSupply}
+        />
+      ),
     },
     {
       title: t('supplyWithdraw.withdraw'),
-      content: renderTabContent({
-        message: t('supplyWithdraw.connectWalletToWithdraw'),
-        title: t('supplyWithdraw.enableToWithdraw', { symbol }),
-        key: 'withdraw',
-        inputLabel: t('supplyWithdraw.withdrawableAmount'),
-        enabledButtonKey: t('supplyWithdraw.withdraw'),
-        disabledButtonKey: t('supplyWithdraw.enterValidAmountWithdraw'),
-        maxInputKey: 'supplyBalance',
-        calculateNewBalance: calculateNewBorrowAmount,
-        isTransactionLoading: isWithdrawLoading,
-        onSubmit: onSubmitWithdraw,
-      }),
+      content: (
+        <TabContent
+          message={t('supplyWithdraw.connectWalletToWithdraw')}
+          title={t('supplyWithdraw.enableToWithdraw', { symbol })}
+          key="withdraw"
+          inputLabel={t('supplyWithdraw.withdrawableAmount')}
+          enabledButtonKey={t('supplyWithdraw.withdraw')}
+          disabledButtonKey={t('supplyWithdraw.enterValidAmountWithdraw')}
+          maxInputKey="supplyBalance"
+          calculateNewBalance={calculateNewBorrowAmount}
+          isTransactionLoading={isWithdrawLoading}
+          onSubmit={onSubmitWithdraw}
+        />
+      ),
     },
   ];
 

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -23,7 +23,7 @@ import useSupply from 'clients/api/mutations/useSupply';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { useTranslation } from 'translation';
 import { Asset, TokenId, VTokenId } from 'types';
-import { formatApy, getBigNumber, convertCoinsToWei } from 'utilities/common';
+import { formatApy, convertCoinsToWei } from 'utilities/common';
 import SupplyWithdrawForm from './SupplyWithdrawForm';
 import { useStyles } from '../styles';
 
@@ -187,6 +187,7 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
 const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
   const { asset, assets, isXvsEnabled, onClose, ...rest } = props;
   const { account: { address: accountAddress = '' } = {} } = useContext(AuthContext);
+
   const { t } = useTranslation();
   const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
   const { userTotalBorrowBalance, userTotalBorrowLimit } = useUserMarketInfo({
@@ -230,7 +231,7 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
   };
 
   const onSubmitWithdraw: IAmountFormProps['onSubmit'] = async value => {
-    const amount = getBigNumber(value);
+    const amount = new BigNumber(value);
     const amountEqualsSupplyBalance = amount.eq(asset.supplyBalance);
     let transactionHash;
     let withdrawlValue;

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -32,6 +32,7 @@ export interface ISupplyWithdrawUiProps {
   className?: string;
   onClose: IModalProps['handleClose'];
   asset: Asset;
+  isXvsEnabled: boolean;
 }
 
 export interface ISupplyWithdrawProps {
@@ -48,7 +49,9 @@ export interface ISupplyWithdrawProps {
  * The fade effect on this component results in that it is still rendered after the asset has been set to undefined
  * when closing the modal.
  */
-export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdrawProps> = ({
+export const SupplyWithdrawUi: React.FC<
+  Omit<ISupplyWithdrawUiProps, 'isXvsEnabled'> & ISupplyWithdrawProps
+> = ({
   className,
   onClose,
   asset,
@@ -183,7 +186,7 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
 };
 
 const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
-  const { asset, ...rest } = props;
+  const { asset, isXvsEnabled, ...rest } = props;
   const { account } = useContext(AuthContext);
   const { t } = useTranslation();
   const { userTotalBorrowBalance, userTotalBorrowLimit } = useUserMarketInfo({
@@ -253,8 +256,6 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
       });
     }
   };
-  // @TODO: elevate state so it can be shared with borrow and supply markets
-  const isXvsEnabled = true;
   const borrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
   // @TODO: include all assets in calculation of yearly earnings
   const { yearlyEarningsCents } = calculateYearlyEarningsCents({

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -84,9 +84,10 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
   const calculateNewSupplyAmount = (initial: BigNumber, amount: BigNumber) => initial.plus(amount);
   const calculateNewBorrowAmount = (initial: BigNumber, amount: BigNumber) => initial.minus(amount);
 
-  const TabContent = ({
+  const renderTabContent = ({
     message,
     title,
+    key,
     inputLabel,
     enabledButtonKey,
     disabledButtonKey,
@@ -97,6 +98,7 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
   }: {
     message: string;
     title: string;
+    key: string;
     inputLabel: string;
     enabledButtonKey: string;
     disabledButtonKey: string;
@@ -116,6 +118,7 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
             vtokenAddress={asset.vtokenAddress}
           >
             <SupplyWithdrawForm
+              key={key}
               asset={asset}
               assets={assets}
               tokenInfo={tokenInfo}
@@ -139,37 +142,33 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
   const tabsContent = [
     {
       title: t('supplyWithdraw.supply'),
-      content: (
-        <TabContent
-          message={t('supplyWithdraw.connectWalletToSupply')}
-          title={t('supplyWithdraw.enableToSupply', { symbol })}
-          key="supply"
-          inputLabel={t('supplyWithdraw.walletBalance')}
-          enabledButtonKey={t('supplyWithdraw.supply')}
-          disabledButtonKey={t('supplyWithdraw.enterValidAmountSupply')}
-          maxInputKey="walletBalance"
-          calculateNewBalance={calculateNewSupplyAmount}
-          isTransactionLoading={isSupplyLoading}
-          onSubmit={onSubmitSupply}
-        />
-      ),
+      content: renderTabContent({
+        message: t('supplyWithdraw.connectWalletToSupply'),
+        title: t('supplyWithdraw.enableToSupply', { symbol }),
+        key: 'supply',
+        inputLabel: t('supplyWithdraw.walletBalance'),
+        enabledButtonKey: t('supplyWithdraw.supply'),
+        disabledButtonKey: t('supplyWithdraw.enterValidAmountSupply'),
+        maxInputKey: 'walletBalance',
+        calculateNewBalance: calculateNewSupplyAmount,
+        isTransactionLoading: isSupplyLoading,
+        onSubmit: onSubmitSupply,
+      }),
     },
     {
       title: t('supplyWithdraw.withdraw'),
-      content: (
-        <TabContent
-          message={t('supplyWithdraw.connectWalletToWithdraw')}
-          title={t('supplyWithdraw.enableToWithdraw', { symbol })}
-          key="withdraw"
-          inputLabel={t('supplyWithdraw.withdrawableAmount')}
-          enabledButtonKey={t('supplyWithdraw.withdraw')}
-          disabledButtonKey={t('supplyWithdraw.enterValidAmountWithdraw')}
-          maxInputKey="supplyBalance"
-          calculateNewBalance={calculateNewBorrowAmount}
-          isTransactionLoading={isWithdrawLoading}
-          onSubmit={onSubmitWithdraw}
-        />
-      ),
+      content: renderTabContent({
+        message: t('supplyWithdraw.connectWalletToWithdraw'),
+        title: t('supplyWithdraw.enableToWithdraw', { symbol }),
+        key: 'withdraw',
+        inputLabel: t('supplyWithdraw.withdrawableAmount'),
+        enabledButtonKey: t('supplyWithdraw.withdraw'),
+        disabledButtonKey: t('supplyWithdraw.enterValidAmountWithdraw'),
+        maxInputKey: 'supplyBalance',
+        calculateNewBalance: calculateNewBorrowAmount,
+        isTransactionLoading: isWithdrawLoading,
+        onSubmit: onSubmitWithdraw,
+      }),
     },
   ];
 

--- a/src/testUtils/renderComponent.tsx
+++ b/src/testUtils/renderComponent.tsx
@@ -31,10 +31,10 @@ const renderComponent = (children: any) => {
     <Theme>
       <Web3Wrapper>
         <QueryClientProvider client={queryClient}>
-          <AuthProvider>
-            <RefreshContextProvider>
-              <VaiContextProvider>
-                <MuiThemeProvider>
+          <MuiThemeProvider>
+            <AuthProvider>
+              <RefreshContextProvider>
+                <VaiContextProvider>
                   <SuccessfulTransactionModalProvider>
                     <BrowserRouter>
                       <ToastContainer
@@ -50,10 +50,10 @@ const renderComponent = (children: any) => {
                       </Switch>
                     </BrowserRouter>
                   </SuccessfulTransactionModalProvider>
-                </MuiThemeProvider>
-              </VaiContextProvider>
-            </RefreshContextProvider>
-          </AuthProvider>
+                </VaiContextProvider>
+              </RefreshContextProvider>
+            </AuthProvider>
+          </MuiThemeProvider>
         </QueryClientProvider>
       </Web3Wrapper>
     </Theme>,

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -62,6 +62,13 @@
   "connectWallet": {
     "connectButton": "Connect wallet"
   },
+  "dashboard": {
+    "markets": {
+      "tabBorrow": "Borrow",
+      "tabSupply": "Supply",
+      "title": "Markets"
+    }
+  },
   "errors": {
     "internal": "An internal error occurred: {{errorMessage}}. Please try again later.",
     "walletNotConnected": "TRANSLATION NEEDED"
@@ -164,6 +171,14 @@
     "enterValidAmountSupply": "Enter a valid amount to supply",
     "enterValidAmountWithdraw": "Enter a valid amount to withdraw",
     "max": "Max",
+    "successfulSupplyTransactionModal": {
+      "message": "You successfully supplied",
+      "title": "Your supply was successful"
+    },
+    "successfulWithdrawTransactionModal": {
+      "message": "You successfully withdrew",
+      "title": "Your withdrawal was successful"
+    },
     "supply": "Supply",
     "supplyApy": "Supply APY",
     "supplyBalance": "Supply Balance",
@@ -178,13 +193,6 @@
     "withdrawError": {
       "description": "There was an error withdrawing {{symbol}}. Please try again later",
       "title": "Withdrawl Error"
-    }
-  },
-  "dashboard": {
-    "markets": {
-      "title": "Markets",
-      "tabSupply": "Supply",
-      "tabBorrow": "Borrow"
     }
   }
 }


### PR DESCRIPTION
 - [x] Show hypothetical borrow limit and daily earnings when user enters a value in input
 - [x] Convert values passed to BorrowBalanceAccountHealth into cents (currently passing dollars) 
 - [x] use XVS lifted state
 - [x] Set default when accessing account (This could be the default value in the context since)
 - [x] Include all assets in calculation of daily earnings
 - [x] Lift theme state above contexts
 - [x] Update validation flow so it doesn't block the user input but instead changes the color of the input to red when the value is higher than the maximum possible (the designs also show an error, but I think we should just ignore it - let me know if you think differently). I've had to integrate the same flow on the borrow/repay modal so have a look if it can help!
 - [x] Pass row onlick as a prop
 - [x] Close modal and display successful transaction modal when transaction is successfully sent
