### PR TITLE
Apply missing styles when tooltip is not rendered

### DIFF
--- a/src/components/v2/ProgressBar/index.tsx
+++ b/src/components/v2/ProgressBar/index.tsx
@@ -63,10 +63,12 @@ export const ProgressBar = ({
         style={props?.style}
         css={[styles.trackWrapper, trackTooltip ? styles.hasTooltip : undefined]}
       >
-        {trackTooltip && (
+        {trackTooltip ? (
           <Tooltip placement={tooltipPlacement} title={trackTooltip}>
             <Box className={props?.className} />
           </Tooltip>
+        ) : (
+          <Box className={props?.className} />
         )}
       </Box>
     );


### PR DESCRIPTION
Apply component with passed prop styles when not rendering track tooltip