### PR TITLE
Update borrow form tests

### DIFF
--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -41,8 +41,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     renderComponent(<Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />);
   });
 
-  // @TODO: enable once PR to fix form has been fixed (https://github.com/VenusProtocol/venus-protocol-interface/pull/428)
-  it.skip('disables submit button if an amount entered in input is higher than asset liquidity', async () => {
+  it('disables submit button if an amount entered in input is higher than asset liquidity', async () => {
     const customFakeAsset: Asset = {
       ...fakeAsset,
       liquidity: new BigNumber(200),

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -195,7 +195,8 @@ const Borrow: React.FC<IBorrowProps> = ({ asset, onClose, isXvsEnabled }) => {
       .dividedBy(asset.tokenPrice);
 
     const tokenDecimals = getVBepToken(asset.id as VTokenId).decimals;
-    const formatValue = (value: BigNumber) => value.toFixed(tokenDecimals, BigNumber.ROUND_DOWN);
+    const formatValue = (value: BigNumber) =>
+      value.dp(tokenDecimals, BigNumber.ROUND_DOWN).toString(10);
 
     return [formatValue(maxCoins), formatValue(safeMaxCoins)];
   }, [


### PR DESCRIPTION
Add tests to cover the most important paths:
- User can’t borrow more than available liquidity
- User can’t borrow amount that would put their borrow balance above their borrow limit
- Pressing on “80% limit” updates input value to the maximum amount of tokens user can borrow before their borrow balance goes above 80% of their borrow limit
- User can borrow amount that is less or equal to available liquidity and that would keep their borrow balance below their borrow limit