### PR TITLE
Fix max input on withdraw and borrow forms

### DIFF
--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -172,10 +172,14 @@ const Borrow: React.FC<IBorrowProps> = ({ asset, onClose, isXvsEnabled }) => {
 
   // Calculate maximum and safe maximum amount of coins user can borrow
   const [limitTokens, safeLimitTokens] = React.useMemo(() => {
-    const safeBorrowLimitCents = borrowLimitCents.multipliedBy(SAFE_BORROW_LIMIT_PERCENTAGE / 100);
-    const marginWithBorrowLimitCents = borrowLimitCents.minus(totalBorrowBalanceCents);
-    const marginWithSafeBorrowLimitCents = safeBorrowLimitCents.minus(totalBorrowBalanceCents);
+    // Return 0 values if borrow limit has been reached
+    if (totalBorrowBalanceCents.isGreaterThan(borrowLimitCents)) {
+      return ['0', '0'];
+    }
 
+    const marginWithBorrowLimitCents = borrowLimitCents.minus(totalBorrowBalanceCents);
+    const safeBorrowLimitCents = borrowLimitCents.multipliedBy(SAFE_BORROW_LIMIT_PERCENTAGE / 100);
+    const marginWithSafeBorrowLimitCents = safeBorrowLimitCents.minus(totalBorrowBalanceCents);
     const tokenDecimals = getVBepToken(asset.id as VTokenId).decimals;
     const formatValue = (value: BigNumber) => value.toFixed(tokenDecimals, BigNumber.ROUND_DOWN);
 

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -52,7 +52,10 @@ export const RepayForm: React.FC<IRepayFormProps> = ({
 
   const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
 
-  const limitTokens = BigNumber.min(asset.borrowBalance, asset.walletBalance).toFixed();
+  const limitTokens = React.useMemo(
+    () => BigNumber.min(asset.borrowBalance, asset.walletBalance).toFixed(),
+    [asset.borrowBalance, asset.walletBalance],
+  );
 
   const getTokenBorrowBalancePercentageTokens = React.useCallback(
     (percentage: number) =>

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -29,12 +29,13 @@ interface ISupplyWithdrawFormUiProps {
   asset: Asset;
   assets: Asset[];
   tokenInfo: ILabeledInlineContentProps[];
+  availableBalance: BigNumber;
+  maxInput: BigNumber;
   userTotalBorrowBalance: BigNumber;
   userTotalBorrowLimit: BigNumber;
   inputLabel: string;
   enabledButtonKey: string;
   disabledButtonKey: string;
-  maxInput: BigNumber;
   calculateNewBalance: (initial: BigNumber, amount: BigNumber) => BigNumber;
   isTransactionLoading: boolean;
   isXvsEnabled: boolean;
@@ -46,6 +47,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
   userTotalBorrowBalance,
   userTotalBorrowLimit,
   assets,
+  availableBalance,
   maxInput,
   inputLabel,
   enabledButtonKey,
@@ -132,7 +134,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
           components={{
             White: <span css={styles.whiteLabel} />,
           }}
-          values={{ amount: format(maxInput), symbol: assetId?.toUpperCase() }}
+          values={{ amount: format(availableBalance), symbol: assetId?.toUpperCase() }}
         />
       </Typography>
 
@@ -199,6 +201,7 @@ interface ISupplyWithdrawFormProps extends ISupplyWithdrawFormUiProps {
 const SupplyWithdrawForm: React.FC<ISupplyWithdrawFormProps> = ({
   onSubmit,
   maxInput,
+  availableBalance,
   ...props
 }) => {
   const onSubmitHandleError: IAmountFormProps['onSubmit'] = async (value: string) => {
@@ -210,7 +213,9 @@ const SupplyWithdrawForm: React.FC<ISupplyWithdrawFormProps> = ({
   };
   return (
     <AmountForm onSubmit={onSubmitHandleError} maxAmount={maxInput.toFixed()}>
-      {() => <SupplyWithdrawContent maxInput={maxInput} {...props} />}
+      {() => (
+        <SupplyWithdrawContent maxInput={maxInput} availableBalance={availableBalance} {...props} />
+      )}
     </AmountForm>
   );
 };

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -29,7 +29,6 @@ interface ISupplyWithdrawFormUiProps {
   asset: Asset;
   assets: Asset[];
   tokenInfo: ILabeledInlineContentProps[];
-  availableBalance: BigNumber;
   maxInput: BigNumber;
   userTotalBorrowBalance: BigNumber;
   userTotalBorrowLimit: BigNumber;
@@ -47,7 +46,6 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
   userTotalBorrowBalance,
   userTotalBorrowLimit,
   assets,
-  availableBalance,
   maxInput,
   inputLabel,
   enabledButtonKey,
@@ -134,7 +132,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
           components={{
             White: <span css={styles.whiteLabel} />,
           }}
-          values={{ amount: format(availableBalance), symbol: assetId?.toUpperCase() }}
+          values={{ amount: format(maxInput), symbol: assetId?.toUpperCase() }}
         />
       </Typography>
 
@@ -201,7 +199,6 @@ interface ISupplyWithdrawFormProps extends ISupplyWithdrawFormUiProps {
 const SupplyWithdrawForm: React.FC<ISupplyWithdrawFormProps> = ({
   onSubmit,
   maxInput,
-  availableBalance,
   ...props
 }) => {
   const onSubmitHandleError: IAmountFormProps['onSubmit'] = async (value: string) => {
@@ -213,9 +210,7 @@ const SupplyWithdrawForm: React.FC<ISupplyWithdrawFormProps> = ({
   };
   return (
     <AmountForm onSubmit={onSubmitHandleError} maxAmount={maxInput.toFixed()}>
-      {() => (
-        <SupplyWithdrawContent maxInput={maxInput} availableBalance={availableBalance} {...props} />
-      )}
+      {() => <SupplyWithdrawContent maxInput={maxInput} {...props} />}
     </AmountForm>
   );
 };

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -155,7 +155,6 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
                 enabledButtonKey={enabledButtonKey}
                 disabledButtonKey={disabledButtonKey}
                 maxInput={maxInput}
-                availableBalance={type === 'supply' ? asset.walletBalance : asset.supplyBalance}
                 calculateNewBalance={calculateNewBalance}
                 isTransactionLoading={isTransactionLoading}
                 isXvsEnabled={isXvsEnabled}

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -81,76 +81,96 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
       ]
     : [];
 
-  const calculateNewSupplyAmount = (initial: BigNumber, amount: BigNumber) => initial.plus(amount);
-  const calculateNewBorrowAmount = (initial: BigNumber, amount: BigNumber) => initial.minus(amount);
-
   const renderTabContent = ({
+    type,
     message,
     title,
-    key,
     inputLabel,
     enabledButtonKey,
     disabledButtonKey,
-    maxInputKey,
     calculateNewBalance,
     isTransactionLoading,
     onSubmit,
   }: {
+    type: 'supply' | 'withdraw';
     message: string;
     title: string;
-    key: string;
     inputLabel: string;
     enabledButtonKey: string;
     disabledButtonKey: string;
-    maxInputKey: 'walletBalance' | 'supplyBalance';
     calculateNewBalance: (initial: BigNumber, amount: BigNumber) => BigNumber;
     isTransactionLoading: boolean;
     onSubmit: IAmountFormProps['onSubmit'];
-  }) => (
-    <div className={className} css={styles.container}>
-      <ConnectWallet message={message}>
-        {asset && (
-          <EnableToken
-            assetId={asset.id as TokenId}
-            title={title}
-            tokenInfo={tokenInfo}
-            isEnabled={!!isEnabled}
-            vtokenAddress={asset.vtokenAddress}
-          >
-            <SupplyWithdrawForm
-              key={key}
-              asset={asset}
-              assets={assets}
+  }) => {
+    const maxInput = React.useMemo(() => {
+      let maxInputDollars = asset.walletBalance;
+
+      // If asset isn't used as collateral user can withdraw the entire supply
+      // balance without affecting their borrow limit
+      if (type === 'withdraw' && !asset.collateral) {
+        maxInputDollars = asset.supplyBalance;
+      } else if (type === 'withdraw') {
+        // Calculate how much token user can withdraw before they risk getting
+        // liquidated (if their borrow balance goes above their borrow limit)
+        const marginWithBorrowLimitDollars = userTotalBorrowLimit.minus(userTotalBorrowBalance);
+        const collateralAmountPerTokenDollars = asset.tokenPrice.multipliedBy(
+          asset.collateralFactor,
+        );
+        const maxTokensBeforeLiquidation = marginWithBorrowLimitDollars
+          .dividedBy(collateralAmountPerTokenDollars)
+          .dp(asset.decimals, BigNumber.ROUND_DOWN);
+
+        maxInputDollars = BigNumber.minimum(maxTokensBeforeLiquidation, asset.supplyBalance);
+      }
+
+      return maxInputDollars;
+    }, []);
+
+    return (
+      <div className={className} css={styles.container}>
+        <ConnectWallet message={message}>
+          {asset && (
+            <EnableToken
+              assetId={asset.id as TokenId}
+              title={title}
               tokenInfo={tokenInfo}
-              userTotalBorrowBalance={userTotalBorrowBalance}
-              userTotalBorrowLimit={userTotalBorrowLimit}
-              onSubmit={onSubmit}
-              inputLabel={inputLabel}
-              enabledButtonKey={enabledButtonKey}
-              disabledButtonKey={disabledButtonKey}
-              maxInput={asset[maxInputKey]}
-              calculateNewBalance={calculateNewBalance}
-              isTransactionLoading={isTransactionLoading}
-              isXvsEnabled={isXvsEnabled}
-            />
-          </EnableToken>
-        )}
-      </ConnectWallet>
-    </div>
-  );
+              isEnabled={!!isEnabled}
+              vtokenAddress={asset.vtokenAddress}
+            >
+              <SupplyWithdrawForm
+                asset={asset}
+                assets={assets}
+                tokenInfo={tokenInfo}
+                userTotalBorrowBalance={userTotalBorrowBalance}
+                userTotalBorrowLimit={userTotalBorrowLimit}
+                onSubmit={onSubmit}
+                inputLabel={inputLabel}
+                enabledButtonKey={enabledButtonKey}
+                disabledButtonKey={disabledButtonKey}
+                maxInput={maxInput}
+                availableBalance={type === 'supply' ? asset.walletBalance : asset.supplyBalance}
+                calculateNewBalance={calculateNewBalance}
+                isTransactionLoading={isTransactionLoading}
+                isXvsEnabled={isXvsEnabled}
+              />
+            </EnableToken>
+          )}
+        </ConnectWallet>
+      </div>
+    );
+  };
 
   const tabsContent = [
     {
       title: t('supplyWithdraw.supply'),
       content: renderTabContent({
+        type: 'supply',
         message: t('supplyWithdraw.connectWalletToSupply'),
         title: t('supplyWithdraw.enableToSupply', { symbol }),
-        key: 'supply',
         inputLabel: t('supplyWithdraw.walletBalance'),
         enabledButtonKey: t('supplyWithdraw.supply'),
         disabledButtonKey: t('supplyWithdraw.enterValidAmountSupply'),
-        maxInputKey: 'walletBalance',
-        calculateNewBalance: calculateNewSupplyAmount,
+        calculateNewBalance: (initial: BigNumber, amount: BigNumber) => initial.plus(amount),
         isTransactionLoading: isSupplyLoading,
         onSubmit: onSubmitSupply,
       }),
@@ -158,14 +178,13 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
     {
       title: t('supplyWithdraw.withdraw'),
       content: renderTabContent({
+        type: 'withdraw',
         message: t('supplyWithdraw.connectWalletToWithdraw'),
         title: t('supplyWithdraw.enableToWithdraw', { symbol }),
-        key: 'withdraw',
         inputLabel: t('supplyWithdraw.withdrawableAmount'),
         enabledButtonKey: t('supplyWithdraw.withdraw'),
         disabledButtonKey: t('supplyWithdraw.enterValidAmountWithdraw'),
-        maxInputKey: 'supplyBalance',
-        calculateNewBalance: calculateNewBorrowAmount,
+        calculateNewBalance: (initial: BigNumber, amount: BigNumber) => initial.minus(amount),
         isTransactionLoading: isWithdrawLoading,
         onSubmit: onSubmitWithdraw,
       }),


### PR DESCRIPTION
I previously opened this as a PR and merged it by accident to a separate branch (so the changes aren't in `develop` thankfully). Sam from the smart contract team spotted an issue where negative values would be set if the borrow limit had been reached, so I added this fix too:
- dissociate `maxInput` from available balance on `SupplyWithdrawForm`
- update calculation of `maxInput` to avoid risking liquidation
- update calculation of `limitTokens` and `safeLimitTokens` to account for case where borrow limit has been reached

@coreyar you had a comment about wanting to dissociate the functions to calculate the updated balance, I've made the change in this PR. Let me know your thoughts.