### PR TITLE
Run tests before commit and display coverage files

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,2 @@
 yarn tsc
+yarn test --watchAll=false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "start": "react-scripts --max_old_space_size=4096 start",
     "prepare": "git apply patches/@stylelint+postcss-css-in-js+0.37.2.patch",
     "build": "react-scripts --max_old_space_size=4096 build",
-    "test": "react-scripts test",
+    "test": "react-scripts test --coverage",
     "eject": "react-scripts eject",
     "pretty": "yarn prettier \"src/**/*.{js,jsx,ts,tsx,html,json,md}\" public/**/*.html --check",
     "lint": "export NODE_OPTIONS=\"--max-old-space-size=4096\" && eslint .",


### PR DESCRIPTION
This PR runs tests before committing and shows coverage on committed files.

While this will add a bit of time to the commit checks I think this is nice because the coverage output even ignoring files that will be removed is really long and not easy to digest. At some point we could add a full report to PRs and enforce a level of coverage with a badge on the README.

My thought is viewing coverage on changed will help guide writing tests as changes are made.