### PR TITLE
Wrap Repay and Mint Vai with Enable Token Component

### DIFF
--- a/src/components/v2/EnableToken/index.spec.tsx
+++ b/src/components/v2/EnableToken/index.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import BigNumber from 'bignumber.js';
+
+import { useUserMarketInfo } from 'clients/api';
+import { AuthContext } from 'context/AuthContext';
+import renderComponent from 'testUtils/renderComponent';
+import { assetData } from '__mocks__/models/asset';
+import en from 'translation/translations/en.json';
+import { TokenId } from 'types';
+import EnableToken from '.';
+
+jest.mock('clients/api');
+jest.mock('components/Basic/Toast');
+
+const fakeAccountAddress = '0x0';
+const fakeAsset = { ...assetData[0], isEnabled: true };
+
+describe('pages/Dashboard/MintRepayVai/MintVai', () => {
+  it('asks the user to enable token if not enabled', async () => {
+    const disabledFakeAsset = { ...fakeAsset, isEnabled: false };
+    (useUserMarketInfo as jest.Mock).mockImplementationOnce(() => ({
+      assets: [disabledFakeAsset],
+      userTotalBorrowLimit: new BigNumber('111'),
+      userTotalBorrowBalance: new BigNumber('91'),
+    }));
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <EnableToken
+          assetId={disabledFakeAsset.id as TokenId}
+          symbol={disabledFakeAsset.symbol}
+          isEnabled={disabledFakeAsset.isEnabled}
+          title="Enable token to proceed"
+          vtokenAddress={fakeAccountAddress}
+          tokenInfo={[]}
+        >
+          Content
+        </EnableToken>
+      </AuthContext.Provider>,
+    );
+    const enableToMintText = en.mintRepayVai.mintVai.enableToken;
+    const enableTextSupply = getByText(enableToMintText);
+    expect(enableTextSupply).toHaveTextContent(enableToMintText);
+  });
+
+  it('renders content when token is enabled', async () => {
+    const enabledFakeAsset = { ...fakeAsset };
+    (useUserMarketInfo as jest.Mock).mockImplementationOnce(() => ({
+      assets: [enabledFakeAsset],
+      userTotalBorrowLimit: new BigNumber('111'),
+      userTotalBorrowBalance: new BigNumber('91'),
+    }));
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <EnableToken
+          assetId={enabledFakeAsset.id as TokenId}
+          symbol={enabledFakeAsset.symbol}
+          isEnabled={enabledFakeAsset.isEnabled}
+          title="Enable token to proceed"
+          vtokenAddress={fakeAccountAddress}
+          tokenInfo={[]}
+        >
+          Content
+        </EnableToken>
+      </AuthContext.Provider>,
+    );
+    const enableToMintText = en.mintRepayVai.mintVai.enableToken;
+    const enableTextSupply = getByText(enableToMintText);
+    expect(enableTextSupply).toHaveTextContent(enableToMintText);
+  });
+});

--- a/src/components/v2/EnableToken/index.spec.tsx
+++ b/src/components/v2/EnableToken/index.spec.tsx
@@ -2,10 +2,8 @@ import React from 'react';
 import BigNumber from 'bignumber.js';
 
 import { useUserMarketInfo } from 'clients/api';
-import { AuthContext } from 'context/AuthContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
-import en from 'translation/translations/en.json';
 import { TokenId } from 'types';
 import EnableToken from '.';
 
@@ -14,8 +12,9 @@ jest.mock('components/Basic/Toast');
 
 const fakeAccountAddress = '0x0';
 const fakeAsset = { ...assetData[0], isEnabled: true };
+const fakeContent = 'Fake Content';
 
-describe('pages/Dashboard/MintRepayVai/MintVai', () => {
+describe('components/EnableToken', () => {
   it('asks the user to enable token if not enabled', async () => {
     const disabledFakeAsset = { ...fakeAsset, isEnabled: false };
     (useUserMarketInfo as jest.Mock).mockImplementationOnce(() => ({
@@ -24,32 +23,17 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
       userTotalBorrowBalance: new BigNumber('91'),
     }));
     const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
+      <EnableToken
+        assetId={disabledFakeAsset.id as TokenId}
+        isEnabled={disabledFakeAsset.isEnabled}
+        title="Enable token to proceed"
+        vtokenAddress={fakeAccountAddress}
+        tokenInfo={[]}
       >
-        <EnableToken
-          assetId={disabledFakeAsset.id as TokenId}
-          symbol={disabledFakeAsset.symbol}
-          isEnabled={disabledFakeAsset.isEnabled}
-          title="Enable token to proceed"
-          vtokenAddress={fakeAccountAddress}
-          tokenInfo={[]}
-        >
-          Content
-        </EnableToken>
-      </AuthContext.Provider>,
+        {fakeContent}
+      </EnableToken>,
     );
-    const enableToMintText = en.mintRepayVai.mintVai.enableToken;
-    const enableTextSupply = getByText(enableToMintText);
-    expect(enableTextSupply).toHaveTextContent(enableToMintText);
+    expect(getByText('Enable token to proceed'));
   });
 
   it('renders content when token is enabled', async () => {
@@ -60,31 +44,16 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
       userTotalBorrowBalance: new BigNumber('91'),
     }));
     const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
+      <EnableToken
+        assetId={enabledFakeAsset.id as TokenId}
+        isEnabled={enabledFakeAsset.isEnabled}
+        title="Enable token to proceed"
+        vtokenAddress={fakeAccountAddress}
+        tokenInfo={[]}
       >
-        <EnableToken
-          assetId={enabledFakeAsset.id as TokenId}
-          symbol={enabledFakeAsset.symbol}
-          isEnabled={enabledFakeAsset.isEnabled}
-          title="Enable token to proceed"
-          vtokenAddress={fakeAccountAddress}
-          tokenInfo={[]}
-        >
-          Content
-        </EnableToken>
-      </AuthContext.Provider>,
+        {fakeContent}
+      </EnableToken>,
     );
-    const enableToMintText = en.mintRepayVai.mintVai.enableToken;
-    const enableTextSupply = getByText(enableToMintText);
-    expect(enableTextSupply).toHaveTextContent(enableToMintText);
+    expect(getByText(fakeContent));
   });
 });

--- a/src/components/v2/EnableToken/index.stories.tsx
+++ b/src/components/v2/EnableToken/index.stories.tsx
@@ -15,7 +15,7 @@ export const Disabled = () => (
   <EnableTokenUi
     isEnabled={false}
     title="To withdraw BNB to the Venus Protocol, you need to enable it first."
-    symbol="eth"
+    assetId="eth"
     tokenInfo={[
       { iconName: 'vai', label: 'Supply APY', children: '77.36' },
       { iconName: 'vai', label: 'Distribution APY', children: '0.82' },
@@ -31,7 +31,7 @@ export const Enabled = () => (
   <EnableTokenUi
     isEnabled
     title="Enable Token"
-    symbol="ETH"
+    assetId="eth"
     tokenInfo={[]}
     approveToken={noop}
     disabled={false}

--- a/src/components/v2/EnableToken/index.stories.tsx
+++ b/src/components/v2/EnableToken/index.stories.tsx
@@ -31,7 +31,7 @@ export const Enabled = () => (
   <EnableTokenUi
     isEnabled
     title="Enable Token"
-    symbol="eth"
+    symbol="ETH"
     tokenInfo={[]}
     approveToken={noop}
     disabled={false}

--- a/src/components/v2/EnableToken/index.tsx
+++ b/src/components/v2/EnableToken/index.tsx
@@ -11,7 +11,6 @@ import { Delimiter } from '../Delimiter';
 import { LabeledInlineContent, ILabeledInlineContentProps } from '../LabeledInlineContent';
 
 export interface IEnableTokenProps {
-  symbol: string;
   assetId: TokenId;
   isEnabled: boolean;
   title: string | React.ReactElement;
@@ -21,8 +20,8 @@ export interface IEnableTokenProps {
   disabled?: boolean;
 }
 
-export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress' | 'assetId'>> = ({
-  symbol,
+export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> = ({
+  assetId,
   title,
   tokenInfo,
   isEnabled,
@@ -36,7 +35,7 @@ export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress' | '
   }
   return (
     <div css={styles.container}>
-      <Icon name={symbol as IconName} css={styles.mainLogo} />
+      <Icon name={assetId as IconName} css={styles.mainLogo} />
       <Typography component="h3" variant="h3" css={styles.mainText}>
         {title}
       </Typography>
@@ -59,6 +58,7 @@ export const EnableToken: React.FC<
   return (
     <EnableTokenUi
       {...rest}
+      assetId={assetId}
       approveToken={() => approveToken({ accountAddress: account?.address, vtokenAddress })}
       disabled={!account}
     />

--- a/src/components/v2/EnableToken/index.tsx
+++ b/src/components/v2/EnableToken/index.tsx
@@ -11,7 +11,8 @@ import { Delimiter } from '../Delimiter';
 import { LabeledInlineContent, ILabeledInlineContentProps } from '../LabeledInlineContent';
 
 export interface IEnableTokenProps {
-  symbol: TokenId;
+  symbol: string;
+  assetId: TokenId;
   isEnabled: boolean;
   title: string | React.ReactElement;
   tokenInfo: ILabeledInlineContentProps[];
@@ -20,7 +21,7 @@ export interface IEnableTokenProps {
   disabled?: boolean;
 }
 
-export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> = ({
+export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress' | 'assetId'>> = ({
   symbol,
   title,
   tokenInfo,
@@ -52,13 +53,12 @@ export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> =
 
 export const EnableToken: React.FC<
   Omit<IEnableTokenProps, 'approveToken' | 'account' | 'disabled'>
-> = ({ symbol, vtokenAddress, ...rest }) => {
-  const { mutate: approveToken } = useApproveToken({ assetId: symbol });
+> = ({ vtokenAddress, assetId, ...rest }) => {
+  const { mutate: approveToken } = useApproveToken({ assetId });
   const { account } = useContext(AuthContext);
   return (
     <EnableTokenUi
       {...rest}
-      symbol={symbol}
       approveToken={() => approveToken({ accountAddress: account?.address, vtokenAddress })}
       disabled={!account}
     />

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -10,7 +10,6 @@ import { AuthContext } from 'context/AuthContext';
 import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
-import en from 'translation/translations/en.json';
 import RepayVai from '.';
 
 jest.mock('clients/api');
@@ -130,33 +129,5 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
       title: expect.any(String),
     });
   });
-
-  it('asks the user to enable token if not enabled', async () => {
-    const disabledFakeVaiAsset = { ...fakeVai, isEnabled: false };
-    (useUserMarketInfo as jest.Mock).mockImplementationOnce(() => ({
-      assets: [disabledFakeVaiAsset],
-      userTotalBorrowLimit: new BigNumber('111'),
-      userTotalBorrowBalance: new BigNumber('91'),
-    }));
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <RepayVai />
-      </AuthContext.Provider>,
-    );
-    const enableToMintText = en.mintRepayVai.mintVai.enableToken;
-    const enableTextSupply = getByText(enableToMintText);
-    expect(enableTextSupply).toHaveTextContent(enableToMintText);
-  });
-
   // @TODO: add tests to cover failing scenarios
 });

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -35,7 +35,21 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
   });
 
   it('renders without crashing', async () => {
-    const { getByText } = renderComponent(<RepayVai />);
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <RepayVai />
+      </AuthContext.Provider>,
+    );
     await waitFor(() => getByText('Available VAI limit'));
   });
 
@@ -45,16 +59,28 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
     );
 
     const { getByText } = renderComponent(
-      <VaiContext.Provider
+      <AuthContext.Provider
         value={{
-          userVaiEnabled: true,
-          userVaiMinted: new BigNumber(0),
-          mintableVai: fakeMintableVai,
-          userVaiBalance: new BigNumber(0),
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
         }}
       >
-        <RepayVai />
-      </VaiContext.Provider>,
+        <VaiContext.Provider
+          value={{
+            userVaiEnabled: true,
+            userVaiMinted: new BigNumber(0),
+            mintableVai: fakeMintableVai,
+            userVaiBalance: new BigNumber(0),
+          }}
+        >
+          <RepayVai />
+        </VaiContext.Provider>
+      </AuthContext.Provider>,
     );
     await waitFor(() => getByText('Available VAI limit'));
 
@@ -67,8 +93,6 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
   it('lets user mint VAI', async () => {
     const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
     (mintVai as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
-
-    const fakeAccountAddress = '0x0';
 
     const { getByText, getByPlaceholderText } = renderComponent(
       <VaiContext.Provider

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
@@ -117,7 +117,8 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
 
   return (
     <EnableToken
-      symbol={VAI_ID}
+      symbol={VAI_ID.toUpperCase()}
+      assetId={VAI_ID}
       title={t('mintRepayVai.mintVai.enableToken')}
       tokenInfo={tokenInfo}
       isEnabled={!!userVaiEnabled}

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
@@ -17,6 +17,7 @@ import {
   SecondaryButton,
   LabeledInlineContent,
   TokenTextField,
+  ConnectWallet,
 } from 'components';
 import { useVaiUser } from 'hooks/useVaiUser';
 import { useGetVaiTreasuryPercentage, useMintVai } from 'clients/api';
@@ -116,62 +117,63 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
   ];
 
   return (
-    <EnableToken
-      symbol={VAI_ID.toUpperCase()}
-      assetId={VAI_ID}
-      title={t('mintRepayVai.mintVai.enableToken')}
-      tokenInfo={tokenInfo}
-      isEnabled={!!userVaiEnabled}
-      vtokenAddress={vaiToken.address}
-    >
-      <AmountForm onSubmit={onSubmit} css={styles.tabContentContainer}>
-        {({ values, setFieldValue, handleBlur, isValid, dirty }) => (
-          <>
-            <div css={styles.ctaContainer}>
-              <TokenTextField
-                name="amount"
-                css={styles.textField}
-                tokenId={VAI_ID}
-                value={values.amount}
-                onChange={amount => setFieldValue('amount', amount, true)}
-                onBlur={handleBlur}
-                max={limitTokens}
-                disabled={disabled || isMintVaiLoading || !hasMintableVai}
-                rightMaxButton={{
-                  label: t('mintRepayVai.mintVai.rightMaxButtonLabel'),
-                  valueOnClick: limitTokens,
-                }}
-              />
+    <ConnectWallet message={t('mintRepayVai.mintVai.connectWallet')}>
+      <EnableToken
+        assetId={VAI_ID}
+        title={t('mintRepayVai.mintVai.enableToken')}
+        tokenInfo={tokenInfo}
+        isEnabled={!!userVaiEnabled}
+        vtokenAddress={vaiToken.address}
+      >
+        <AmountForm onSubmit={onSubmit} css={styles.tabContentContainer}>
+          {({ values, setFieldValue, handleBlur, isValid, dirty }) => (
+            <>
+              <div css={styles.ctaContainer}>
+                <TokenTextField
+                  name="amount"
+                  css={styles.textField}
+                  tokenId={VAI_ID}
+                  value={values.amount}
+                  onChange={amount => setFieldValue('amount', amount, true)}
+                  onBlur={handleBlur}
+                  max={limitTokens}
+                  disabled={disabled || isMintVaiLoading || !hasMintableVai}
+                  rightMaxButton={{
+                    label: t('mintRepayVai.mintVai.rightMaxButtonLabel'),
+                    valueOnClick: limitTokens,
+                  }}
+                />
 
-              <LabeledInlineContent
-                css={styles.getRow({ isLast: false })}
-                iconName={VAI_ID}
-                label={t('mintRepayVai.mintVai.vaiLimitLabel')}
+                <LabeledInlineContent
+                  css={styles.getRow({ isLast: false })}
+                  iconName={VAI_ID}
+                  label={t('mintRepayVai.mintVai.vaiLimitLabel')}
+                >
+                  {readableVaiLimit}
+                </LabeledInlineContent>
+
+                <LabeledInlineContent
+                  css={styles.getRow({ isLast: true })}
+                  iconName="fee"
+                  label={t('mintRepayVai.mintVai.mintFeeLabel')}
+                >
+                  {getReadableMintFee(values.amount)}
+                </LabeledInlineContent>
+              </div>
+
+              <SecondaryButton
+                type="submit"
+                loading={isMintVaiLoading}
+                disabled={disabled || !isValid || !dirty}
+                fullWidth
               >
-                {readableVaiLimit}
-              </LabeledInlineContent>
-
-              <LabeledInlineContent
-                css={styles.getRow({ isLast: true })}
-                iconName="fee"
-                label={t('mintRepayVai.mintVai.mintFeeLabel')}
-              >
-                {getReadableMintFee(values.amount)}
-              </LabeledInlineContent>
-            </div>
-
-            <SecondaryButton
-              type="submit"
-              loading={isMintVaiLoading}
-              disabled={disabled || !isValid || !dirty}
-              fullWidth
-            >
-              {t('mintRepayVai.mintVai.btnMintVai')}
-            </SecondaryButton>
-          </>
-        )}
-      </AmountForm>
-    </EnableToken>
+                {t('mintRepayVai.mintVai.btnMintVai')}
+              </SecondaryButton>
+            </>
+          )}
+        </AmountForm>
+      </EnableToken>
+    </ConnectWallet>
   );
 };
 

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -10,7 +10,6 @@ import { AuthContext } from 'context/AuthContext';
 import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
-import en from 'translation/translations/en.json';
 import RepayVai from '.';
 
 jest.mock('clients/api');
@@ -122,33 +121,5 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
       title: expect.any(String),
     });
   });
-
-  it('asks the user to enable token if not enabled', async () => {
-    const disabledFakeVaiAsset = { ...fakeVai, isEnabled: false };
-    (useUserMarketInfo as jest.Mock).mockImplementationOnce(() => ({
-      assets: [disabledFakeVaiAsset],
-      userTotalBorrowLimit: new BigNumber('111'),
-      userTotalBorrowBalance: new BigNumber('91'),
-    }));
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <RepayVai />
-      </AuthContext.Provider>,
-    );
-    const enableToRepayText = en.mintRepayVai.repayVai.enableToken;
-    const enableTextSupply = getByText(enableToRepayText);
-    expect(enableTextSupply).toHaveTextContent(enableToRepayText);
-  });
-
   // @TODO: add tests to cover failing scenarios
 });

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -34,22 +34,48 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
   });
 
   it('renders without crashing', async () => {
-    const { getByText } = renderComponent(<RepayVai />);
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <RepayVai />
+      </AuthContext.Provider>,
+    );
     await waitFor(() => getByText('Repay VAI balance'));
   });
 
   it('displays the correct repay VAI balance', async () => {
     const { getByText } = renderComponent(
-      <VaiContext.Provider
+      <AuthContext.Provider
         value={{
-          userVaiEnabled: true,
-          userVaiMinted: fakeUserVaiMinted,
-          mintableVai: new BigNumber(0),
-          userVaiBalance: new BigNumber(0),
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
         }}
       >
-        <RepayVai />
-      </VaiContext.Provider>,
+        <VaiContext.Provider
+          value={{
+            userVaiEnabled: true,
+            userVaiMinted: fakeUserVaiMinted,
+            mintableVai: new BigNumber(0),
+            userVaiBalance: new BigNumber(0),
+          }}
+        >
+          <RepayVai />
+        </VaiContext.Provider>
+      </AuthContext.Provider>,
     );
     await waitFor(() => getByText('Repay VAI balance'));
 

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
@@ -99,7 +99,8 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
 
   return (
     <EnableToken
-      symbol={VAI_ID}
+      symbol={VAI_ID.toUpperCase()}
+      assetId={VAI_ID}
       title={t('mintRepayVai.repayVai.enableToken')}
       tokenInfo={tokenInfo}
       isEnabled={!!userVaiEnabled}

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
@@ -11,6 +11,7 @@ import { AmountForm, IAmountFormProps } from 'containers/AmountForm';
 import { AuthContext } from 'context/AuthContext';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import {
+  ConnectWallet,
   EnableToken,
   IconName,
   ILabeledInlineContentProps,
@@ -98,54 +99,55 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
   ];
 
   return (
-    <EnableToken
-      symbol={VAI_ID.toUpperCase()}
-      assetId={VAI_ID}
-      title={t('mintRepayVai.repayVai.enableToken')}
-      tokenInfo={tokenInfo}
-      isEnabled={!!userVaiEnabled}
-      vtokenAddress={vaiToken.address}
-    >
-      <AmountForm onSubmit={onSubmit} css={styles.tabContentContainer}>
-        {({ values, setFieldValue, handleBlur, isValid, dirty }) => (
-          <>
-            <div css={styles.ctaContainer}>
-              <TokenTextField
-                name="amount"
-                css={styles.textField}
-                tokenId={VAI_ID}
-                value={values.amount}
-                onChange={amount => setFieldValue('amount', amount, true)}
-                onBlur={handleBlur}
-                max={limitTokens}
-                disabled={disabled || isRepayVaiLoading || !hasRepayableVai}
-                rightMaxButton={{
-                  label: t('mintRepayVai.repayVai.rightMaxButtonLabel'),
-                  valueOnClick: limitTokens,
-                }}
-              />
+    <ConnectWallet message={t('mintRepayVai.repayVai.connectWallet')}>
+      <EnableToken
+        assetId={VAI_ID}
+        title={t('mintRepayVai.repayVai.enableToken')}
+        tokenInfo={tokenInfo}
+        isEnabled={!!userVaiEnabled}
+        vtokenAddress={vaiToken.address}
+      >
+        <AmountForm onSubmit={onSubmit} css={styles.tabContentContainer}>
+          {({ values, setFieldValue, handleBlur, isValid, dirty }) => (
+            <>
+              <div css={styles.ctaContainer}>
+                <TokenTextField
+                  name="amount"
+                  css={styles.textField}
+                  tokenId={VAI_ID}
+                  value={values.amount}
+                  onChange={amount => setFieldValue('amount', amount, true)}
+                  onBlur={handleBlur}
+                  max={limitTokens}
+                  disabled={disabled || isRepayVaiLoading || !hasRepayableVai}
+                  rightMaxButton={{
+                    label: t('mintRepayVai.repayVai.rightMaxButtonLabel'),
+                    valueOnClick: limitTokens,
+                  }}
+                />
 
-              <LabeledInlineContent
-                css={styles.getRow({ isLast: true })}
-                iconName={VAI_ID}
-                label={t('mintRepayVai.repayVai.repayVaiBalance')}
+                <LabeledInlineContent
+                  css={styles.getRow({ isLast: true })}
+                  iconName={VAI_ID}
+                  label={t('mintRepayVai.repayVai.repayVaiBalance')}
+                >
+                  {readableRepayableVai}
+                </LabeledInlineContent>
+              </div>
+
+              <SecondaryButton
+                type="submit"
+                loading={isRepayVaiLoading}
+                disabled={disabled || !isValid || !dirty}
+                fullWidth
               >
-                {readableRepayableVai}
-              </LabeledInlineContent>
-            </div>
-
-            <SecondaryButton
-              type="submit"
-              loading={isRepayVaiLoading}
-              disabled={disabled || !isValid || !dirty}
-              fullWidth
-            >
-              {t('mintRepayVai.repayVai.btnRepayVai')}
-            </SecondaryButton>
-          </>
-        )}
-      </AmountForm>
-    </EnableToken>
+                {t('mintRepayVai.repayVai.btnRepayVai')}
+              </SecondaryButton>
+            </>
+          )}
+        </AmountForm>
+      </EnableToken>
+    </ConnectWallet>
   );
 };
 

--- a/src/pages/Dashboard/MintRepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/index.spec.tsx
@@ -1,12 +1,24 @@
 import React from 'react';
+import BigNumber from 'bignumber.js';
 import { waitFor, fireEvent } from '@testing-library/react';
-
+import { useUserMarketInfo } from 'clients/api';
 import renderComponent from 'testUtils/renderComponent';
+import { assetData } from '__mocks__/models/asset';
 import MintRepayVai from '.';
 
 jest.mock('clients/api');
 
+const fakeVai = { ...assetData, id: 'vai', symbol: 'VAI', isEnabled: true };
+
 describe('pages/Dashboard/MintRepayVai', () => {
+  beforeEach(() => {
+    (useUserMarketInfo as jest.Mock).mockImplementation(() => ({
+      assets: [...assetData, fakeVai],
+      userTotalBorrowLimit: new BigNumber('111'),
+      userTotalBorrowBalance: new BigNumber('91'),
+    }));
+  });
+
   it('renders without crashing', async () => {
     const { getByText } = renderComponent(<MintRepayVai />);
     await waitFor(() => getByText('Mint/Repay VAI'));

--- a/src/pages/Dashboard/MintRepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/index.spec.tsx
@@ -2,12 +2,14 @@ import React from 'react';
 import BigNumber from 'bignumber.js';
 import { waitFor, fireEvent } from '@testing-library/react';
 import { useUserMarketInfo } from 'clients/api';
+import { AuthContext } from 'context/AuthContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
 import MintRepayVai from '.';
 
 jest.mock('clients/api');
 
+const fakeAccountAddress = '0x0';
 const fakeVai = { ...assetData, id: 'vai', symbol: 'VAI', isEnabled: true };
 
 describe('pages/Dashboard/MintRepayVai', () => {
@@ -20,12 +22,40 @@ describe('pages/Dashboard/MintRepayVai', () => {
   });
 
   it('renders without crashing', async () => {
-    const { getByText } = renderComponent(<MintRepayVai />);
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <MintRepayVai />
+      </AuthContext.Provider>,
+    );
     await waitFor(() => getByText('Mint/Repay VAI'));
   });
 
   it('renders mint tab by default and lets user switch to repay tab', async () => {
-    const { getByText } = renderComponent(<MintRepayVai />);
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <MintRepayVai />
+      </AuthContext.Provider>,
+    );
 
     // Check mint tab is display by default
     await waitFor(() => getByText('Available VAI limit'));

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -198,7 +198,8 @@ const Borrow: React.FC<IBorrowProps> = ({ asset, onClose, isXvsEnabled }) => {
     <ConnectWallet message={t('borrowRepayModal.borrow.connectWalletMessage')}>
       {asset && (
         <EnableToken
-          symbol={asset.id}
+          assetId={asset.id}
+          symbol={asset.symbol}
           title={t('borrowRepayModal.borrow.enableToken.title', { symbol: asset.symbol })}
           tokenInfo={[
             {

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -199,7 +199,6 @@ const Borrow: React.FC<IBorrowProps> = ({ asset, onClose, isXvsEnabled }) => {
       {asset && (
         <EnableToken
           assetId={asset.id}
-          symbol={asset.symbol}
           title={t('borrowRepayModal.borrow.enableToken.title', { symbol: asset.symbol })}
           tokenInfo={[
             {

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -222,7 +222,8 @@ const Repay: React.FC<IRepayProps> = ({ asset, onClose, isXvsEnabled }) => {
     <ConnectWallet message={t('borrowRepayModal.repay.connectWalletMessage')}>
       {asset && (
         <EnableToken
-          symbol={asset.id}
+          assetId={asset.id}
+          symbol={asset.symbol}
           title={t('borrowRepayModal.repay.enableToken.title', { symbol: asset.symbol })}
           tokenInfo={[
             {

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -223,7 +223,6 @@ const Repay: React.FC<IRepayProps> = ({ asset, onClose, isXvsEnabled }) => {
       {asset && (
         <EnableToken
           assetId={asset.id}
-          symbol={asset.symbol}
           title={t('borrowRepayModal.repay.enableToken.title', { symbol: asset.symbol })}
           tokenInfo={[
             {

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -62,39 +62,6 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
     expect(connectTextWithdraw).toHaveTextContent(en.supplyWithdraw.connectWalletToWithdraw);
   });
 
-  it('asks the user to enable token if not enabled', async () => {
-    const disabledAsset = { ...asset, isEnabled: false };
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={disabledAsset} isXvsEnabled assets={assetData} />
-      </AuthContext.Provider>,
-    );
-    const enableToSupplyText = en.supplyWithdraw.enableToSupply.replace(
-      '{{symbol}}',
-      disabledAsset.symbol,
-    );
-    const enableToWithdrawText = en.supplyWithdraw.enableToWithdraw.replace(
-      '{{symbol}}',
-      disabledAsset.symbol,
-    );
-    const enableTextSupply = getByText(enableToSupplyText);
-    expect(enableTextSupply).toHaveTextContent(enableToSupplyText);
-    const withdrawButton = getByText(en.supplyWithdraw.withdraw);
-    fireEvent.click(withdrawButton);
-    const enableTextWithdraw = getByText(enableToWithdrawText);
-    expect(enableTextWithdraw).toHaveTextContent(enableToWithdrawText);
-  });
-
   it('submit is disabled with no amount', async () => {
     const { getByText } = renderComponent(
       <AuthContext.Provider

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -111,7 +111,8 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
       <ConnectWallet message={message}>
         {asset && (
           <EnableToken
-            symbol={assetId as TokenId}
+            assetId={asset.id as TokenId}
+            symbol={asset.symbol}
             title={title}
             tokenInfo={tokenInfo}
             isEnabled={!!isEnabled}

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -112,7 +112,6 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
         {asset && (
           <EnableToken
             assetId={asset.id as TokenId}
-            symbol={asset.symbol}
             title={title}
             tokenInfo={tokenInfo}
             isEnabled={!!isEnabled}

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -87,7 +87,6 @@
     }
   },
   "errors": {
-    "internal": "An internal error occurred: {{errorMessage}}. Please try again later.",
     "walletNotConnected": "Wallet not connected"
   },
   "footer": {
@@ -148,6 +147,7 @@
   "mintRepayVai": {
     "mintVai": {
       "btnMintVai": "Mint VAI",
+      "connectWallet": "Please connect your wallet to mint",
       "enableToken": "To mint VAI to the Venus Protocol, you need to approve it first",
       "mintFeeLabel": "Mint fee",
       "rightMaxButtonLabel": "SAFE MAX",
@@ -160,10 +160,10 @@
     },
     "repayVai": {
       "btnRepayVai": "Repay VAI",
+      "connectWallet": "Please connect your wallet to repay",
       "enableToken": "To repay VAI to the Venus Protocol, you need to approve it first",
       "repayVaiBalance": "Repay VAI balance",
       "rightMaxButtonLabel": "MAX",
-      "successMessage": "You successfully repaid {{tokens}}",
       "undefinedAccountErrorMessage": "account undefined"
     },
     "tabMint": "Mint VAI",
@@ -207,10 +207,6 @@
     "supplyBalanceValue": "{{amount}} {{symbol}}",
     "walletBalance": "Wallet balance: <White>{{amount}} {{symbol}}</White>",
     "withdraw": "Withdraw",
-    "withdrawableAmount": "Withdrawable amount: <White>{{amount}} {{symbol}}</White>",
-    "withdrawError": {
-      "description": "There was an error withdrawing {{symbol}}. Please try again later",
-      "title": "Withdrawl Error"
-    }
+    "withdrawableAmount": "Withdrawable amount: <White>{{amount}} {{symbol}}</White>"
   }
 }

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -148,6 +148,7 @@
   "mintRepayVai": {
     "mintVai": {
       "btnMintVai": "Mint VAI",
+      "enableToken": "To mint VAI to the Venus Protocol, you need to approve it first",
       "mintFeeLabel": "Mint fee",
       "rightMaxButtonLabel": "SAFE MAX",
       "successfulTransactionModal": {
@@ -159,6 +160,7 @@
     },
     "repayVai": {
       "btnRepayVai": "Repay VAI",
+      "enableToken": "To repay VAI to the Venus Protocol, you need to approve it first",
       "repayVaiBalance": "Repay VAI balance",
       "rightMaxButtonLabel": "MAX",
       "successMessage": "You successfully repaid {{tokens}}",
@@ -205,6 +207,10 @@
     "supplyBalanceValue": "{{amount}} {{symbol}}",
     "walletBalance": "Wallet balance: <White>{{amount}} {{symbol}}</White>",
     "withdraw": "Withdraw",
-    "withdrawableAmount": "Withdrawable amount: <White>{{amount}} {{symbol}}</White>"
+    "withdrawableAmount": "Withdrawable amount: <White>{{amount}} {{symbol}}</White>",
+    "withdrawError": {
+      "description": "There was an error withdrawing {{symbol}}. Please try again later",
+      "title": "Withdrawl Error"
+    }
   }
 }


### PR DESCRIPTION
The PR wrap the the Repay and Mint VAI component in the Enable Token Component so that the user will only see the form if they've enable the token.

If they haven't enable the token they will be prompted to enable it