### PR TITLE
Update grid layout of dashboard tables

### DIFF
--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -89,7 +89,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
       }}
       rowKeyIndex={0}
       rowOnClick={rowOnClick}
-      gridTemplateColumns={styles.getGridTemplateColumns({ isMobile: isSmDown })}
+      gridTemplateColumns={styles.getGridTemplateColumns({ isCardLayout: isLgDown })}
     />
   );
 };

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
@@ -106,7 +106,7 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
       }}
       rowKeyIndex={0}
       rowOnClick={rowOnClick}
-      gridTemplateColumns={styles.getGridTemplateColumns({ isMobile: isSmDown })}
+      gridTemplateColumns={styles.getGridTemplateColumns({ isCardLayout: isLgDown })}
     />
   );
 };

--- a/src/pages/Dashboard/Markets/BorrowMarket/styles.ts
+++ b/src/pages/Dashboard/Markets/BorrowMarket/styles.ts
@@ -1,4 +1,12 @@
-export const useStyles = () => ({
-  getGridTemplateColumns: ({ isMobile }: { isMobile: boolean }) =>
-    isMobile ? '1fr 1fr 1fr' : '120px 1fr 1fr 1fr',
-});
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  return {
+    getGridTemplateColumns: ({ isCardLayout }: { isCardLayout: boolean }) =>
+      isCardLayout
+        ? '1fr 1fr 1fr'
+        : `minmax(${theme.spacing(30)}, 1fr) 1fr 1fr minmax(${theme.spacing(31)}, 1fr)`,
+  };
+};

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -94,7 +94,7 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
       }}
       rowOnClick={rowOnClick}
       rowKeyIndex={0}
-      gridTemplateColumns={styles.getGridTemplateColumns({ isMobile: isSmDown })}
+      gridTemplateColumns={styles.getGridTemplateColumns({ isCardLayout: isLgDown })}
     />
   );
 };

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -91,7 +91,7 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
       }}
       rowOnClick={rowOnClick}
       rowKeyIndex={0}
-      gridTemplateColumns={styles.getGridTemplateColumns({ isMobile: isSmDown })}
+      gridTemplateColumns={styles.getGridTemplateColumns({ isCardLayout: isLgDown })}
     />
   );
 };

--- a/src/pages/Dashboard/Markets/SupplyMarket/styles.ts
+++ b/src/pages/Dashboard/Markets/SupplyMarket/styles.ts
@@ -1,4 +1,12 @@
-export const useStyles = () => ({
-  getGridTemplateColumns: ({ isMobile }: { isMobile: boolean }) =>
-    isMobile ? '1fr 1fr 120px' : '120px 1fr 1fr 1fr',
-});
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  return {
+    getGridTemplateColumns: ({ isCardLayout }: { isCardLayout: boolean }) =>
+      isCardLayout
+        ? `1fr 1fr minmax(${theme.spacing(30)}, 1fr)`
+        : `minmax(${theme.spacing(30)}, 1fr) 1fr 1fr minmax(${theme.spacing(36)}, 1fr)`,
+  };
+};


### PR DESCRIPTION
To make the tables a bit more flexible in terms of responsiveness, this PR uses `minmax` for some of the grid columns so they scale with all screen resolutions.