### PR TITLE
Update default order of dashboard tables

### DIFF
--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -84,7 +84,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
       data={rows}
       initialOrder={{
         orderBy: 'apy',
-        orderDirection: 'asc',
+        orderDirection: 'desc',
       }}
       rowKeyIndex={0}
       rowOnClick={rowOnClick}

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
@@ -102,7 +102,7 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
       data={rows}
       initialOrder={{
         orderBy: 'apyEarned',
-        orderDirection: 'asc',
+        orderDirection: 'desc',
       }}
       rowKeyIndex={0}
       rowOnClick={rowOnClick}

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -90,7 +90,7 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
       data={rows}
       initialOrder={{
         orderBy: 'apyEarned',
-        orderDirection: 'asc',
+        orderDirection: 'desc',
       }}
       rowOnClick={rowOnClick}
       rowKeyIndex={0}

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -87,7 +87,7 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
       data={rows}
       initialOrder={{
         orderBy: 'apy',
-        orderDirection: 'asc',
+        orderDirection: 'desc',
       }}
       rowOnClick={rowOnClick}
       rowKeyIndex={0}


### PR DESCRIPTION
Order by by APY from highest to lowest (the most interesting tokens are the ones with the highest APYs).