### PR TITLE
Set AuthContext value from renderComponent in tests

### DIFF
--- a/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
+++ b/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
@@ -5,7 +5,6 @@ import BigNumber from 'bignumber.js';
 import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import fakeAddress from '__mocks__/models/address';
 import renderComponent from 'testUtils/renderComponent';
-import { AuthContext } from 'context/AuthContext';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { getXvsReward, claimXvsReward } from 'clients/api';
 import ClaimXvsRewardButton, { TEST_ID } from '.';
@@ -24,21 +23,13 @@ describe('pages/Dashboard/MintRepayVai', () => {
   });
 
   it('renders nothing if user have no claimable XVS reward', () => {
-    const { queryAllByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAddress,
-          },
-        }}
-      >
-        <ClaimXvsRewardButton />
-      </AuthContext.Provider>,
-    );
+    const { queryAllByTestId } = renderComponent(() => <ClaimXvsRewardButton />, {
+      authContextValue: {
+        account: {
+          address: fakeAddress,
+        },
+      },
+    });
     expect(queryAllByTestId(TEST_ID)).toHaveLength(0);
   });
 
@@ -47,21 +38,13 @@ describe('pages/Dashboard/MintRepayVai', () => {
       async () => new BigNumber('10000000000000000000000'),
     );
 
-    const { getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAddress,
-          },
-        }}
-      >
-        <ClaimXvsRewardButton />
-      </AuthContext.Provider>,
-    );
+    const { getByTestId } = renderComponent(() => <ClaimXvsRewardButton />, {
+      authContextValue: {
+        account: {
+          address: fakeAddress,
+        },
+      },
+    });
 
     await waitFor(() => expect(getByTestId(TEST_ID)));
     expect(getByTestId(TEST_ID).textContent).toContain('10,000 XVS');
@@ -74,21 +57,13 @@ describe('pages/Dashboard/MintRepayVai', () => {
     (getXvsReward as jest.Mock).mockImplementationOnce(async () => fakeXvsReward);
     (claimXvsReward as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
-    const { getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAddress,
-          },
-        }}
-      >
-        <ClaimXvsRewardButton />
-      </AuthContext.Provider>,
-    );
+    const { getByTestId } = renderComponent(() => <ClaimXvsRewardButton />, {
+      authContextValue: {
+        account: {
+          address: fakeAddress,
+        },
+      },
+    });
 
     await waitFor(() => expect(getByTestId(TEST_ID)));
 

--- a/src/context/VaiContext.tsx
+++ b/src/context/VaiContext.tsx
@@ -10,6 +10,13 @@ import {
 import useRefresh from 'hooks/useRefresh';
 import { AuthContext } from './AuthContext';
 
+export interface IVaiContextValue {
+  userVaiMinted: BigNumber;
+  userVaiBalance: BigNumber;
+  userVaiEnabled: boolean;
+  mintableVai: BigNumber;
+}
+
 const VaiContext = React.createContext({
   userVaiMinted: new BigNumber(0),
   userVaiBalance: new BigNumber(0),

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.spec.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.spec.tsx
@@ -2,14 +2,12 @@ import React from 'react';
 import BigNumber from 'bignumber.js';
 import { fireEvent, waitFor } from '@testing-library/react';
 import { assetData } from '__mocks__/models/asset';
+import fakeAccountAddress from '__mocks__/models/address';
 import renderComponent from 'testUtils/renderComponent';
 import { enterMarkets, useUserMarketInfo } from 'clients/api';
 import { switchAriaLabel } from 'components';
-import { AuthContext } from 'context/AuthContext';
 import en from 'translation/translations/en.json';
 import SupplyMarket from '.';
-
-const fakeAccountAddress = '0x0';
 
 jest.mock('clients/api');
 
@@ -40,24 +38,21 @@ describe('pages/SupplyMarket', () => {
 
   it('clicking toggle only toggles collateral', async () => {
     const { queryByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
+      () => (
         <SupplyMarket
           isXvsEnabled
           suppliedAssets={[]}
           supplyMarketAssets={assetData}
           accountAddress={fakeAccountAddress}
         />
-      </AuthContext.Provider>,
+      ),
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
     );
     const toggle = document.querySelector(
       `input[aria-label="${switchAriaLabel}"]`,

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -6,7 +6,6 @@ import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import { mintVai, getVaiTreasuryPercentage, useUserMarketInfo } from 'clients/api';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { formatCoinsToReadableValue } from 'utilities/common';
-import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
 import fakeAccountAddress from '__mocks__/models/address';
@@ -49,27 +48,19 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
       async () => fakeVaiTreasuryPercentage,
     );
 
-    const { getByText } = renderComponent(
-      () => (
-        <VaiContext.Provider
-          value={{
-            userVaiEnabled: true,
-            userVaiMinted: new BigNumber(0),
-            mintableVai: fakeMintableVai,
-            userVaiBalance: new BigNumber(0),
-          }}
-        >
-          <RepayVai />
-        </VaiContext.Provider>
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
+    const { getByText } = renderComponent(() => <RepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
         },
       },
-    );
+      vaiContextValue: {
+        userVaiEnabled: true,
+        userVaiMinted: new BigNumber(0),
+        mintableVai: fakeMintableVai,
+        userVaiBalance: new BigNumber(0),
+      },
+    });
     await waitFor(() => getByText('Available VAI limit'));
 
     // Check available VAI limit displays correctly
@@ -82,27 +73,19 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
     const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
     (mintVai as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
-    const { getByText, getByPlaceholderText } = renderComponent(
-      () => (
-        <VaiContext.Provider
-          value={{
-            userVaiEnabled: true,
-            mintableVai: fakeMintableVai,
-            userVaiMinted: new BigNumber(0),
-            userVaiBalance: new BigNumber(0),
-          }}
-        >
-          <RepayVai />
-        </VaiContext.Provider>
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
+    const { getByText, getByPlaceholderText } = renderComponent(() => <RepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
         },
       },
-    );
+      vaiContextValue: {
+        userVaiEnabled: true,
+        mintableVai: fakeMintableVai,
+        userVaiMinted: new BigNumber(0),
+        userVaiBalance: new BigNumber(0),
+      },
+    });
     await waitFor(() => getByText('Available VAI limit'));
 
     // Click on "SAFE MAX" button

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -6,17 +6,16 @@ import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import { mintVai, getVaiTreasuryPercentage, useUserMarketInfo } from 'clients/api';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { formatCoinsToReadableValue } from 'utilities/common';
-import { AuthContext } from 'context/AuthContext';
 import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
+import fakeAccountAddress from '__mocks__/models/address';
 import RepayVai from '.';
 
 jest.mock('clients/api');
 jest.mock('components/Basic/Toast');
 jest.mock('hooks/useSuccessfulTransactionModal');
 
-const fakeAccountAddress = '0x0';
 const fakeVai = { ...assetData, id: 'vai', symbol: 'VAI', isEnabled: true };
 const fakeMintableVai = new BigNumber('1000');
 const formattedFakeUserVaiMinted = formatCoinsToReadableValue({
@@ -35,21 +34,13 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
   });
 
   it('renders without crashing', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <RepayVai />
-      </AuthContext.Provider>,
-    );
+    const { getByText } = renderComponent(() => <RepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
+        },
+      },
+    });
     await waitFor(() => getByText('Available VAI limit'));
   });
 
@@ -59,17 +50,7 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
     );
 
     const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
+      () => (
         <VaiContext.Provider
           value={{
             userVaiEnabled: true,
@@ -80,7 +61,14 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
         >
           <RepayVai />
         </VaiContext.Provider>
-      </AuthContext.Provider>,
+      ),
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
     );
     await waitFor(() => getByText('Available VAI limit'));
 
@@ -95,28 +83,25 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
     (mintVai as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
     const { getByText, getByPlaceholderText } = renderComponent(
-      <VaiContext.Provider
-        value={{
-          userVaiEnabled: true,
-          mintableVai: fakeMintableVai,
-          userVaiMinted: new BigNumber(0),
-          userVaiBalance: new BigNumber(0),
-        }}
-      >
-        <AuthContext.Provider
+      () => (
+        <VaiContext.Provider
           value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
+            userVaiEnabled: true,
+            mintableVai: fakeMintableVai,
+            userVaiMinted: new BigNumber(0),
+            userVaiBalance: new BigNumber(0),
           }}
         >
           <RepayVai />
-        </AuthContext.Provider>
-      </VaiContext.Provider>,
+        </VaiContext.Provider>
+      ),
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
     );
     await waitFor(() => getByText('Available VAI limit'));
 

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -6,17 +6,16 @@ import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import { repayVai, useUserMarketInfo } from 'clients/api';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { formatCoinsToReadableValue } from 'utilities/common';
-import { AuthContext } from 'context/AuthContext';
 import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
+import fakeAccountAddress from '__mocks__/models/address';
 import RepayVai from '.';
 
 jest.mock('clients/api');
 jest.mock('components/Basic/Toast');
 jest.mock('hooks/useSuccessfulTransactionModal');
 
-const fakeAccountAddress = '0x0';
 const fakeUserVaiMinted = new BigNumber('1000000');
 const formattedFakeUserVaiMinted = formatCoinsToReadableValue({
   value: fakeUserVaiMinted,
@@ -34,37 +33,19 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
   });
 
   it('renders without crashing', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <RepayVai />
-      </AuthContext.Provider>,
-    );
+    const { getByText } = renderComponent(() => <RepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
+        },
+      },
+    });
     await waitFor(() => getByText('Repay VAI balance'));
   });
 
   it('displays the correct repay VAI balance', async () => {
     const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
+      () => (
         <VaiContext.Provider
           value={{
             userVaiEnabled: true,
@@ -75,7 +56,14 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
         >
           <RepayVai />
         </VaiContext.Provider>
-      </AuthContext.Provider>,
+      ),
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
     );
     await waitFor(() => getByText('Repay VAI balance'));
 
@@ -90,28 +78,25 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
     const fakeUserVaiBalance = fakeUserVaiMinted;
 
     const { getByText, getByPlaceholderText } = renderComponent(
-      <VaiContext.Provider
-        value={{
-          userVaiEnabled: true,
-          mintableVai: new BigNumber(0),
-          userVaiMinted: fakeUserVaiMinted,
-          userVaiBalance: fakeUserVaiBalance,
-        }}
-      >
-        <AuthContext.Provider
+      () => (
+        <VaiContext.Provider
           value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
+            userVaiEnabled: true,
+            mintableVai: new BigNumber(0),
+            userVaiMinted: fakeUserVaiMinted,
+            userVaiBalance: fakeUserVaiBalance,
           }}
         >
           <RepayVai />
-        </AuthContext.Provider>
-      </VaiContext.Provider>,
+        </VaiContext.Provider>
+      ),
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
     );
     await waitFor(() => getByText('Repay VAI balance'));
 

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -6,7 +6,6 @@ import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import { repayVai, useUserMarketInfo } from 'clients/api';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { formatCoinsToReadableValue } from 'utilities/common';
-import { VaiContext } from 'context/VaiContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
 import fakeAccountAddress from '__mocks__/models/address';
@@ -44,27 +43,19 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
   });
 
   it('displays the correct repay VAI balance', async () => {
-    const { getByText } = renderComponent(
-      () => (
-        <VaiContext.Provider
-          value={{
-            userVaiEnabled: true,
-            userVaiMinted: fakeUserVaiMinted,
-            mintableVai: new BigNumber(0),
-            userVaiBalance: new BigNumber(0),
-          }}
-        >
-          <RepayVai />
-        </VaiContext.Provider>
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
+    const { getByText } = renderComponent(() => <RepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
         },
       },
-    );
+      vaiContextValue: {
+        userVaiEnabled: true,
+        userVaiMinted: fakeUserVaiMinted,
+        mintableVai: new BigNumber(0),
+        userVaiBalance: new BigNumber(0),
+      },
+    });
     await waitFor(() => getByText('Repay VAI balance'));
 
     // Check user repay VAI balance displays correctly
@@ -77,27 +68,19 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
 
     const fakeUserVaiBalance = fakeUserVaiMinted;
 
-    const { getByText, getByPlaceholderText } = renderComponent(
-      () => (
-        <VaiContext.Provider
-          value={{
-            userVaiEnabled: true,
-            mintableVai: new BigNumber(0),
-            userVaiMinted: fakeUserVaiMinted,
-            userVaiBalance: fakeUserVaiBalance,
-          }}
-        >
-          <RepayVai />
-        </VaiContext.Provider>
-      ),
-      {
-        authContextValue: {
-          account: {
-            address: fakeAccountAddress,
-          },
+    const { getByText, getByPlaceholderText } = renderComponent(() => <RepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
         },
       },
-    );
+      vaiContextValue: {
+        userVaiEnabled: true,
+        mintableVai: new BigNumber(0),
+        userVaiMinted: fakeUserVaiMinted,
+        userVaiBalance: fakeUserVaiBalance,
+      },
+    });
     await waitFor(() => getByText('Repay VAI balance'));
 
     // Input amount

--- a/src/pages/Dashboard/MintRepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/index.spec.tsx
@@ -2,14 +2,13 @@ import React from 'react';
 import BigNumber from 'bignumber.js';
 import { waitFor, fireEvent } from '@testing-library/react';
 import { useUserMarketInfo } from 'clients/api';
-import { AuthContext } from 'context/AuthContext';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
+import fakeAccountAddress from '__mocks__/models/address';
 import MintRepayVai from '.';
 
 jest.mock('clients/api');
 
-const fakeAccountAddress = '0x0';
 const fakeVai = { ...assetData, id: 'vai', symbol: 'VAI', isEnabled: true };
 
 describe('pages/Dashboard/MintRepayVai', () => {
@@ -22,40 +21,24 @@ describe('pages/Dashboard/MintRepayVai', () => {
   });
 
   it('renders without crashing', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <MintRepayVai />
-      </AuthContext.Provider>,
-    );
+    const { getByText } = renderComponent(() => <MintRepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
+        },
+      },
+    });
     await waitFor(() => getByText('Mint/Repay VAI'));
   });
 
   it('renders mint tab by default and lets user switch to repay tab', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <MintRepayVai />
-      </AuthContext.Provider>,
-    );
+    const { getByText } = renderComponent(() => <MintRepayVai />, {
+      authContextValue: {
+        account: {
+          address: fakeAccountAddress,
+        },
+      },
+    });
 
     // Check mint tab is display by default
     await waitFor(() => getByText('Available VAI limit'));

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -9,7 +9,6 @@ import { Asset } from 'types';
 import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import fakeAccountAddress from '__mocks__/models/address';
 import { useUserMarketInfo, borrowVToken } from 'clients/api';
-import { AuthContext } from 'context/AuthContext';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import renderComponent from 'testUtils/renderComponent';
 import en from 'translation/translations/en.json';
@@ -48,19 +47,14 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     };
 
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      () => <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));
 
@@ -86,19 +80,14 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
 
   it('disables submit button if amount to borrow requested would make user borrow balance go higher than their borrow limit', async () => {
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));
 
@@ -130,19 +119,14 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
 
   it('updates input value correctly when pressing on max button', async () => {
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));
 
@@ -177,19 +161,14 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     (borrowVToken as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      () => <Borrow asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Borrow asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.borrow.submitButtonDisabled));
 

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -7,7 +7,6 @@ import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import fakeAccountAddress from '__mocks__/models/address';
 import { assetData } from '__mocks__/models/asset';
 import { useUserMarketInfo, repayNonBnbVToken } from 'clients/api';
-import { AuthContext } from 'context/AuthContext';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import renderComponent from 'testUtils/renderComponent';
 import en from 'translation/translations/en.json';
@@ -40,19 +39,14 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
 
   it('disables submit button if an incorrect amount is entered in input', async () => {
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      () => <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Repay asset={fakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
 
@@ -87,19 +81,14 @@ describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
     (repayNonBnbVToken as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
     const { getByText, getByTestId } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      () => <Repay asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Repay asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
     await waitFor(() => getByText(en.borrowRepayModal.repay.submitButtonDisabled));
 

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -64,7 +64,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
   const userTotalBorrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
   const userTotalBorrowLimitCents = userTotalBorrowLimit.multipliedBy(100);
 
-  const hypotheticalTokenSupplyBalance = amountString
+  const hypotheticalTokenSupplyBalance = amountValue
     ? calculateNewBalance(asset.supplyBalance, amount)
     : undefined;
 

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -286,6 +286,14 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
 });
 
 describe('Withdraw form', () => {
+  beforeEach(() => {
+    (useUserMarketInfo as jest.Mock).mockImplementation(() => ({
+      assets: [], // Not used in these tests
+      userTotalBorrowLimit: fakeUserTotalBorrowLimitDollars,
+      userTotalBorrowBalance: fakeUserTotalBorrowBalanceDollars,
+    }));
+  });
+
   it('redeem is called when full amount is withdrawn', async () => {
     (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
     const { getByText } = renderComponent(

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -7,7 +7,6 @@ import fakeAccountAddress from '__mocks__/models/address';
 import { assetData } from '__mocks__/models/asset';
 import renderComponent from 'testUtils/renderComponent';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
-import { AuthContext } from 'context/AuthContext';
 import {
   supplyNonBnb,
   supplyBnb,
@@ -20,6 +19,9 @@ import { Asset, TokenId } from 'types';
 import en from 'translation/translations/en.json';
 import SupplyWithdraw from '.';
 
+const ONE = '1';
+const ONE_WEI = '1000000000000000000';
+const asset = assetData[1];
 const fakeGetVTokenBalance = new BigNumber('111');
 
 const fakeAsset: Asset = {
@@ -45,25 +47,15 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
   });
 
   it('renders without crashing', async () => {
-    renderComponent(
-      <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
-    );
+    renderComponent(() => (
+      <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
+    ));
   });
 
   it('asks the user to connect if wallet is not connected', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: undefined,
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-      </AuthContext.Provider>,
-    );
+    const { getByText } = renderComponent(() => (
+      <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
+    ));
 
     const connectTextSupply = getByText(en.supplyWithdraw.connectWalletToSupply);
     expect(connectTextSupply).toHaveTextContent(en.supplyWithdraw.connectWalletToSupply);
@@ -73,316 +65,277 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
     expect(connectTextWithdraw).toHaveTextContent(en.supplyWithdraw.connectWalletToWithdraw);
   });
 
-  describe('Supply form', () => {
-    it('displays correct token wallet balance', async () => {
-      const { getByText } = renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-        </AuthContext.Provider>,
-      );
-
-      await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
-    });
-
-    it('displays correct token supply balance', async () => {
-      const { getByText } = renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-        </AuthContext.Provider>,
-      );
-
-      await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
-    });
-
-    it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {
-      const customFakeAsset: Asset = {
-        ...fakeAsset,
-        walletBalance: new BigNumber(1),
-      };
-
-      const { getByText } = renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw
-            onClose={jest.fn()}
-            asset={customFakeAsset}
-            isXvsEnabled
-            assets={[customFakeAsset]}
-          />
-        </AuthContext.Provider>,
-      );
-      await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
-
-      // Check submit button is disabled
-      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
-        'disabled',
-      );
-
-      const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
-
-      // Enter amount in input
-      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-      fireEvent.change(tokenTextInput, {
-        target: { value: incorrectValueTokens },
-      });
-
-      // Check submit button is still disabled
-      await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
-      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
-        'disabled',
-      );
-    });
-
-    it('submit is disabled with no amount', async () => {
-      const { getByText } = renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-        </AuthContext.Provider>,
-      );
-
-      const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
-      expect(disabledButtonText).toHaveTextContent(en.supplyWithdraw.enterValidAmountSupply);
-      const disabledButton = document.querySelector('button[type="submit"]');
-      expect(disabledButton).toHaveAttribute('disabled');
-    });
-
-    it('lets user supply BNB, then displays successful transaction modal and calls onClose callback on success', async () => {
-      const customFakeAsset: Asset = {
-        ...fakeAsset,
-        id: 'bnb' as TokenId,
-        symbol: 'BNB',
-        vsymbol: 'vBNB',
-        walletBalance: new BigNumber('11'),
-      };
-
-      const onCloseMock = jest.fn();
-      const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
-
-      (supplyBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
-
-      renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw
-            onClose={onCloseMock}
-            asset={customFakeAsset}
-            isXvsEnabled
-            assets={[fakeAsset]}
-          />
-        </AuthContext.Provider>,
-      );
-
-      const correctAmountTokens = 1;
-      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-      fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
-
-      // Click on submit button
-      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-      await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
-      fireEvent.click(submitButton);
-
-      const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
-        new BigNumber(10).pow(customFakeAsset.decimals),
-      );
-
-      await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }));
-      expect(onCloseMock).toHaveBeenCalledTimes(1);
-      await waitFor(() =>
-        expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
-          transactionHash: fakeTransactionReceipt.transactionHash,
-          amount: {
-            tokenId: customFakeAsset.id,
-            valueWei: expectedAmountWei,
+  it('submit is disabled with no amount', async () => {
+    const { getByText } = renderComponent(
+      () => <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
           },
-          message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
-          title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
-        }),
-      );
-    });
+        },
+      },
+    );
 
-    it('lets user supply non-BNB tokens, then displays successful transaction modal and calls onClose callback on success', async () => {
-      const customFakeAsset: Asset = {
-        ...fakeAsset,
-        id: 'eth' as TokenId,
-        symbol: 'ETH',
-        vsymbol: 'vETH',
-        walletBalance: new BigNumber('11'),
-      };
-
-      const onCloseMock = jest.fn();
-      const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
-
-      (supplyNonBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
-
-      renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw
-            onClose={onCloseMock}
-            asset={customFakeAsset}
-            isXvsEnabled
-            assets={[fakeAsset]}
-          />
-        </AuthContext.Provider>,
-      );
-
-      const correctAmountTokens = 1;
-      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-      fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
-
-      // Click on submit button
-      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-      await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
-      fireEvent.click(submitButton);
-
-      const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
-        new BigNumber(10).pow(customFakeAsset.decimals),
-      );
-
-      await waitFor(() =>
-        expect(supplyNonBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
-      );
-      expect(onCloseMock).toHaveBeenCalledTimes(1);
-      await waitFor(() =>
-        expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
-          transactionHash: fakeTransactionReceipt.transactionHash,
-          amount: {
-            tokenId: customFakeAsset.id,
-            valueWei: expectedAmountWei,
-          },
-          message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
-          title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
-        }),
-      );
-    });
+    await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
   });
 
-  describe('Withdraw form', () => {
-    it('redeem is called when full amount is withdrawn', async () => {
-      (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
-      const { getByText } = renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-        </AuthContext.Provider>,
-      );
+  it('displays correct token supply balance', async () => {
+    const { getByText } = renderComponent(
+      () => <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
+    );
 
-      const withdrawButton = await waitFor(() => getByText(en.supplyWithdraw.withdraw));
-      fireEvent.click(withdrawButton);
-      const maxButton = await waitFor(() => getByText(en.supplyWithdraw.max.toUpperCase()));
-      act(() => {
-        fireEvent.click(maxButton);
-      });
-      const submitButton = await waitFor(
-        () => document.querySelector('button[type="submit"]') as HTMLButtonElement,
-      );
-      await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
-      fireEvent.click(submitButton);
-      await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amountWei: fakeGetVTokenBalance }));
+    await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
+  });
+
+  it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {
+    const customFakeAsset: Asset = {
+      ...fakeAsset,
+      walletBalance: new BigNumber(1),
+    };
+
+    const { getByText } = renderComponent(
+      () => <SupplyWithdraw
+        onClose={jest.fn()}
+        asset={customFakeAsset}
+        isXvsEnabled
+        assets={[customFakeAsset]}
+      />,
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
+    );
+    await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
+
+    // Check submit button is disabled
+    expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
+      'disabled',
+    );
+
+    const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
+
+    // Enter amount in input
+    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+    fireEvent.change(tokenTextInput, {
+      target: { value: incorrectValueTokens },
     });
 
-    it('redeemUnderlying is called when partial amount is withdrawn', async () => {
-      const { getByText } = renderComponent(
-        <AuthContext.Provider
-          value={{
-            login: jest.fn(),
-            logOut: jest.fn(),
-            openAuthModal: jest.fn(),
-            closeAuthModal: jest.fn(),
-            account: {
-              address: fakeAccountAddress,
-            },
-          }}
-        >
-          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
-        </AuthContext.Provider>,
-      );
-      const withdrawButton = getByText(en.supplyWithdraw.withdraw);
-      fireEvent.click(withdrawButton);
+    // Check submit button is still disabled
+    await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
+    expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
+      'disabled',
+    );
+  });
 
-      const correctAmountTokens = 1;
+  it('submit is disabled with no amount', async () => {
+    const { getByText } = renderComponent(
+      () => <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
 
-      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-      act(() => {
-        fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
-      });
-      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-      expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
-      fireEvent.click(submitButton);
+    );
 
-      const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
-        new BigNumber(10).pow(fakeAsset.decimals),
-      );
+    const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
+    expect(disabledButtonText).toHaveTextContent(en.supplyWithdraw.enterValidAmountSupply);
+    const disabledButton = document.querySelector('button[type="submit"]');
+    expect(disabledButton).toHaveAttribute('disabled');
+  });
 
-      await waitFor(() =>
-        expect(redeemUnderlying).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
-      );
+  it('lets user supply BNB, then displays successful transaction modal and calls onClose callback on success', async () => {
+    const customFakeAsset: Asset = {
+      ...fakeAsset,
+      id: 'bnb' as TokenId,
+      symbol: 'BNB',
+      vsymbol: 'vBNB',
+      walletBalance: new BigNumber('11'),
+    };
+
+    const onCloseMock = jest.fn();
+    const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+    (supplyBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
+
+    renderComponent(
+      () => <SupplyWithdraw
+        onClose={onCloseMock}
+        asset={customFakeAsset}
+        isXvsEnabled
+        assets={[fakeAsset]}
+      />,
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
+    );
+
+    const correctAmountTokens = 1;
+    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+    fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
+
+    // Click on submit button
+    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+    await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
+    fireEvent.click(submitButton);
+
+    const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
+      new BigNumber(10).pow(customFakeAsset.decimals),
+    );
+
+    await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }));
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
+        transactionHash: fakeTransactionReceipt.transactionHash,
+        amount: {
+          tokenId: customFakeAsset.id,
+          valueWei: expectedAmountWei,
+        },
+        message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
+        title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
+      }),
+    );
+  });
+
+  it('lets user supply non-BNB tokens, then displays successful transaction modal and calls onClose callback on success', async () => {
+    const customFakeAsset: Asset = {
+      ...fakeAsset,
+      id: 'eth' as TokenId,
+      symbol: 'ETH',
+      vsymbol: 'vETH',
+      walletBalance: new BigNumber('11'),
+    };
+
+    const onCloseMock = jest.fn();
+    const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+    (supplyNonBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
+
+    renderComponent(
+      () => (
+        <SupplyWithdraw
+          onClose={onCloseMock}
+          asset={customFakeAsset}
+          isXvsEnabled
+          assets={[fakeAsset]}
+        />
+      ),
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
+    );
+
+    const correctAmountTokens = 1;
+    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+    fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
+
+    // Click on submit button
+    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+    await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply));
+    fireEvent.click(submitButton);
+
+    const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
+      new BigNumber(10).pow(customFakeAsset.decimals),
+    );
+
+    await waitFor(() =>
+      expect(supplyNonBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
+    );
+    expect(onCloseMock).toHaveBeenCalledTimes(1);
+    await waitFor(() =>
+      expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
+        transactionHash: fakeTransactionReceipt.transactionHash,
+        amount: {
+          tokenId: customFakeAsset.id,
+          valueWei: expectedAmountWei,
+        },
+        message: en.supplyWithdraw.successfulSupplyTransactionModal.message,
+        title: en.supplyWithdraw.successfulSupplyTransactionModal.title,
+      }),
+    );
+  });
+});
+
+describe('Withdraw form', () => {
+  it('redeem is called when full amount is withdrawn', async () => {
+    (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
+    const { getByText } = renderComponent(
+      () => <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
+    );
+
+    const withdrawButton = await waitFor(() => getByText(en.supplyWithdraw.withdraw));
+    fireEvent.click(withdrawButton);
+    const maxButton = await waitFor(() => getByText(en.supplyWithdraw.max.toUpperCase()));
+    act(() => {
+      fireEvent.click(maxButton);
     });
+    const submitButton = await waitFor(
+      () => document.querySelector('button[type="submit"]') as HTMLButtonElement,
+    );
+    await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
+    fireEvent.click(submitButton);
+    await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amountWei: fakeGetVTokenBalance }));
+  });
+
+  it('redeemUnderlying is called when partial amount is withdrawn', async () => {
+    const { getByText } = renderComponent(
+      () => <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
+      {
+        authContextValue: {
+          account: {
+            address: fakeAccountAddress,
+          },
+        },
+      },
+    );
+    const withdrawButton = getByText(en.supplyWithdraw.withdraw);
+    fireEvent.click(withdrawButton);
+
+    const correctAmountTokens = 1;
+
+    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+    act(() => {
+      fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
+    });
+    const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+    expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
+    fireEvent.click(submitButton);
+
+    const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
+      new BigNumber(10).pow(fakeAsset.decimals),
+    );
+
+    await waitFor(() =>
+      expect(redeemUnderlying).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
+    );
   });
 });

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -19,8 +19,6 @@ import { Asset, TokenId } from 'types';
 import en from 'translation/translations/en.json';
 import SupplyWithdraw from '.';
 
-const ONE = '1';
-const ONE_WEI = '1000000000000000000';
 const asset = assetData[1];
 const fakeGetVTokenBalance = new BigNumber('111');
 
@@ -67,7 +65,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
 
   it('submit is disabled with no amount', async () => {
     const { getByText } = renderComponent(
-      () => <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
+      () => (
+        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
+      ),
       {
         authContextValue: {
           account: {
@@ -82,7 +82,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
 
   it('displays correct token supply balance', async () => {
     const { getByText } = renderComponent(
-      () => <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
+      () => (
+        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
+      ),
       {
         authContextValue: {
           account: {
@@ -102,12 +104,14 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
     };
 
     const { getByText } = renderComponent(
-      () => <SupplyWithdraw
-        onClose={jest.fn()}
-        asset={customFakeAsset}
-        isXvsEnabled
-        assets={[customFakeAsset]}
-      />,
+      () => (
+        <SupplyWithdraw
+          onClose={jest.fn()}
+          asset={customFakeAsset}
+          isXvsEnabled
+          assets={[customFakeAsset]}
+        />
+      ),
       {
         authContextValue: {
           account: {
@@ -140,7 +144,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
 
   it('submit is disabled with no amount', async () => {
     const { getByText } = renderComponent(
-      () => <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />,
+      () => (
+        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={[fakeAsset]} />
+      ),
       {
         authContextValue: {
           account: {
@@ -148,7 +154,6 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
           },
         },
       },
-
     );
 
     const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
@@ -172,12 +177,14 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
     (supplyBnb as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
     renderComponent(
-      () => <SupplyWithdraw
-        onClose={onCloseMock}
-        asset={customFakeAsset}
-        isXvsEnabled
-        assets={[fakeAsset]}
-      />,
+      () => (
+        <SupplyWithdraw
+          onClose={onCloseMock}
+          asset={customFakeAsset}
+          isXvsEnabled
+          assets={[fakeAsset]}
+        />
+      ),
       {
         authContextValue: {
           account: {

--- a/src/testUtils/renderComponent.tsx
+++ b/src/testUtils/renderComponent.tsx
@@ -11,15 +11,22 @@ import { SuccessfulTransactionModalProvider } from 'context/SuccessfulTransactio
 import { init as initTranslationLibrary } from 'translation';
 import Theme from 'theme';
 import { RefreshContextProvider } from 'context/RefreshContext';
-import { VaiContextProvider } from 'context/VaiContext';
+import { VaiContext, IVaiContextValue } from 'context/VaiContext';
 import { MuiThemeProvider } from 'theme/MuiThemeProvider/MuiThemeProvider';
+import BigNumber from 'bignumber.js';
 
 // Initialize internationalization library
 initTranslationLibrary();
 
 const renderComponent = (
   children: React.ReactElement | (() => React.ReactElement),
-  { authContextValue = {} }: { authContextValue?: Partial<IAuthContextValue> } = {},
+  {
+    authContextValue = {},
+    vaiContextValue = {},
+  }: {
+    authContextValue?: Partial<IAuthContextValue>;
+    vaiContextValue?: Partial<IVaiContextValue>;
+  } = {},
 ) => {
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -37,6 +44,13 @@ const renderComponent = (
     account: undefined,
     ...authContextValue,
   };
+  const defaultVaiContextValues = {
+    userVaiMinted: new BigNumber(0),
+    userVaiBalance: new BigNumber(0),
+    userVaiEnabled: false,
+    mintableVai: new BigNumber(0),
+    ...vaiContextValue,
+  };
 
   const renderRes = render(
     <Theme>
@@ -45,7 +59,7 @@ const renderComponent = (
           <MuiThemeProvider>
             <AuthContext.Provider value={defaultAuthContextValues}>
               <RefreshContextProvider>
-                <VaiContextProvider>
+                <VaiContext.Provider value={defaultVaiContextValues}>
                   <SuccessfulTransactionModalProvider>
                     <BrowserRouter>
                       <ToastContainer
@@ -64,7 +78,7 @@ const renderComponent = (
                       </Switch>
                     </BrowserRouter>
                   </SuccessfulTransactionModalProvider>
-                </VaiContextProvider>
+                </VaiContext.Provider>
               </RefreshContextProvider>
             </AuthContext.Provider>
           </MuiThemeProvider>


### PR DESCRIPTION
To set the AuthContext in tests we are wrapping the tested component directly, this is cumbersome to just set a single value on the context.
It also results in the component getting wrapped twice in the AuthContext.

The same refactor has been made for VaiContext