### PR TITLE
Update repay form tests

### DIFF
--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -75,7 +75,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));
     expect(
       getByText(en.borrowRepayModal.borrow.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
   });
 
   it('disables submit button if amount to borrow requested would make user borrow balance go higher than their borrow limit', async () => {
@@ -94,7 +94,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     // Check submit button is disabled
     expect(
       getByText(en.borrowRepayModal.borrow.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
 
     const fakeBorrowDeltaDollars = fakeUserTotalBorrowLimitDollars.minus(
       fakeUserTotalBorrowBalanceDollars,
@@ -149,9 +149,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     await waitFor(() => expect(input.value).toBe(expectedInputValue));
 
     // Check submit button is enabled
-    expect(
-      getByText(en.borrowRepayModal.borrow.submitButton).closest('button'),
-    ).not.toHaveAttribute('disabled');
+    expect(getByText(en.borrowRepayModal.borrow.submitButton).closest('button')).toBeEnabled();
   });
 
   it('lets user borrow tokens, then displays successful transaction modal and calls onClose callback on success', async () => {

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -60,7 +60,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
 
     expect(
       getByText(en.borrowRepayModal.borrow.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
 
     const incorrectValueTokens = customFakeAsset.liquidity
       .dividedBy(customFakeAsset.tokenPrice)
@@ -114,7 +114,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));
     expect(
       getByText(en.borrowRepayModal.borrow.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
   });
 
   it('updates input value correctly when pressing on max button', async () => {
@@ -174,7 +174,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
 
     expect(
       getByText(en.borrowRepayModal.borrow.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
 
     // Enter amount in input
     const correctAmountTokens = 1;

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -11,7 +11,7 @@ import { useUserMarketInfo, repayNonBnbVToken } from 'clients/api';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import renderComponent from 'testUtils/renderComponent';
 import en from 'translation/translations/en.json';
-import Repay from '.';
+import Repay, { PRESET_PERCENTAGES } from '.';
 
 const fakeAsset: Asset = {
   ...assetData[0],
@@ -37,41 +37,25 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
   });
 
   it('displays correct token borrow balance', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
-    );
+    const { getByText } = renderComponent(<Repay asset={fakeAsset} onClose={noop} isXvsEnabled />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
+        },
+      },
+    });
 
     await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
   });
 
   it('displays correct token wallet balance', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
-    );
+    const { getByText } = renderComponent(<Repay asset={fakeAsset} onClose={noop} isXvsEnabled />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
+        },
+      },
+    });
 
     await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
   });
@@ -83,19 +67,14 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     };
 
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
 
@@ -119,19 +98,14 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
 
   it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
 
@@ -153,7 +127,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     ).toHaveAttribute('disabled');
   });
 
-  it('updates input value to token wallet balance when it is lower than token borrow balance', async () => {
+  it('updates input value to token wallet balance when pressing on max button if token wallet balance is lower than token borrow balance', async () => {
     const customFakeAsset: Asset = {
       ...fakeAsset,
       borrowBalance: new BigNumber(100),
@@ -161,19 +135,14 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     };
 
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
 
@@ -194,7 +163,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     );
   });
 
-  it('updates input value to token borrow balance when it is lower than token wallet balance', async () => {
+  it('updates input value to token borrow balance when pressing on max button if token borrow balance is lower than token wallet balance', async () => {
     const customFakeAsset: Asset = {
       ...fakeAsset,
       borrowBalance: new BigNumber(10),
@@ -202,19 +171,14 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     };
 
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
 
@@ -235,9 +199,15 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     );
   });
 
-  it('disables submit button if an incorrect amount is entered in input', async () => {
+  it('updates input value to correct value when pressing on preset percentage buttons', async () => {
+    const customFakeAsset: Asset = {
+      ...fakeAsset,
+      borrowBalance: new BigNumber(100),
+      walletBalance: new BigNumber(100),
+    };
+
     const { getByText, getByTestId } = renderComponent(
-      () => <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />,
+      <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />,
       {
         authContextValue: {
           account: {
@@ -248,28 +218,29 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
 
-    expect(
-      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    // Check input is empty
+    const input = getByTestId('token-text-field') as HTMLInputElement;
+    expect(input.value).toBe('');
 
-    // Enter amount in input
-    fireEvent.change(getByTestId('token-text-field'), {
-      target: { value: fakeAsset.borrowBalance.toFixed() },
-    });
+    for (let i = 0; i < PRESET_PERCENTAGES.length; i++) {
+      const presetPercentage = PRESET_PERCENTAGES[i];
 
-    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButton));
-    expect(getByText(en.borrowRepayModal.repay.submitButton).closest('button')).not.toHaveAttribute(
-      'disabled',
-    );
+      // Press on preset percentage button
+      fireEvent.click(getByText(`${presetPercentage}%`));
 
-    // Enter amount higher than maximum borrow limit in input
-    fireEvent.change(getByTestId('token-text-field'), {
-      target: { value: fakeAsset.borrowBalance.plus(1).toFixed() },
-    });
-    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
-    expect(
-      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+      const expectedInputValue = customFakeAsset.borrowBalance
+        .multipliedBy(presetPercentage / 100)
+        .dp(customFakeAsset.decimals)
+        .toFixed();
+
+      // eslint-disable-next-line
+      await waitFor(() => expect(input.value).toBe(expectedInputValue));
+
+      // Check submit button is enabled
+      expect(
+        getByText(en.borrowRepayModal.repay.submitButton).closest('button'),
+      ).not.toHaveAttribute('disabled');
+    }
   });
 
   it('lets user repay borrowed tokens, then displays successful transaction modal and calls onClose callback on success', async () => {
@@ -279,7 +250,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     (repayNonBnbVToken as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
     const { getByText, getByTestId } = renderComponent(
-      () => <Repay asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />,
+      <Repay asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />,
       {
         authContextValue: {
           account: {
@@ -294,16 +265,18 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
       getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
     ).toHaveAttribute('disabled');
 
+    const correctAmountTokens = 1;
+
     // Enter amount in input
     fireEvent.change(getByTestId('token-text-field'), {
-      target: { value: fakeAsset.borrowBalance.toFixed() },
+      target: { value: correctAmountTokens },
     });
 
     // Click on submit button
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButton));
     fireEvent.click(getByText(en.borrowRepayModal.repay.submitButton));
 
-    const expectedAmountWei = fakeAsset.borrowBalance.multipliedBy(
+    const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
       new BigNumber(10).pow(fakeAsset.decimals),
     );
 

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -80,7 +80,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
 
     expect(
       getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
 
     const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
 
@@ -93,7 +93,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
     expect(
       getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
   });
 
   it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {
@@ -111,7 +111,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
 
     expect(
       getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
 
     const incorrectValueTokens = fakeAsset.borrowBalance.plus(1).toFixed();
 
@@ -124,7 +124,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
     expect(
       getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
   });
 
   it('updates input value to token wallet balance when pressing on max button if token wallet balance is lower than token borrow balance', async () => {
@@ -158,9 +158,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     await waitFor(() => expect(input.value).toBe(expectedInputValue));
 
     // Check submit button is enabled
-    expect(getByText(en.borrowRepayModal.repay.submitButton).closest('button')).not.toHaveAttribute(
-      'disabled',
-    );
+    expect(getByText(en.borrowRepayModal.repay.submitButton).closest('button')).toBeEnabled();
   });
 
   it('updates input value to token borrow balance when pressing on max button if token borrow balance is lower than token wallet balance', async () => {
@@ -194,9 +192,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     await waitFor(() => expect(input.value).toBe(expectedInputValue));
 
     // Check submit button is enabled
-    expect(getByText(en.borrowRepayModal.repay.submitButton).closest('button')).not.toHaveAttribute(
-      'disabled',
-    );
+    expect(getByText(en.borrowRepayModal.repay.submitButton).closest('button')).toBeEnabled();
   });
 
   it('updates input value to correct value when pressing on preset percentage buttons', async () => {
@@ -239,7 +235,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
       // Check submit button is enabled
       expect(
         getByText(en.borrowRepayModal.repay.submitButton).closest('button'),
-      ).not.toHaveAttribute('disabled');
+      ).not.toBeDisabled();
     }
   });
 
@@ -263,7 +259,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
 
     expect(
       getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
-    ).toHaveAttribute('disabled');
+    ).toBeDisabled();
 
     const correctAmountTokens = 1;
 

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -56,6 +56,26 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
   });
 
+  it('displays correct wallet balance for the relevant token', async () => {
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
+  });
+
   it('disables submit button if an incorrect amount is entered in input', async () => {
     const { getByText, getByTestId } = renderComponent(
       () => <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />,

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -151,7 +151,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     expect(input.value).toBe('');
 
     // Press on max button
-    fireEvent.click(getByText('MAX'));
+    fireEvent.click(getByText(en.borrowRepayModal.repay.rightMaxButtonLabel));
 
     const expectedInputValue = customFakeAsset.walletBalance.dp(customFakeAsset.decimals).toFixed();
 
@@ -185,7 +185,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     expect(input.value).toBe('');
 
     // Press on max button
-    fireEvent.click(getByText('MAX'));
+    fireEvent.click(getByText(en.borrowRepayModal.repay.rightMaxButtonLabel));
 
     const expectedInputValue = customFakeAsset.borrowBalance.dp(customFakeAsset.decimals).toFixed();
 

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -203,7 +203,7 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     };
 
     const { getByText, getByTestId } = renderComponent(
-      <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />,
+      <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />,
       {
         authContextValue: {
           account: {

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -76,6 +76,42 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
   });
 
+  it('disables submit button if an amount entered in input is higher than borrow balance of token', async () => {
+    const { getByText, getByTestId } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
+
+    expect(
+      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
+    ).toHaveAttribute('disabled');
+
+    const incorrectValueTokens = fakeAsset.borrowBalance.plus(1).toFixed();
+
+    // Enter amount in input
+    fireEvent.change(getByTestId('token-text-field'), {
+      target: { value: incorrectValueTokens },
+    });
+
+    // Check submit button is disabled
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
+    expect(
+      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
+    ).toHaveAttribute('disabled');
+  });
+
   it('disables submit button if an incorrect amount is entered in input', async () => {
     const { getByText, getByTestId } = renderComponent(
       () => <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />,

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -77,6 +77,47 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
   });
 
   it('disables submit button if an amount entered in input is higher than borrow balance of token', async () => {
+    const customFakeAsset: Asset = {
+      ...fakeAsset,
+      walletBalance: new BigNumber(1),
+    };
+
+    const { getByText, getByTestId } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <Repay asset={customFakeAsset} onClose={noop} isXvsEnabled />
+      </AuthContext.Provider>,
+    );
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
+
+    expect(
+      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
+    ).toHaveAttribute('disabled');
+
+    const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
+
+    // Enter amount in input
+    fireEvent.change(getByTestId('token-text-field'), {
+      target: { value: incorrectValueTokens },
+    });
+
+    // Check submit button is disabled
+    await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
+    expect(
+      getByText(en.borrowRepayModal.repay.submitButtonDisabled).closest('button'),
+    ).toHaveAttribute('disabled');
+  });
+
+  it.only('disables submit button if an amount entered in input is higher than wallet balance for the relevant token', async () => {
     const { getByText, getByTestId } = renderComponent(
       <AuthContext.Provider
         value={{

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -28,6 +28,8 @@ import { useStyles } from '../../styles';
 import { useStyles as useRepayStyles } from './styles';
 import AccountData from '../AccountData';
 
+export const PRESET_PERCENTAGES = [25, 50, 75, 100];
+
 export interface IRepayFormProps {
   asset: Asset;
   repay: (amountWei: BigNumber) => Promise<string>;
@@ -155,7 +157,7 @@ export const RepayForm: React.FC<IRepayFormProps> = ({
             </Typography>
 
             <div css={styles.selectButtonsContainer}>
-              {[25, 50, 75, 100].map(percentage => (
+              {PRESET_PERCENTAGES.map(percentage => (
                 <TertiaryButton
                   key={`select-button-${percentage}`}
                   css={styles.selectButton}

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -76,281 +76,299 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
         },
       },
     );
-
-    await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
-  });
-
-  it('displays correct token supply balance', async () => {
-    const { getByText } = renderComponent(
-      () => (
-        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
-        },
-      },
-    );
-
-    await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
-  });
-
-  it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {
-    const customFakeAsset: Asset = {
-      ...fakeAsset,
-      walletBalance: new BigNumber(1),
-    };
-
-    const { getByText } = renderComponent(
-      () => (
-        <SupplyWithdraw
-          onClose={jest.fn()}
-          asset={customFakeAsset}
-          isXvsEnabled
-          assets={[customFakeAsset]}
-        />
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
-        },
-      },
-    );
-    await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
-
-    // Check submit button is disabled
-    expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
-      'disabled',
-    );
-
-    const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
-
-    // Enter amount in input
-    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-    fireEvent.change(tokenTextInput, {
-      target: { value: incorrectValueTokens },
-    });
-
-    // Check submit button is still disabled
-    await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
-    expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
-      'disabled',
-    );
-  });
-
-  it('submit is disabled with no amount', async () => {
-    const { getByText } = renderComponent(
-      () => (
-        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
-        },
-      },
-    );
-
     const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
     expect(disabledButtonText).toHaveTextContent(en.supplyWithdraw.enterValidAmountSupply);
     const disabledButton = document.querySelector('button[type="submit"]');
-    expect(disabledButton).toHaveAttribute('disabled');
+    expect(disabledButton).toBeDisabled();
   });
 
-  it('lets user supply BNB, then displays successful transaction modal and calls onClose callback on success', async () => {
-    const customFakeAsset: Asset = {
-      ...fakeAsset,
-      id: 'bnb' as TokenId,
-      symbol: 'BNB',
-      vsymbol: 'vBNB',
-      walletBalance: new BigNumber('11'),
-    };
-
-    const onCloseMock = jest.fn();
-    const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
-
-    (supplyBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
-
-    renderComponent(
-      () => (
-        <SupplyWithdraw
-          onClose={onCloseMock}
-          asset={customFakeAsset}
-          isXvsEnabled
-          assets={[fakeAsset]}
-        />
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
+  describe('Supply form', () => {
+    it('displays correct token wallet balance', async () => {
+      const { getByText } = renderComponent(
+        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
           },
         },
-      },
-    );
-
-    const correctAmountTokens = 1;
-    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-    fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
-
-    // Click on submit button
-    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-    await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
-    fireEvent.click(submitButton);
-
-    const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
-      new BigNumber(10).pow(customFakeAsset.decimals),
-    );
-
-    await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }));
-    expect(onCloseMock).toHaveBeenCalledTimes(1);
-    await waitFor(() =>
-      expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
-        transactionHash: fakeTransactionReceipt.transactionHash,
-        amount: {
-          tokenId: customFakeAsset.id,
-          valueWei: expectedAmountWei,
-        },
-        message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
-        title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
-      }),
-    );
-  });
-
-  it('lets user supply non-BNB tokens, then displays successful transaction modal and calls onClose callback on success', async () => {
-    const customFakeAsset: Asset = {
-      ...fakeAsset,
-      id: 'eth' as TokenId,
-      symbol: 'ETH',
-      vsymbol: 'vETH',
-      walletBalance: new BigNumber('11'),
-    };
-
-    const onCloseMock = jest.fn();
-    const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
-
-    (supplyNonBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
-
-    renderComponent(
-      () => (
-        <SupplyWithdraw
-          onClose={onCloseMock}
-          asset={customFakeAsset}
-          isXvsEnabled
-          assets={[fakeAsset]}
-        />
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
-        },
-      },
-    );
-
-    const correctAmountTokens = 1;
-    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-    fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
-
-    // Click on submit button
-    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-    await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
-    fireEvent.click(submitButton);
-
-    const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
-      new BigNumber(10).pow(customFakeAsset.decimals),
-    );
-
-    await waitFor(() =>
-      expect(supplyNonBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
-    );
-    expect(onCloseMock).toHaveBeenCalledTimes(1);
-    await waitFor(() =>
-      expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
-        transactionHash: fakeTransactionReceipt.transactionHash,
-        amount: {
-          tokenId: customFakeAsset.id,
-          valueWei: expectedAmountWei,
-        },
-        message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
-        title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
-      }),
-    );
-  });
-});
-
-describe('Withdraw form', () => {
-  beforeEach(() => {
-    (useUserMarketInfo as jest.Mock).mockImplementation(() => ({
-      assets: [], // Not used in these tests
-      userTotalBorrowLimit: fakeUserTotalBorrowLimitDollars,
-      userTotalBorrowBalance: fakeUserTotalBorrowBalanceDollars,
-    }));
-  });
-
-  it('redeem is called when full amount is withdrawn', async () => {
-    (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
-    const { getByText } = renderComponent(
-      () => <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
-        },
-      },
-    );
-
-    const withdrawButton = await waitFor(() => getByText(en.supplyWithdraw.withdraw));
-    fireEvent.click(withdrawButton);
-    const maxButton = await waitFor(() => getByText(en.supplyWithdraw.max.toUpperCase()));
-    act(() => {
-      fireEvent.click(maxButton);
+      );
+      await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
     });
-    const submitButton = await waitFor(
-      () => document.querySelector('button[type="submit"]') as HTMLButtonElement,
-    );
-    await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
-    fireEvent.click(submitButton);
-    await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amountWei: fakeGetVTokenBalance }));
-  });
 
-  it('redeemUnderlying is called when partial amount is withdrawn', async () => {
-    const { getByText } = renderComponent(
-      () => <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
+    it('displays correct token supply balance', async () => {
+      const { getByText } = renderComponent(
+        () => (
+          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
+        ),
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
           },
         },
-      },
-    );
-    const withdrawButton = getByText(en.supplyWithdraw.withdraw);
-    fireEvent.click(withdrawButton);
+      );
 
-    const correctAmountTokens = 1;
+      await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
+    });
 
-    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-    act(() => {
+    it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {
+      const customFakeAsset: Asset = {
+        ...fakeAsset,
+        walletBalance: new BigNumber(1),
+      };
+
+      const { getByText } = renderComponent(
+        () => (
+          <SupplyWithdraw
+            onClose={jest.fn()}
+            asset={customFakeAsset}
+            isXvsEnabled
+            assets={[customFakeAsset]}
+          />
+        ),
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
+          },
+        },
+      );
+      await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
+
+      // Check submit button is disabled
+      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
+        'disabled',
+      );
+
+      const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
+
+      // Enter amount in input
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+      fireEvent.change(tokenTextInput, {
+        target: { value: incorrectValueTokens },
+      });
+
+      // Check submit button is still disabled
+      await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
+      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
+        'disabled',
+      );
+    });
+
+    it('submit is disabled with no amount', async () => {
+      const { getByText } = renderComponent(
+        () => (
+          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
+        ),
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
+          },
+        },
+      );
+
+      const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
+      expect(disabledButtonText).toHaveTextContent(en.supplyWithdraw.enterValidAmountSupply);
+      const disabledButton = document.querySelector('button[type="submit"]');
+      expect(disabledButton).toHaveAttribute('disabled');
+    });
+
+    it('lets user supply BNB, then displays successful transaction modal and calls onClose callback on success', async () => {
+      const customFakeAsset: Asset = {
+        ...fakeAsset,
+        id: 'bnb' as TokenId,
+        symbol: 'BNB',
+        vsymbol: 'vBNB',
+        walletBalance: new BigNumber('11'),
+      };
+
+      const onCloseMock = jest.fn();
+      const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+      (supplyBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
+
+      renderComponent(
+        () => (
+          <SupplyWithdraw
+            onClose={onCloseMock}
+            asset={customFakeAsset}
+            isXvsEnabled
+            assets={[fakeAsset]}
+          />
+        ),
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
+          },
+        },
+      );
+
+      const correctAmountTokens = 1;
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
       fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
+
+      // Click on submit button
+      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
+      fireEvent.click(submitButton);
+
+      const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
+        new BigNumber(10).pow(customFakeAsset.decimals),
+      );
+
+      await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }));
+      expect(onCloseMock).toHaveBeenCalledTimes(1);
+      await waitFor(() =>
+        expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
+          transactionHash: fakeTransactionReceipt.transactionHash,
+          amount: {
+            tokenId: customFakeAsset.id,
+            valueWei: expectedAmountWei,
+          },
+          message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
+          title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
+        }),
+      );
     });
-    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
-    fireEvent.click(submitButton);
 
-    const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
-      new BigNumber(10).pow(fakeAsset.decimals),
-    );
+    it('lets user supply non-BNB tokens, then displays successful transaction modal and calls onClose callback on success', async () => {
+      const customFakeAsset: Asset = {
+        ...fakeAsset,
+        id: 'eth' as TokenId,
+        symbol: 'ETH',
+        vsymbol: 'vETH',
+        walletBalance: new BigNumber('11'),
+      };
 
-    await waitFor(() =>
-      expect(redeemUnderlying).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
-    );
+      const onCloseMock = jest.fn();
+      const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+      (supplyNonBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
+
+      renderComponent(
+        () => (
+          <SupplyWithdraw
+            onClose={onCloseMock}
+            asset={customFakeAsset}
+            isXvsEnabled
+            assets={[fakeAsset]}
+          />
+        ),
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
+          },
+        },
+      );
+
+      const correctAmountTokens = 1;
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+      fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
+
+      // Click on submit button
+      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
+      fireEvent.click(submitButton);
+
+      const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
+        new BigNumber(10).pow(customFakeAsset.decimals),
+      );
+
+      await waitFor(() =>
+        expect(supplyNonBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
+      );
+      expect(onCloseMock).toHaveBeenCalledTimes(1);
+      await waitFor(() =>
+        expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
+          transactionHash: fakeTransactionReceipt.transactionHash,
+          amount: {
+            tokenId: customFakeAsset.id,
+            valueWei: expectedAmountWei,
+          },
+          message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
+          title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
+        }),
+      );
+    });
+  });
+
+  describe('Withdraw form', () => {
+    beforeEach(() => {
+      (useUserMarketInfo as jest.Mock).mockImplementation(() => ({
+        assets: [], // Not used in these tests
+        userTotalBorrowLimit: fakeUserTotalBorrowLimitDollars,
+        userTotalBorrowBalance: fakeUserTotalBorrowBalanceDollars,
+      }));
+    });
+
+    it('redeem is called when full amount is withdrawn', async () => {
+      (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
+      const { getByText } = renderComponent(
+        () => <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
+          },
+        },
+      );
+
+      const withdrawButton = await waitFor(() => getByText(en.supplyWithdraw.withdraw));
+      fireEvent.click(withdrawButton);
+      const maxButton = await waitFor(() => getByText(en.supplyWithdraw.max.toUpperCase()));
+      act(() => {
+        fireEvent.click(maxButton);
+      });
+      const submitButton = await waitFor(
+        () => document.querySelector('button[type="submit"]') as HTMLButtonElement,
+      );
+      await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
+      fireEvent.click(submitButton);
+      await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amountWei: fakeGetVTokenBalance }));
+    });
+
+    it('redeemUnderlying is called when partial amount is withdrawn', async () => {
+      const { getByText } = renderComponent(
+        () => <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
+        {
+          authContextValue: {
+            account: {
+              address: fakeAccountAddress,
+            },
+          },
+        },
+      );
+      const withdrawButton = getByText(en.supplyWithdraw.withdraw);
+      fireEvent.click(withdrawButton);
+
+      const correctAmountTokens = 1;
+
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+      act(() => {
+        fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
+      });
+      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
+      fireEvent.click(submitButton);
+
+      const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
+        new BigNumber(10).pow(fakeAsset.decimals),
+      );
+
+      await waitFor(() =>
+        expect(redeemUnderlying).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
+      );
+    });
   });
 });

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -94,6 +94,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         },
       );
+
       await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
     });
 
@@ -140,9 +141,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
 
       // Check submit button is disabled
-      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
-        'disabled',
-      );
+      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toBeDisabled();
 
       const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
 
@@ -154,9 +153,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
 
       // Check submit button is still disabled
       await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
-      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
-        'disabled',
-      );
+      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toBeDisabled();
     });
 
     it('submit is disabled with no amount', async () => {
@@ -176,7 +173,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
       expect(disabledButtonText).toHaveTextContent(en.supplyWithdraw.enterValidAmountSupply);
       const disabledButton = document.querySelector('button[type="submit"]');
-      expect(disabledButton).toHaveAttribute('disabled');
+      expect(disabledButton).toBeDisabled();
     });
 
     it('lets user supply BNB, then displays successful transaction modal and calls onClose callback on success', async () => {


### PR DESCRIPTION
Add tests to cover the most important paths:
- Borrow balance displayed for given token is correct
- Wallet balance displayed is correct
- User can’t repay amount that’s higher than borrow balance of given token
- User can’t repay amount that’s higher than wallet balance
- Pressing on “MAX” button updates input value to wallet balance if borrow balance of given token is equal or greater than that
- Pressing on “MAX” button updates input value to borrow balance if wallet balance is greater or equal than that
- Pressing on “25%” button updates input value to be 25% of the supply balance of the given token
- Pressing on “50%” button updates input value to be 25% of the supply balance of the given token
- Pressing on “75%” button updates input value to be 25% of the supply balance of the given token
- Pressing on “100%” button updates input value to be 25% of the supply balance of the given token
- User can repay amount that is less or equal to their wallet balance and the borrow balance of the given token