### PR TITLE
Fix amount of decimals used to display wallet balance on Supply form

### DIFF
--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -132,7 +132,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
           components={{
             White: <span css={styles.whiteLabel} />,
           }}
-          values={{ amount: format(maxInput), symbol: assetId?.toUpperCase() }}
+          values={{ amount: format(maxInput, asset.decimals), symbol: assetId?.toUpperCase() }}
         />
       </Typography>
 


### PR DESCRIPTION
<img width="513" alt="Screen Shot 2022-05-06 at 14 57 02" src="https://user-images.githubusercontent.com/44675210/167147572-a7c00197-2414-44a4-bd71-761f8d2c8249.png">
