### PR TITLE
Update supply form tests

### DIFF
--- a/src/clients/api/index.ts
+++ b/src/clients/api/index.ts
@@ -42,7 +42,6 @@ export * from './mutations/useSupplyBnb';
 export { default as redeem } from './mutations/redeem';
 export * from './mutations/redeem';
 export { default as useRedeem } from './mutations/useRedeem';
-export * from './mutations/useRedeem';
 
 export { default as repayNonBnbVToken } from './mutations/repayNonBnbVToken';
 export * from './mutations/repayNonBnbVToken';
@@ -55,7 +54,6 @@ export { default as useRepayBnb } from './mutations/useRepayBnb';
 export { default as redeemUnderlying } from './mutations/redeemUnderlying';
 export * from './mutations/redeemUnderlying';
 export { default as useRedeemUnderlying } from './mutations/useRedeemUnderlying';
-export * from './mutations/useRedeemUnderlying';
 
 export { default as claimXvsReward } from './mutations/claimXvsReward';
 export * from './mutations/claimXvsReward';

--- a/src/clients/api/mutations/convertVrt.spec.ts
+++ b/src/clients/api/mutations/convertVrt.spec.ts
@@ -25,7 +25,7 @@ describe('api/mutation/convertVrt', () => {
     try {
       await convertVrt({
         vrtConverterContract: fakeContract,
-        amount: fakeAmount,
+        amountWei: fakeAmount,
         accountAddress: address,
       });
 
@@ -49,7 +49,7 @@ describe('api/mutation/convertVrt', () => {
 
     const response = await convertVrt({
       vrtConverterContract: fakeContract,
-      amount: fakeAmount,
+      amountWei: fakeAmount,
       accountAddress: address,
     });
 

--- a/src/clients/api/mutations/convertVrt.ts
+++ b/src/clients/api/mutations/convertVrt.ts
@@ -3,7 +3,7 @@ import { VrtConverter } from 'types/contracts';
 
 export interface IConvertVrtInput {
   vrtConverterContract: VrtConverter;
-  amount: string;
+  amountWei: string;
   accountAddress: string;
 }
 
@@ -11,10 +11,10 @@ export type ConvertVrtOutput = TransactionReceipt;
 
 const convertVrt = async ({
   vrtConverterContract,
-  amount,
+  amountWei,
   accountAddress,
 }: IConvertVrtInput): Promise<ConvertVrtOutput> =>
-  vrtConverterContract.methods.convert(amount).send({
+  vrtConverterContract.methods.convert(amountWei).send({
     from: accountAddress,
   });
 

--- a/src/clients/api/mutations/redeem.spec.ts
+++ b/src/clients/api/mutations/redeem.spec.ts
@@ -1,4 +1,9 @@
+import BigNumber from 'bignumber.js';
+
+import { VBep20 } from 'types/contracts';
 import redeem from './redeem';
+
+const fakeAmount = new BigNumber(10000000000000000);
 
 describe('api/mutation/redeem', () => {
   test('throws an error when request fails', async () => {
@@ -10,12 +15,12 @@ describe('api/mutation/redeem', () => {
           },
         }),
       },
-    } as any;
+    } as unknown as VBep20;
 
     try {
       await redeem({
         tokenContract: fakeContract,
-        amount: '10000000000000000',
+        amount: fakeAmount,
         account: '0x3d759121234cd36F8124C21aFe1c6852d2bEd848',
       });
 
@@ -26,7 +31,6 @@ describe('api/mutation/redeem', () => {
   });
 
   test('returns undefined when request succeeds', async () => {
-    const fakeAmountWei = '10000000000000000';
     const fakeFromAccountsAddress = '0x3d759121234cd36F8124C21aFe1c6852d2bEd848';
 
     const sendMock = jest.fn(async () => undefined);
@@ -38,17 +42,17 @@ describe('api/mutation/redeem', () => {
       methods: {
         redeem: redeemMock,
       },
-    } as unknown as any;
+    } as unknown as VBep20;
 
     const response = await redeem({
       tokenContract: fakeContract,
-      amount: fakeAmountWei,
+      amount: fakeAmount,
       account: fakeFromAccountsAddress,
     });
 
     expect(response).toBe(undefined);
     expect(redeemMock).toHaveBeenCalledTimes(1);
-    expect(redeemMock).toHaveBeenCalledWith(fakeAmountWei);
+    expect(redeemMock).toHaveBeenCalledWith(fakeAmount.toFixed());
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock).toHaveBeenCalledWith({ from: fakeFromAccountsAddress });
   });

--- a/src/clients/api/mutations/redeem.spec.ts
+++ b/src/clients/api/mutations/redeem.spec.ts
@@ -20,7 +20,7 @@ describe('api/mutation/redeem', () => {
     try {
       await redeem({
         tokenContract: fakeContract,
-        amount: fakeAmount,
+        amountWei: fakeAmount,
         account: '0x3d759121234cd36F8124C21aFe1c6852d2bEd848',
       });
 
@@ -46,7 +46,7 @@ describe('api/mutation/redeem', () => {
 
     const response = await redeem({
       tokenContract: fakeContract,
-      amount: fakeAmount,
+      amountWei: fakeAmount,
       account: fakeFromAccountsAddress,
     });
 

--- a/src/clients/api/mutations/redeem.ts
+++ b/src/clients/api/mutations/redeem.ts
@@ -1,15 +1,17 @@
+import BigNumber from 'bignumber.js';
 import type { TransactionReceipt } from 'web3-core';
+
 import { VBep20 } from 'types/contracts';
 
 export interface IRedeemInput {
   tokenContract: VBep20;
   account: string;
-  amount: string;
+  amount: BigNumber;
 }
 
 export type RedeemOutput = TransactionReceipt;
 
 const redeem = async ({ tokenContract, account, amount }: IRedeemInput): Promise<RedeemOutput> =>
-  tokenContract.methods.redeem(amount).send({ from: account });
+  tokenContract.methods.redeem(amount.toFixed()).send({ from: account });
 
 export default redeem;

--- a/src/clients/api/mutations/redeem.ts
+++ b/src/clients/api/mutations/redeem.ts
@@ -6,12 +6,12 @@ import { VBep20 } from 'types/contracts';
 export interface IRedeemInput {
   tokenContract: VBep20;
   account: string;
-  amount: BigNumber;
+  amountWei: BigNumber;
 }
 
 export type RedeemOutput = TransactionReceipt;
 
-const redeem = async ({ tokenContract, account, amount }: IRedeemInput): Promise<RedeemOutput> =>
-  tokenContract.methods.redeem(amount.toFixed()).send({ from: account });
+const redeem = async ({ tokenContract, account, amountWei }: IRedeemInput): Promise<RedeemOutput> =>
+  tokenContract.methods.redeem(amountWei.toFixed()).send({ from: account });
 
 export default redeem;

--- a/src/clients/api/mutations/redeemUnderlying.spec.ts
+++ b/src/clients/api/mutations/redeemUnderlying.spec.ts
@@ -1,4 +1,10 @@
+import BigNumber from 'bignumber.js';
+
+import fakeAccountAddress from '__mocks__/models/address';
+import { VBep20 } from 'types/contracts';
 import redeemUnderlying from './redeemUnderlying';
+
+const fakeAmount = new BigNumber(10000000000000000);
 
 describe('api/mutation/redeemUnderlying', () => {
   test('throws an error when request fails', async () => {
@@ -10,13 +16,13 @@ describe('api/mutation/redeemUnderlying', () => {
           },
         }),
       },
-    } as any;
+    } as unknown as VBep20;
 
     try {
       await redeemUnderlying({
         tokenContract: fakeContract,
-        amount: '10000000000000000',
-        account: '0x3d759121234cd36F8124C21aFe1c6852d2bEd848',
+        amount: fakeAmount,
+        account: fakeAccountAddress,
       });
 
       throw new Error('redeemUnderlying should have thrown an error but did not');
@@ -26,9 +32,6 @@ describe('api/mutation/redeemUnderlying', () => {
   });
 
   test('returns undefined when request succeeds', async () => {
-    const fakeAmountWei = '10000000000000000';
-    const fakeFromAccountsAddress = '0x3d759121234cd36F8124C21aFe1c6852d2bEd848';
-
     const sendMock = jest.fn(async () => undefined);
     const redeemUnderlyingMock = jest.fn(() => ({
       send: sendMock,
@@ -38,18 +41,18 @@ describe('api/mutation/redeemUnderlying', () => {
       methods: {
         redeemUnderlying: redeemUnderlyingMock,
       },
-    } as unknown as any;
+    } as unknown as VBep20;
 
     const response = await redeemUnderlying({
       tokenContract: fakeContract,
-      amount: fakeAmountWei,
-      account: fakeFromAccountsAddress,
+      amount: fakeAmount,
+      account: fakeAccountAddress,
     });
 
     expect(response).toBe(undefined);
     expect(redeemUnderlyingMock).toHaveBeenCalledTimes(1);
-    expect(redeemUnderlyingMock).toHaveBeenCalledWith(fakeAmountWei);
+    expect(redeemUnderlyingMock).toHaveBeenCalledWith(fakeAmount.toFixed());
     expect(sendMock).toHaveBeenCalledTimes(1);
-    expect(sendMock).toHaveBeenCalledWith({ from: fakeFromAccountsAddress });
+    expect(sendMock).toHaveBeenCalledWith({ from: fakeAccountAddress });
   });
 });

--- a/src/clients/api/mutations/redeemUnderlying.spec.ts
+++ b/src/clients/api/mutations/redeemUnderlying.spec.ts
@@ -21,7 +21,7 @@ describe('api/mutation/redeemUnderlying', () => {
     try {
       await redeemUnderlying({
         tokenContract: fakeContract,
-        amount: fakeAmount,
+        amountWei: fakeAmount,
         account: fakeAccountAddress,
       });
 
@@ -45,7 +45,7 @@ describe('api/mutation/redeemUnderlying', () => {
 
     const response = await redeemUnderlying({
       tokenContract: fakeContract,
-      amount: fakeAmount,
+      amountWei: fakeAmount,
       account: fakeAccountAddress,
     });
 

--- a/src/clients/api/mutations/redeemUnderlying.ts
+++ b/src/clients/api/mutations/redeemUnderlying.ts
@@ -6,7 +6,7 @@ import { VBep20, VBnbToken } from 'types/contracts';
 export interface IRedeemUnderlyingInput {
   tokenContract: VBep20 | VBnbToken;
   account: string;
-  amount: BigNumber;
+  amountWei: BigNumber;
 }
 
 export type RedeemUnderlyingOutput = TransactionReceipt;
@@ -14,8 +14,8 @@ export type RedeemUnderlyingOutput = TransactionReceipt;
 const redeemUnderlying = async ({
   tokenContract,
   account,
-  amount,
+  amountWei,
 }: IRedeemUnderlyingInput): Promise<RedeemUnderlyingOutput> =>
-  tokenContract.methods.redeemUnderlying(amount.toFixed()).send({ from: account });
+  tokenContract.methods.redeemUnderlying(amountWei.toFixed()).send({ from: account });
 
 export default redeemUnderlying;

--- a/src/clients/api/mutations/redeemUnderlying.ts
+++ b/src/clients/api/mutations/redeemUnderlying.ts
@@ -1,10 +1,12 @@
+import BigNumber from 'bignumber.js';
 import type { TransactionReceipt } from 'web3-core';
+
 import { VBep20, VBnbToken } from 'types/contracts';
 
 export interface IRedeemUnderlyingInput {
   tokenContract: VBep20 | VBnbToken;
   account: string;
-  amount: string;
+  amount: BigNumber;
 }
 
 export type RedeemUnderlyingOutput = TransactionReceipt;
@@ -14,6 +16,6 @@ const redeemUnderlying = async ({
   account,
   amount,
 }: IRedeemUnderlyingInput): Promise<RedeemUnderlyingOutput> =>
-  tokenContract.methods.redeemUnderlying(amount).send({ from: account });
+  tokenContract.methods.redeemUnderlying(amount.toFixed()).send({ from: account });
 
 export default redeemUnderlying;

--- a/src/clients/api/mutations/supplyBnb.spec.ts
+++ b/src/clients/api/mutations/supplyBnb.spec.ts
@@ -1,5 +1,10 @@
+import BigNumber from 'bignumber.js';
+
+import { VBnbToken } from 'types/contracts';
 import { VBEP_TOKENS } from 'constants/tokens';
 import supplyBnb from './supplyBnb';
+
+const fakeAmount = new BigNumber(10000000000000000);
 
 describe('api/mutation/supplyBnb', () => {
   test('throws an error when request fails', async () => {
@@ -19,13 +24,13 @@ describe('api/mutation/supplyBnb', () => {
           },
         }),
       },
-    } as any;
+    } as unknown as VBnbToken;
 
     try {
       await supplyBnb({
         web3: fakeWeb3,
         tokenContract: fakeContract,
-        amount: '10000000000000000',
+        amount: fakeAmount,
         account: '0x3d759121234cd36F8124C21aFe1c6852d2bEd848',
       });
 
@@ -36,7 +41,6 @@ describe('api/mutation/supplyBnb', () => {
   });
 
   test('returns undefined when request succeeds', async () => {
-    const fakeAmount = '100000000';
     const fakeAccount = '0x3d759121234cd36F8124C21aFe1c6852d2bEd848';
 
     const sendTransactionMock = jest.fn(async () => {});
@@ -57,7 +61,7 @@ describe('api/mutation/supplyBnb', () => {
           encodeABI: () => fakeEncodedUri,
         }),
       },
-    } as any;
+    } as unknown as VBnbToken;
 
     const response = await supplyBnb({
       web3: fakeWeb3,
@@ -71,7 +75,7 @@ describe('api/mutation/supplyBnb', () => {
     expect(sendTransactionMock).toHaveBeenCalledWith({
       from: fakeAccount,
       data: fakeEncodedUri,
-      value: fakeAmount,
+      value: fakeAmount.toFixed(),
       to: VBEP_TOKENS.bnb.address,
     });
   });

--- a/src/clients/api/mutations/supplyBnb.spec.ts
+++ b/src/clients/api/mutations/supplyBnb.spec.ts
@@ -30,7 +30,7 @@ describe('api/mutation/supplyBnb', () => {
       await supplyBnb({
         web3: fakeWeb3,
         tokenContract: fakeContract,
-        amount: fakeAmount,
+        amountWei: fakeAmount,
         account: '0x3d759121234cd36F8124C21aFe1c6852d2bEd848',
       });
 
@@ -66,7 +66,7 @@ describe('api/mutation/supplyBnb', () => {
     const response = await supplyBnb({
       web3: fakeWeb3,
       tokenContract: fakeContract,
-      amount: fakeAmount,
+      amountWei: fakeAmount,
       account: fakeAccount,
     });
 

--- a/src/clients/api/mutations/supplyBnb.ts
+++ b/src/clients/api/mutations/supplyBnb.ts
@@ -9,7 +9,7 @@ export interface ISupplyBnbInput {
   tokenContract: VBnbToken;
   web3: Web3;
   account: string;
-  amount: BigNumber;
+  amountWei: BigNumber;
 }
 
 const vBnbAddress = getVBepToken('bnb').address;
@@ -20,13 +20,13 @@ const supplyBnb = async ({
   web3,
   tokenContract,
   account,
-  amount,
+  amountWei,
 }: ISupplyBnbInput): Promise<SupplyBnbOutput> => {
   const contractData = tokenContract.methods.mint().encodeABI();
   const tx = {
     from: account,
     to: vBnbAddress,
-    value: amount.toFixed(),
+    value: amountWei.toFixed(),
     data: contractData,
   };
 

--- a/src/clients/api/mutations/supplyBnb.ts
+++ b/src/clients/api/mutations/supplyBnb.ts
@@ -1,5 +1,7 @@
+import BigNumber from 'bignumber.js';
 import Web3 from 'web3';
 import type { TransactionReceipt } from 'web3-core';
+
 import { VBnbToken } from 'types/contracts';
 import { getVBepToken } from 'utilities';
 
@@ -7,7 +9,7 @@ export interface ISupplyBnbInput {
   tokenContract: VBnbToken;
   web3: Web3;
   account: string;
-  amount: string;
+  amount: BigNumber;
 }
 
 const vBnbAddress = getVBepToken('bnb').address;
@@ -24,7 +26,7 @@ const supplyBnb = async ({
   const tx = {
     from: account,
     to: vBnbAddress,
-    value: amount,
+    value: amount.toFixed(),
     data: contractData,
   };
 

--- a/src/clients/api/mutations/supplyNonBnb.spec.ts
+++ b/src/clients/api/mutations/supplyNonBnb.spec.ts
@@ -1,4 +1,9 @@
+import BigNumber from 'bignumber.js';
+
+import { VBep20 } from 'types/contracts';
 import supply from './supplyNonBnb';
+
+const fakeAmount = new BigNumber(1000000000000);
 
 describe('api/mutation/supplyNonBnb', () => {
   test('throws an error when request fails', async () => {
@@ -10,12 +15,12 @@ describe('api/mutation/supplyNonBnb', () => {
           },
         }),
       },
-    } as any;
+    } as unknown as VBep20;
 
     try {
       await supply({
         tokenContract: fakeContract,
-        amount: '10000000000000000',
+        amount: fakeAmount,
         account: '0x3d759121234cd36F8124C21aFe1c6852d2bEd848',
       });
 
@@ -26,7 +31,6 @@ describe('api/mutation/supplyNonBnb', () => {
   });
 
   test('returns undefined when request succeeds', async () => {
-    const fakeAmount = '1000000000000';
     const fakeAccount = '0x3d759121234cd36F8124C21aFe1c6852d2bEd848';
 
     const sendMock = jest.fn(async () => undefined);
@@ -38,7 +42,7 @@ describe('api/mutation/supplyNonBnb', () => {
       methods: {
         mint: supplyMock,
       },
-    } as unknown as any;
+    } as unknown as VBep20;
 
     const response = await supply({
       tokenContract: fakeContract,
@@ -48,7 +52,7 @@ describe('api/mutation/supplyNonBnb', () => {
 
     expect(response).toBe(undefined);
     expect(supplyMock).toHaveBeenCalledTimes(1);
-    expect(supplyMock).toHaveBeenCalledWith(fakeAmount);
+    expect(supplyMock).toHaveBeenCalledWith(fakeAmount.toFixed());
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock).toHaveBeenCalledWith({ from: fakeAccount });
   });

--- a/src/clients/api/mutations/supplyNonBnb.spec.ts
+++ b/src/clients/api/mutations/supplyNonBnb.spec.ts
@@ -20,7 +20,7 @@ describe('api/mutation/supplyNonBnb', () => {
     try {
       await supply({
         tokenContract: fakeContract,
-        amount: fakeAmount,
+        amountWei: fakeAmount,
         account: '0x3d759121234cd36F8124C21aFe1c6852d2bEd848',
       });
 
@@ -46,7 +46,7 @@ describe('api/mutation/supplyNonBnb', () => {
 
     const response = await supply({
       tokenContract: fakeContract,
-      amount: fakeAmount,
+      amountWei: fakeAmount,
       account: fakeAccount,
     });
 

--- a/src/clients/api/mutations/supplyNonBnb.ts
+++ b/src/clients/api/mutations/supplyNonBnb.ts
@@ -5,7 +5,7 @@ import { VBep20 } from 'types/contracts';
 export interface ISupplyNonBnbInput {
   tokenContract: VBep20;
   account: string;
-  amount: BigNumber;
+  amountWei: BigNumber;
 }
 
 export type SupplyNonBnbOutput = TransactionReceipt;
@@ -13,8 +13,8 @@ export type SupplyNonBnbOutput = TransactionReceipt;
 const supplyNonBnb = async ({
   tokenContract,
   account,
-  amount,
+  amountWei,
 }: ISupplyNonBnbInput): Promise<SupplyNonBnbOutput> =>
-  tokenContract.methods.mint(amount.toFixed()).send({ from: account });
+  tokenContract.methods.mint(amountWei.toFixed()).send({ from: account });
 
 export default supplyNonBnb;

--- a/src/clients/api/mutations/supplyNonBnb.ts
+++ b/src/clients/api/mutations/supplyNonBnb.ts
@@ -1,10 +1,11 @@
+import BigNumber from 'bignumber.js';
 import type { TransactionReceipt } from 'web3-core';
 import { VBep20 } from 'types/contracts';
 
 export interface ISupplyNonBnbInput {
   tokenContract: VBep20;
   account: string;
-  amount: string;
+  amount: BigNumber;
 }
 
 export type SupplyNonBnbOutput = TransactionReceipt;
@@ -14,6 +15,6 @@ const supplyNonBnb = async ({
   account,
   amount,
 }: ISupplyNonBnbInput): Promise<SupplyNonBnbOutput> =>
-  tokenContract.methods.mint(amount).send({ from: account });
+  tokenContract.methods.mint(amount.toFixed()).send({ from: account });
 
 export default supplyNonBnb;

--- a/src/clients/api/mutations/useRedeem.ts
+++ b/src/clients/api/mutations/useRedeem.ts
@@ -7,10 +7,6 @@ import redeem, { IRedeemInput, RedeemOutput } from 'clients/api/mutations/redeem
 import FunctionKey from 'constants/functionKey';
 import { useVTokenContract } from 'clients/contracts/hooks';
 
-export interface UseRedeemParams {
-  amount: string;
-}
-
 const useRedeem = (
   { assetId, account }: { assetId: VTokenId; account: string },
   // TODO: use custom error type https://app.clickup.com/t/2rvwhnt

--- a/src/clients/api/mutations/useRedeemUnderlying.ts
+++ b/src/clients/api/mutations/useRedeemUnderlying.ts
@@ -9,10 +9,6 @@ import redeemUnderlying, {
 import FunctionKey from 'constants/functionKey';
 import { useVTokenContract } from 'clients/contracts/hooks';
 
-export interface UseRedeemUnderlyingParams {
-  amount: string;
-}
-
 const useRedeemUnderlying = (
   { assetId, account }: { assetId: VTokenId; account: string },
   // TODO: use custom error type https://app.clickup.com/t/2rvwhnt

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import BigNumber from 'bignumber.js';
 import { act, fireEvent, waitFor } from '@testing-library/react';
+
+import fakeAccountAddress from '__mocks__/models/address';
 import { assetData } from '__mocks__/models/asset';
 import renderComponent from 'testUtils/renderComponent';
 import { AuthContext } from 'context/AuthContext';
@@ -12,202 +14,241 @@ import {
   getVTokenBalance,
   useUserMarketInfo,
 } from 'clients/api';
-import { TokenId } from 'types';
+import { Asset, TokenId } from 'types';
 import en from 'translation/translations/en.json';
 import SupplyWithdraw from '.';
 
 const ONE = '1';
 const ONE_WEI = '1000000000000000000';
-const asset = assetData[1];
-const fakeAccountAddress = '0x0';
 const fakeGetVTokenBalance = new BigNumber('111');
 
+const fakeAsset: Asset = {
+  ...assetData[0],
+  tokenPrice: new BigNumber(1),
+  supplyBalance: new BigNumber(1000),
+  walletBalance: new BigNumber(10000000),
+};
+const fakeAssets = [fakeAsset];
+
+const fakeUserTotalBorrowLimitDollars = new BigNumber(1000);
+const fakeUserTotalBorrowBalanceDollars = new BigNumber(10);
+
 jest.mock('clients/api');
+jest.mock('hooks/useSuccessfulTransactionModal');
 
 describe('pages/Dashboard/SupplyWithdrawUi', () => {
   beforeEach(() => {
     (useUserMarketInfo as jest.Mock).mockImplementation(() => ({
-      assets: assetData,
-      userTotalBorrowLimit: new BigNumber('111'),
-      userTotalBorrowBalance: new BigNumber('91'),
+      assets: [], // Not used in these tests
+      userTotalBorrowLimit: fakeUserTotalBorrowLimitDollars,
+      userTotalBorrowBalance: fakeUserTotalBorrowBalanceDollars,
     }));
   });
 
-  it('renders without crashing', async () => {
-    renderComponent(
-      <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />,
-    );
-  });
-
-  it('asks the user to connect if wallet is not connected', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: undefined,
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
-      </AuthContext.Provider>,
-    );
-
-    const connectTextSupply = getByText(en.supplyWithdraw.connectWalletToSupply);
-    expect(connectTextSupply).toHaveTextContent(en.supplyWithdraw.connectWalletToSupply);
-    const withdrawButton = getByText(en.supplyWithdraw.withdraw);
-    fireEvent.click(withdrawButton);
-    const connectTextWithdraw = getByText(en.supplyWithdraw.connectWalletToWithdraw);
-    expect(connectTextWithdraw).toHaveTextContent(en.supplyWithdraw.connectWalletToWithdraw);
-  });
-
-  it('submit is disabled with no amount', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
-      </AuthContext.Provider>,
-    );
-
-    const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
-    expect(disabledButtonText).toHaveTextContent(en.supplyWithdraw.enterValidAmountSupply);
-    const disabledButton = document.querySelector('button[type="submit"]');
-    expect(disabledButton).toHaveAttribute('disabled');
-  });
-
-  it('calls supplyBnb when supplying BNB', async () => {
-    const bnbAsset = {
-      ...asset,
-      id: 'bnb' as TokenId,
-      symbol: 'BNB',
-      vsymbol: 'vBNB',
-      walletBalance: new BigNumber('11'),
-    };
-    renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={bnbAsset} isXvsEnabled assets={assetData} />
-      </AuthContext.Provider>,
-    );
-    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-    act(() => {
-      fireEvent.change(tokenTextInput, { target: { value: ONE } });
+  describe('Supply form', () => {
+    it('renders without crashing', async () => {
+      renderComponent(
+        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />,
+      );
     });
-    const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.supply);
-    fireEvent.click(sumbitButton);
-    await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amount: ONE_WEI }));
+
+    it.only('displays correct token wallet balance', async () => {
+      const { getByText } = renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: {
+              address: fakeAccountAddress,
+            },
+          }}
+        >
+          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />
+        </AuthContext.Provider>,
+      );
+
+      await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
+    });
+
+    it('asks the user to connect if wallet is not connected', async () => {
+      const { getByText } = renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: undefined,
+          }}
+        >
+          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />
+        </AuthContext.Provider>,
+      );
+
+      const connectTextSupply = getByText(en.supplyWithdraw.connectWalletToSupply);
+      expect(connectTextSupply).toHaveTextContent(en.supplyWithdraw.connectWalletToSupply);
+      const withdrawButton = getByText(en.supplyWithdraw.withdraw);
+      fireEvent.click(withdrawButton);
+      const connectTextWithdraw = getByText(en.supplyWithdraw.connectWalletToWithdraw);
+      expect(connectTextWithdraw).toHaveTextContent(en.supplyWithdraw.connectWalletToWithdraw);
+    });
+
+    it('submit is disabled with no amount', async () => {
+      const { getByText } = renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: {
+              address: fakeAccountAddress,
+            },
+          }}
+        >
+          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />
+        </AuthContext.Provider>,
+      );
+
+      const disabledButtonText = getByText(en.supplyWithdraw.enterValidAmountSupply);
+      expect(disabledButtonText).toHaveTextContent(en.supplyWithdraw.enterValidAmountSupply);
+      const disabledButton = document.querySelector('button[type="submit"]');
+      expect(disabledButton).toHaveAttribute('disabled');
+    });
+
+    it('calls supplyBnb when supplying BNB', async () => {
+      const bnbAsset = {
+        ...fakeAsset,
+        id: 'bnb' as TokenId,
+        symbol: 'BNB',
+        vsymbol: 'vBNB',
+        walletBalance: new BigNumber('11'),
+      };
+      renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: {
+              address: fakeAccountAddress,
+            },
+          }}
+        >
+          <SupplyWithdraw onClose={jest.fn()} asset={bnbAsset} isXvsEnabled assets={fakeAssets} />
+        </AuthContext.Provider>,
+      );
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+      act(() => {
+        fireEvent.change(tokenTextInput, { target: { value: ONE } });
+      });
+      const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.supply);
+      fireEvent.click(sumbitButton);
+      await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amount: ONE_WEI }));
+    });
+
+    it('calls supplyNonBnb when supplying other token', async () => {
+      const nonBnbAsset = {
+        ...fakeAsset,
+        id: 'eth' as TokenId,
+        symbol: 'ETH',
+        vsymbol: 'vETH',
+        walletBalance: new BigNumber('11'),
+      };
+      renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: {
+              address: fakeAccountAddress,
+            },
+          }}
+        >
+          <SupplyWithdraw
+            onClose={jest.fn()}
+            asset={nonBnbAsset}
+            isXvsEnabled
+            assets={fakeAssets}
+          />
+        </AuthContext.Provider>,
+      );
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+      act(() => {
+        fireEvent.change(tokenTextInput, { target: { value: ONE } });
+      });
+      const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.supply);
+      fireEvent.click(sumbitButton);
+      await waitFor(() => expect(supplyNonBnb).toHaveBeenCalledWith({ amount: ONE_WEI }));
+    });
   });
 
-  it('calls supplyNonBnb when supplying other token', async () => {
-    const nonBnbAsset = {
-      ...asset,
-      id: 'eth' as TokenId,
-      symbol: 'ETH',
-      vsymbol: 'vETH',
-      walletBalance: new BigNumber('11'),
-    };
-    renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={nonBnbAsset} isXvsEnabled assets={assetData} />
-      </AuthContext.Provider>,
-    );
-    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-    act(() => {
-      fireEvent.change(tokenTextInput, { target: { value: ONE } });
-    });
-    const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.supply);
-    fireEvent.click(sumbitButton);
-    await waitFor(() => expect(supplyNonBnb).toHaveBeenCalledWith({ amount: ONE_WEI }));
-  });
+  describe('Withdraw form', () => {
+    it('redeem is called when full amount is withdrawn', async () => {
+      (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
+      const { getByText } = renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: {
+              address: fakeAccountAddress,
+            },
+          }}
+        >
+          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />
+        </AuthContext.Provider>,
+      );
 
-  it('redeem is called when full amount is withdrawn', async () => {
-    (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
-      </AuthContext.Provider>,
-    );
-
-    const withdrawButton = await waitFor(() => getByText(en.supplyWithdraw.withdraw));
-    fireEvent.click(withdrawButton);
-    const maxButton = await waitFor(() => getByText(en.supplyWithdraw.max.toUpperCase()));
-    act(() => {
-      fireEvent.click(maxButton);
+      const withdrawButton = await waitFor(() => getByText(en.supplyWithdraw.withdraw));
+      fireEvent.click(withdrawButton);
+      const maxButton = await waitFor(() => getByText(en.supplyWithdraw.max.toUpperCase()));
+      act(() => {
+        fireEvent.click(maxButton);
+      });
+      const sumbitButton = await waitFor(
+        () => document.querySelector('button[type="submit"]') as HTMLButtonElement,
+      );
+      await waitFor(() => expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
+      fireEvent.click(sumbitButton);
+      await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amount: fakeGetVTokenBalance }));
     });
-    const sumbitButton = await waitFor(
-      () => document.querySelector('button[type="submit"]') as HTMLButtonElement,
-    );
-    await waitFor(() => expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
-    fireEvent.click(sumbitButton);
-    await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amount: fakeGetVTokenBalance }));
-  });
 
-  it('redeemUnderlying is called when partial amount is withdrawn', async () => {
-    const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
-          account: {
-            address: fakeAccountAddress,
-          },
-        }}
-      >
-        <SupplyWithdraw onClose={jest.fn()} asset={asset} isXvsEnabled assets={assetData} />
-      </AuthContext.Provider>,
-    );
-    const withdrawButton = getByText(en.supplyWithdraw.withdraw);
-    fireEvent.click(withdrawButton);
-    const tokenTextInput = document.querySelector('input') as HTMLInputElement;
-    act(() => {
-      fireEvent.change(tokenTextInput, { target: { value: ONE } });
+    it('redeemUnderlying is called when partial amount is withdrawn', async () => {
+      const { getByText } = renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: {
+              address: fakeAccountAddress,
+            },
+          }}
+        >
+          <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />
+        </AuthContext.Provider>,
+      );
+      const withdrawButton = getByText(en.supplyWithdraw.withdraw);
+      fireEvent.click(withdrawButton);
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+      act(() => {
+        fireEvent.change(tokenTextInput, { target: { value: ONE } });
+      });
+      const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
+      fireEvent.click(sumbitButton);
+      await waitFor(() => expect(redeemUnderlying).toHaveBeenCalledWith({ amount: ONE_WEI }));
     });
-    const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-    expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
-    fireEvent.click(sumbitButton);
-    await waitFor(() => expect(redeemUnderlying).toHaveBeenCalledWith({ amount: ONE_WEI }));
   });
 });

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -45,14 +45,37 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
     }));
   });
 
-  describe('Supply form', () => {
-    it('renders without crashing', async () => {
-      renderComponent(
-        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />,
-      );
-    });
+  it('renders without crashing', async () => {
+    renderComponent(
+      <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />,
+    );
+  });
 
-    it.only('displays correct token wallet balance', async () => {
+  it('asks the user to connect if wallet is not connected', async () => {
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: undefined,
+        }}
+      >
+        <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />
+      </AuthContext.Provider>,
+    );
+
+    const connectTextSupply = getByText(en.supplyWithdraw.connectWalletToSupply);
+    expect(connectTextSupply).toHaveTextContent(en.supplyWithdraw.connectWalletToSupply);
+    const withdrawButton = getByText(en.supplyWithdraw.withdraw);
+    fireEvent.click(withdrawButton);
+    const connectTextWithdraw = getByText(en.supplyWithdraw.connectWalletToWithdraw);
+    expect(connectTextWithdraw).toHaveTextContent(en.supplyWithdraw.connectWalletToWithdraw);
+  });
+
+  describe('Supply form', () => {
+    it('displays correct token wallet balance', async () => {
       const { getByText } = renderComponent(
         <AuthContext.Provider
           value={{
@@ -72,7 +95,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       await waitFor(() => getByText(`10,000,000 ${fakeAsset.symbol.toUpperCase()}`));
     });
 
-    it('asks the user to connect if wallet is not connected', async () => {
+    it('displays correct token supply balance', async () => {
       const { getByText } = renderComponent(
         <AuthContext.Provider
           value={{
@@ -80,19 +103,16 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
             logOut: jest.fn(),
             openAuthModal: jest.fn(),
             closeAuthModal: jest.fn(),
-            account: undefined,
+            account: {
+              address: fakeAccountAddress,
+            },
           }}
         >
           <SupplyWithdraw onClose={jest.fn()} asset={fakeAsset} isXvsEnabled assets={fakeAssets} />
         </AuthContext.Provider>,
       );
 
-      const connectTextSupply = getByText(en.supplyWithdraw.connectWalletToSupply);
-      expect(connectTextSupply).toHaveTextContent(en.supplyWithdraw.connectWalletToSupply);
-      const withdrawButton = getByText(en.supplyWithdraw.withdraw);
-      fireEvent.click(withdrawButton);
-      const connectTextWithdraw = getByText(en.supplyWithdraw.connectWalletToWithdraw);
-      expect(connectTextWithdraw).toHaveTextContent(en.supplyWithdraw.connectWalletToWithdraw);
+      await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
     });
 
     it('submit is disabled with no amount', async () => {

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -115,6 +115,54 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
     });
 
+    it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {
+      const customFakeAsset: Asset = {
+        ...fakeAsset,
+        walletBalance: new BigNumber(1),
+      };
+
+      const { getByText } = renderComponent(
+        <AuthContext.Provider
+          value={{
+            login: jest.fn(),
+            logOut: jest.fn(),
+            openAuthModal: jest.fn(),
+            closeAuthModal: jest.fn(),
+            account: {
+              address: fakeAccountAddress,
+            },
+          }}
+        >
+          <SupplyWithdraw
+            onClose={jest.fn()}
+            asset={customFakeAsset}
+            isXvsEnabled
+            assets={fakeAssets}
+          />
+        </AuthContext.Provider>,
+      );
+      await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
+
+      // Check submit button is disabled
+      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
+        'disabled',
+      );
+
+      const incorrectValueTokens = customFakeAsset.walletBalance.plus(1).toFixed();
+
+      // Enter amount in input
+      const tokenTextInput = document.querySelector('input') as HTMLInputElement;
+      fireEvent.change(tokenTextInput, {
+        target: { value: incorrectValueTokens },
+      });
+
+      // Check submit button is still disabled
+      await waitFor(() => getByText(en.supplyWithdraw.enterValidAmountSupply));
+      expect(getByText(en.supplyWithdraw.enterValidAmountSupply).closest('button')).toHaveAttribute(
+        'disabled',
+      );
+    });
+
     it('submit is disabled with no amount', async () => {
       const { getByText } = renderComponent(
         <AuthContext.Provider
@@ -165,9 +213,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       act(() => {
         fireEvent.change(tokenTextInput, { target: { value: ONE } });
       });
-      const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-      expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.supply);
-      fireEvent.click(sumbitButton);
+      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply);
+      fireEvent.click(submitButton);
       await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amount: ONE_WEI }));
     });
 
@@ -203,9 +251,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       act(() => {
         fireEvent.change(tokenTextInput, { target: { value: ONE } });
       });
-      const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-      expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.supply);
-      fireEvent.click(sumbitButton);
+      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(submitButton).toHaveTextContent(en.supplyWithdraw.supply);
+      fireEvent.click(submitButton);
       await waitFor(() => expect(supplyNonBnb).toHaveBeenCalledWith({ amount: ONE_WEI }));
     });
   });
@@ -235,11 +283,11 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       act(() => {
         fireEvent.click(maxButton);
       });
-      const sumbitButton = await waitFor(
+      const submitButton = await waitFor(
         () => document.querySelector('button[type="submit"]') as HTMLButtonElement,
       );
-      await waitFor(() => expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
-      fireEvent.click(sumbitButton);
+      await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
+      fireEvent.click(submitButton);
       await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amount: fakeGetVTokenBalance }));
     });
 
@@ -265,9 +313,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       act(() => {
         fireEvent.change(tokenTextInput, { target: { value: ONE } });
       });
-      const sumbitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
-      expect(sumbitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
-      fireEvent.click(sumbitButton);
+      const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
+      expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
+      fireEvent.click(submitButton);
       await waitFor(() => expect(redeemUnderlying).toHaveBeenCalledWith({ amount: ONE_WEI }));
     });
   });

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -313,7 +313,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
   });
 
   describe('Withdraw form', () => {
-    it.skip('redeem is called when full amount is withdrawn', async () => {
+    it('redeem is called when full amount is withdrawn', async () => {
       (getVTokenBalance as jest.Mock).mockImplementationOnce(async () => fakeGetVTokenBalance);
       const { getByText } = renderComponent(
         <AuthContext.Provider
@@ -345,7 +345,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amount: fakeGetVTokenBalance }));
     });
 
-    it.skip('redeemUnderlying is called when partial amount is withdrawn', async () => {
+    it('redeemUnderlying is called when partial amount is withdrawn', async () => {
       const { getByText } = renderComponent(
         <AuthContext.Provider
           value={{
@@ -363,14 +363,24 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       );
       const withdrawButton = getByText(en.supplyWithdraw.withdraw);
       fireEvent.click(withdrawButton);
+
+      const correctAmountTokens = 1;
+
       const tokenTextInput = document.querySelector('input') as HTMLInputElement;
       act(() => {
-        fireEvent.change(tokenTextInput, { target: { value: ONE } });
+        fireEvent.change(tokenTextInput, { target: { value: correctAmountTokens } });
       });
       const submitButton = document.querySelector('button[type="submit"]') as HTMLButtonElement;
       expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw);
       fireEvent.click(submitButton);
-      await waitFor(() => expect(redeemUnderlying).toHaveBeenCalledWith({ amount: ONE_WEI }));
+
+      const expectedAmountWei = new BigNumber(correctAmountTokens).multipliedBy(
+        new BigNumber(10).pow(fakeAsset.decimals),
+      );
+
+      await waitFor(() =>
+        expect(redeemUnderlying).toHaveBeenCalledWith({ amount: expectedAmountWei }),
+      );
     });
   });
 });

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -233,7 +233,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
         new BigNumber(10).pow(customFakeAsset.decimals),
       );
 
-      await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amount: expectedAmountWei }));
+      await waitFor(() => expect(supplyBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }));
       expect(onCloseMock).toHaveBeenCalledTimes(1);
       await waitFor(() =>
         expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
@@ -296,7 +296,9 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
         new BigNumber(10).pow(customFakeAsset.decimals),
       );
 
-      await waitFor(() => expect(supplyNonBnb).toHaveBeenCalledWith({ amount: expectedAmountWei }));
+      await waitFor(() =>
+        expect(supplyNonBnb).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
+      );
       expect(onCloseMock).toHaveBeenCalledTimes(1);
       await waitFor(() =>
         expect(openSuccessfulTransactionModal).toHaveBeenCalledWith({
@@ -342,7 +344,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       );
       await waitFor(() => expect(submitButton).toHaveTextContent(en.supplyWithdraw.withdraw));
       fireEvent.click(submitButton);
-      await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amount: fakeGetVTokenBalance }));
+      await waitFor(() => expect(redeem).toHaveBeenCalledWith({ amountWei: fakeGetVTokenBalance }));
     });
 
     it('redeemUnderlying is called when partial amount is withdrawn', async () => {
@@ -379,7 +381,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
       );
 
       await waitFor(() =>
-        expect(redeemUnderlying).toHaveBeenCalledWith({ amount: expectedAmountWei }),
+        expect(redeemUnderlying).toHaveBeenCalledWith({ amountWei: expectedAmountWei }),
       );
     });
   });

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -243,8 +243,6 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
     });
     onClose();
 
-    console.log('HEERRE');
-
     openSuccessfulTransactionModal({
       title: t('supplyWithdraw.successfulSupplyTransactionModal.title'),
       message: t('supplyWithdraw.successfulSupplyTransactionModal.message'),

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -239,7 +239,7 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
   const onSubmitSupply: IAmountFormProps['onSubmit'] = async value => {
     const supplyAmount = new BigNumber(value).times(new BigNumber(10).pow(asset.decimals || 18));
     const res = await supply({
-      amount: supplyAmount,
+      amountWei: supplyAmount,
     });
     onClose();
 
@@ -259,13 +259,13 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
     const amountEqualsSupplyBalance = amount.eq(asset.supplyBalance);
     let transactionHash;
     if (amountEqualsSupplyBalance && vTokenBalanceWei) {
-      const res = await redeem({ amount: new BigNumber(vTokenBalanceWei) });
+      const res = await redeem({ amountWei: new BigNumber(vTokenBalanceWei) });
       ({ transactionHash } = res);
       // Display successful transaction modal
     } else {
       const withdrawAmount = amount.times(new BigNumber(10).pow(asset.decimals)).integerValue();
       const res = await redeemUnderlying({
-        amount: withdrawAmount,
+        amountWei: withdrawAmount,
       });
       ({ transactionHash } = res);
     }

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -218,7 +218,7 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
   const { userTotalBorrowBalance, userTotalBorrowLimit } = useUserMarketInfo({
     accountAddress,
   });
-  const { data: vTokenBalance } = useGetVTokenBalance(
+  const { data: vTokenBalanceWei } = useGetVTokenBalance(
     { account: accountAddress, vTokenId: asset.id as VTokenId },
     { enabled: !!accountAddress },
   );
@@ -237,13 +237,14 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
     });
   const isWithdrawLoading = isRedeemLoading || isRedeemUnderlyingLoading;
   const onSubmitSupply: IAmountFormProps['onSubmit'] = async value => {
-    const supplyAmount = new BigNumber(value)
-      .times(new BigNumber(10).pow(asset.decimals || 18))
-      .toString(10);
+    const supplyAmount = new BigNumber(value).times(new BigNumber(10).pow(asset.decimals || 18));
     const res = await supply({
       amount: supplyAmount,
     });
     onClose();
+
+    console.log('HEERRE');
+
     openSuccessfulTransactionModal({
       title: t('supplyWithdraw.successfulSupplyTransactionModal.title'),
       message: t('supplyWithdraw.successfulSupplyTransactionModal.message'),
@@ -259,17 +260,14 @@ const SupplyWithdrawModal: React.FC<ISupplyWithdrawUiProps> = props => {
     const amount = new BigNumber(value);
     const amountEqualsSupplyBalance = amount.eq(asset.supplyBalance);
     let transactionHash;
-    if (amountEqualsSupplyBalance && vTokenBalance) {
-      const res = await redeem({ amount: vTokenBalance });
+    if (amountEqualsSupplyBalance && vTokenBalanceWei) {
+      const res = await redeem({ amount: new BigNumber(vTokenBalanceWei) });
       ({ transactionHash } = res);
       // Display successful transaction modal
     } else {
-      const withdrawlAmount = amount
-        .times(new BigNumber(10).pow(asset.decimals))
-        .integerValue()
-        .toString(10);
+      const withdrawAmount = amount.times(new BigNumber(10).pow(asset.decimals)).integerValue();
       const res = await redeemUnderlying({
-        amount: withdrawlAmount,
+        amount: withdrawAmount,
       });
       ({ transactionHash } = res);
     }


### PR DESCRIPTION
- Update mutations used by `SupplyWithdraw` component so `amount` param uses `BigNumber` to be consistent with other mutations

Tests added:
- Wallet balance displayed is correct
- Supply balance displayed is correct
- Pressing on “MAX” button updates input value to wallet balance
- User can’t supply amount that’s higher than their wallet balance
- User can supply amount that is less or equal to their wallet balance