### PR TITLE
Fix warnings printed in console

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,6 +63,7 @@ module.exports = {
         },
       },
     ],
+    '@typescript-eslint/explicit-module-boundary-types': 0,
     'react/jsx-wrap-multilines': 0,
     'generator-star-spacing': 0,
   },

--- a/src/clients/api/mutations/redeem.ts
+++ b/src/clients/api/mutations/redeem.ts
@@ -10,6 +10,6 @@ export interface IRedeemInput {
 export type RedeemOutput = TransactionReceipt;
 
 const redeem = async ({ tokenContract, account, amount }: IRedeemInput): Promise<RedeemOutput> =>
-  tokenContract.methods.redeem(amount).send({ from: account! });
+  tokenContract.methods.redeem(amount).send({ from: account });
 
 export default redeem;

--- a/src/clients/api/mutations/redeemUnderlying.ts
+++ b/src/clients/api/mutations/redeemUnderlying.ts
@@ -14,6 +14,6 @@ const redeemUnderlying = async ({
   account,
   amount,
 }: IRedeemUnderlyingInput): Promise<RedeemUnderlyingOutput> =>
-  tokenContract.methods.redeemUnderlying(amount).send({ from: account! });
+  tokenContract.methods.redeemUnderlying(amount).send({ from: account });
 
 export default redeemUnderlying;

--- a/src/components/Basic/Table.tsx
+++ b/src/components/Basic/Table.tsx
@@ -90,7 +90,7 @@ const MarketTableWrapper = styled.div`
         text-align: right;
         width: 28%;
 
-        &:first-child {
+        &:first-of-type {
           width: 16%;
         }
 
@@ -116,7 +116,7 @@ const MarketTableWrapper = styled.div`
         text-align: right;
         width: 28%;
 
-        &:first-child {
+        &:first-of-type {
           width: 16%;
         }
 

--- a/src/components/v2/ProgressBar/index.tsx
+++ b/src/components/v2/ProgressBar/index.tsx
@@ -42,30 +42,33 @@ export const ProgressBar = ({
     secondaryOver: mark ? !!(secondaryValue && secondaryValue > mark) : false,
   });
 
-  const renderMark = (props?: NonNullable<SliderTypeMap['props']['componentsProps']>['mark']) => {
-    if (markTooltip) {
-      return (
-        <Box component="span" {...props} css={[styles.mark, styles.hasTooltip]}>
-          <Tooltip placement={tooltipPlacement} title={markTooltip}>
-            <span css={styles.tooltipHelper}>.</span>
-          </Tooltip>
-        </Box>
-      );
-    }
-
-    return <Box component="span" {...props} css={styles.mark} />;
-  };
+  const renderMark = (props?: NonNullable<SliderTypeMap['props']['componentsProps']>['mark']) => (
+    <Box
+      component="span"
+      style={props?.style}
+      className={props?.className}
+      css={[styles.mark, markTooltip ? styles.hasTooltip : undefined]}
+    >
+      {markTooltip && (
+        <Tooltip placement={tooltipPlacement} title={markTooltip}>
+          <span css={styles.tooltipHelper}>.</span>
+        </Tooltip>
+      )}
+    </Box>
+  );
 
   const renderTrack = (props?: NonNullable<SliderTypeMap['props']['componentsProps']>['track']) => {
-    const primaryRail = trackTooltip ? (
-      <div style={props?.style} css={[styles.trackWrapper, styles.hasTooltip]}>
-        <Tooltip placement={tooltipPlacement} title={trackTooltip}>
-          {/* passed styles undefined here because wrapper is now handling this part */}
-          <Box {...props} style={undefined} />
-        </Tooltip>
-      </div>
-    ) : (
-      <Box css={styles.trackWrapper} {...props} />
+    const primaryRail = (
+      <Box
+        style={props?.style}
+        css={[styles.trackWrapper, trackTooltip ? styles.hasTooltip : undefined]}
+      >
+        {trackTooltip && (
+          <Tooltip placement={tooltipPlacement} title={trackTooltip}>
+            <Box className={props?.className} />
+          </Tooltip>
+        )}
+      </Box>
     );
 
     return (
@@ -75,8 +78,7 @@ export const ProgressBar = ({
         {secondaryValue !== undefined && (
           <Box
             css={styles.secondaryRail(secondaryValue < max ? secondaryValue : max)}
-            {...props}
-            style={undefined}
+            className={props?.className}
           />
         )}
       </>

--- a/src/components/v2/Table/styles.ts
+++ b/src/components/v2/Table/styles.ts
@@ -74,7 +74,7 @@ export const useStyles = () => {
         cursor: pointer;
       }
 
-      .MuiTableCell-root:first-child {
+      .MuiTableCell-root:first-of-type {
         padding-left: ${theme.spacing(6)};
         text-align: left;
         justify-content: flex-start;

--- a/src/pages/Dashboard/Markets/styles.ts
+++ b/src/pages/Dashboard/Markets/styles.ts
@@ -70,7 +70,7 @@ export const useStyles = () => {
       display: flex;
       flex-direction: column;
 
-      > :first-child {
+      > :first-of-type {
         color: ${theme.palette.text.primary};
       }
     `,
@@ -78,7 +78,7 @@ export const useStyles = () => {
       display: flex;
       width: 100%;
       align-items: center;
-      > :first-child {
+      > :first-of-type {
         margin-right: ${theme.spacing(2)};
       }
     `,

--- a/src/pages/Dashboard/MyAccount/styles.ts
+++ b/src/pages/Dashboard/MyAccount/styles.ts
@@ -79,7 +79,7 @@ export const useMyAccountStyles = () => {
         }
       }
 
-      :first-child {
+      :first-of-type {
         border-left: none;
         padding-left: 0;
       }


### PR DESCRIPTION
- disable `@typescript-eslint/explicit-module-boundary-types` eslint rule. We infer most of the return types of our functions already, this rule doesn't do anything for us
- remove unnecessary type assertions
- replace `:first-child` instances with `:first-of-type`. The explanation for this comes from [this post](https://stackoverflow.com/questions/57239807/the-pseudo-class-first-child-is-potentially-unsafe-when-doing-server-side-ren):
> This comes from [@emotion](https://emotion.sh/docs/introduction) through storybook - since emotion (creates CSS through JavaScript) sometimes injects a <style> element in the beginning - which would make that the first child and breaks your CSS. first-of-type [is supported in most browsers these days](https://caniuse.com/?search=first-of-type) and can be used in many cases alternatively.
- Update `ProgressBar` so only recognized props are spread on tags. This still doesn't fix a warning we're getting:
<img width="788" alt="Screen Shot 2022-05-04 at 08 54 40" src="https://user-images.githubusercontent.com/44675210/166642200-ab69711a-3946-4cce-9c75-2f32d3bd756f.png">
But since it seems to come from MUI directly, we can't do anything about it other than updating MUI if they've released a fix (I haven't looked into it, since updating the library could break other elements of the app).
