### PR TITLE
Add back key to supply and withdraw forms

### DIFF
--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -145,6 +145,7 @@ export const SupplyWithdrawUi: React.FC<ISupplyWithdrawUiProps & ISupplyWithdraw
               vtokenAddress={asset.vtokenAddress}
             >
               <SupplyWithdrawForm
+                key={`form-${type}`}
                 asset={asset}
                 assets={assets}
                 tokenInfo={tokenInfo}


### PR DESCRIPTION
I replaced them in one of my previous PR with "type", thinking they weren't used for anything else but they actually are used to differentiate each form from the other. This PR adds the keys back.