### PR TITLE
Update Amount Form validation to use Big Numbers

### DIFF
--- a/src/containers/AmountForm/validationSchema.ts
+++ b/src/containers/AmountForm/validationSchema.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup';
+import BigNumber from 'bignumber.js';
 
 export type FormValues = yup.InferType<ReturnType<typeof getValidationSchema>>;
 
@@ -16,7 +17,7 @@ const getValidationSchema = (maxAmount?: string) =>
       .test(
         'isHigherThanMax',
         ErrorCode.HIGHER_THAN_MAX,
-        value => !value || !maxAmount || +value <= +maxAmount,
+        value => !value || !maxAmount || new BigNumber(value).lte(new BigNumber(maxAmount)),
       ),
   });
 


### PR DESCRIPTION
Casting to a number causes significant digits to be dropped