### PR TITLE
Position mobile menu so it is fullscreen

### DIFF
--- a/src/components/v2/Layout/Sidebar/index.tsx
+++ b/src/components/v2/Layout/Sidebar/index.tsx
@@ -87,6 +87,8 @@ export const SidebarUi: React.FC = () => {
           transitionDuration={0}
           marginThreshold={0}
           TransitionProps={{ style: { transition: 'background 0.2s linear' } }}
+          anchorReference="anchorPosition"
+          anchorPosition={{ top: 0, left: 0 }}
         >
           <div css={[styles.flexRow, styles.doublePadding]}>
             <LogoMobile css={styles.mobileLogo} />

--- a/src/components/v2/Layout/Sidebar/styles.ts
+++ b/src/components/v2/Layout/Sidebar/styles.ts
@@ -173,10 +173,6 @@ export const useStyles = () => {
 
       > .MuiPaper-root {
         background-color: ${theme.palette.background.default};
-        background-image: none;
-        position: absolute;
-        top: 0;
-        left: 0;
         height: 100vh;
         max-height: 100vh;
         width: 100vw;


### PR DESCRIPTION
Positions the menu using materialui Menu props because the current styling is fragile and make break if the container styles change