### PR TITLE
Remove break-all CSS rule

### DIFF
--- a/src/components/Vote/VoteOverview/ProposalDetail.tsx
+++ b/src/components/Vote/VoteOverview/ProposalDetail.tsx
@@ -24,11 +24,7 @@ const ProposalDetailWrapper = styled.div`
     h4,
     h5,
     h6 {
-      word-break: break-all;
       color: var(--color-text-main);
-    }
-    p {
-      word-break: break-all;
     }
   }
 `;

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -64,7 +64,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
   const userTotalBorrowBalanceCents = userTotalBorrowBalance.multipliedBy(100);
   const userTotalBorrowLimitCents = userTotalBorrowLimit.multipliedBy(100);
 
-  const hypotheticalTokenSupplyBalance = amountString
+  const hypotheticalTokenSupplyBalance = amountValue
     ? calculateNewBalance(asset.supplyBalance, amount)
     : undefined;
 


### PR DESCRIPTION
This fixes an issue on the proposal screen where words would be broken without using an hyphen.