### PR TITLE
Shorten large liquidities

### DIFF
--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -67,6 +67,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
         render: () =>
           formatCentsToReadableValue({
             value: asset.liquidity.multipliedBy(100),
+            shorthand: true,
           }),
         value: asset.liquidity.toNumber(),
       },

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -168,18 +168,39 @@ export const convertCoinsToWei = ({ value, tokenId }: { value: BigNumber; tokenI
 export const convertCentsToDollars = (value: number) =>
   new BigNumber(value).dividedBy(100).toFixed(2);
 
+const ONE_BILLION = 1000000000;
+const ONE_MILLION = 1000000;
+const ONE_THOUSAND = 1000;
+
 export const formatCentsToReadableValue = ({
   value,
+  shorthand = false,
 }: {
   value: number | BigNumber | undefined;
+  shorthand?: boolean;
 }) => {
   if (value === undefined) {
     return PLACEHOLDER_KEY;
   }
 
-  return `$${formatCommaThousandsPeriodDecimal(
-    convertCentsToDollars(typeof value === 'number' ? value : value.toNumber()),
-  )}`;
+  if (!shorthand) {
+    return `$${formatCommaThousandsPeriodDecimal(
+      convertCentsToDollars(typeof value === 'number' ? value : value.toNumber()),
+    )}`;
+  }
+
+  // Shorten value
+  const wrappedValueDollars = new BigNumber(value).dividedBy(100);
+  let shortenedValue = wrappedValueDollars.toFixed(2);
+  if (wrappedValueDollars.isGreaterThan(ONE_BILLION)) {
+    shortenedValue = `${wrappedValueDollars.dividedBy(ONE_BILLION).dp(2).toFixed()}B`;
+  } else if (wrappedValueDollars.isGreaterThan(ONE_MILLION)) {
+    shortenedValue = `${wrappedValueDollars.dividedBy(ONE_MILLION).dp(2).toFixed()}M`;
+  } else if (wrappedValueDollars.isGreaterThan(ONE_THOUSAND)) {
+    shortenedValue = `${wrappedValueDollars.dividedBy(ONE_THOUSAND).dp(2).toFixed()}K`;
+  }
+
+  return `$${shortenedValue}`;
 };
 
 export const formatToReadablePercentage = (value: number | string | BigNumber | undefined) => {


### PR DESCRIPTION
After speaking and agreeing with the design team, this PR adds an optional `shorthand` param to `formatCentsToReadableValue` so large values can be shortened.
<img width="138" alt="Screen Shot 2022-05-04 at 19 20 34" src="https://user-images.githubusercontent.com/44675210/166800524-e57f20ac-6cd2-4466-acf6-3128f7869fbb.png">
