### PR TITLE
Display borrowable balance on borrow form

### DIFF
--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -40,6 +40,65 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     renderComponent(<Borrow asset={fakeAsset} onClose={noop} isXvsEnabled />);
   });
 
+  it('renders correct token borrowable amount when asset liquidity is higher than maximum amount of tokens user can borrow before reaching their borrow limit', async () => {
+    const customFakeAsset: Asset = {
+      ...fakeAsset,
+      liquidity: new BigNumber(100000000),
+    };
+
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />
+      </AuthContext.Provider>,
+    );
+
+    const borrowDeltaDollars = fakeUserTotalBorrowLimitDollars.minus(
+      fakeUserTotalBorrowBalanceDollars,
+    );
+    const borrowDeltaTokens = borrowDeltaDollars.dividedBy(fakeAsset.tokenPrice);
+
+    await waitFor(() =>
+      getByText(`${borrowDeltaTokens.toFixed()} ${customFakeAsset.symbol.toUpperCase()}`),
+    );
+  });
+
+  it('renders correct token borrowable amount when asset liquidity is lower than maximum amount of tokens user can borrow before reaching their borrow limit', async () => {
+    const customFakeAsset: Asset = {
+      ...fakeAsset,
+      liquidity: new BigNumber(200),
+    };
+
+    const { getByText } = renderComponent(
+      <AuthContext.Provider
+        value={{
+          login: jest.fn(),
+          logOut: jest.fn(),
+          openAuthModal: jest.fn(),
+          closeAuthModal: jest.fn(),
+          account: {
+            address: fakeAccountAddress,
+          },
+        }}
+      >
+        <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />
+      </AuthContext.Provider>,
+    );
+
+    await waitFor(() =>
+      getByText(`${customFakeAsset.liquidity.toFixed()} ${customFakeAsset.symbol.toUpperCase()}`),
+    );
+  });
+
   it('disables submit button if an amount entered in input is higher than asset liquidity', async () => {
     const customFakeAsset: Asset = {
       ...fakeAsset,

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -47,19 +47,14 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     };
 
     const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
 
     const borrowDeltaDollars = fakeUserTotalBorrowLimitDollars.minus(
@@ -67,9 +62,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     );
     const borrowDeltaTokens = borrowDeltaDollars.dividedBy(fakeAsset.tokenPrice);
 
-    await waitFor(() =>
-      getByText(`${borrowDeltaTokens.toFixed()} ${customFakeAsset.symbol.toUpperCase()}`),
-    );
+    await waitFor(() => getByText(`${borrowDeltaTokens.toFixed()} ${customFakeAsset.symbol}`));
   });
 
   it('renders correct token borrowable amount when asset liquidity is lower than maximum amount of tokens user can borrow before reaching their borrow limit', async () => {
@@ -79,23 +72,18 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     };
 
     const { getByText } = renderComponent(
-      <AuthContext.Provider
-        value={{
-          login: jest.fn(),
-          logOut: jest.fn(),
-          openAuthModal: jest.fn(),
-          closeAuthModal: jest.fn(),
+      <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />,
+      {
+        authContextValue: {
           account: {
             address: fakeAccountAddress,
           },
-        }}
-      >
-        <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />
-      </AuthContext.Provider>,
+        },
+      },
     );
 
     await waitFor(() =>
-      getByText(`${customFakeAsset.liquidity.toFixed()} ${customFakeAsset.symbol.toUpperCase()}`),
+      getByText(`${customFakeAsset.liquidity.toFixed()} ${customFakeAsset.symbol}`),
     );
   });
 
@@ -106,7 +94,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     };
 
     const { getByText, getByTestId } = renderComponent(
-      () => <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />,
+      <Borrow asset={customFakeAsset} onClose={noop} isXvsEnabled />,
       {
         authContextValue: {
           account: {
@@ -220,7 +208,7 @@ describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
     (borrowVToken as jest.Mock).mockImplementationOnce(async () => fakeTransactionReceipt);
 
     const { getByText, getByTestId } = renderComponent(
-      () => <Borrow asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />,
+      <Borrow asset={fakeAsset} onClose={onCloseMock} isXvsEnabled />,
       {
         authContextValue: {
           account: {

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -103,7 +103,6 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
             <FormikTokenTextField
               name="amount"
               tokenId={asset.id}
-              css={styles.input}
               disabled={isBorrowLoading}
               rightMaxButton={{
                 label: t('borrowRepayModal.borrow.rightMaxButtonLabel', {
@@ -114,21 +113,16 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
               data-testid="token-text-field"
               // Only display error state if amount is higher than borrow limit
               hasError={errors.amount === ErrorCode.HIGHER_THAN_MAX}
+              description={
+                <Trans
+                  i18nKey="borrowRepayModal.borrow.borrowableAmount"
+                  components={{
+                    White: <span css={styles.whiteLabel} />,
+                  }}
+                  values={{ amount: readableTokenBorrowableAmount }}
+                />
+              }
             />
-
-            <Typography
-              component="div"
-              variant="small2"
-              css={[styles.greyLabel, styles.borrowableBalance]}
-            >
-              <Trans
-                i18nKey="borrowRepayModal.borrow.borrowableAmount"
-                components={{
-                  White: <span css={styles.whiteLabel} />,
-                }}
-                values={{ amount: readableTokenBorrowableAmount }}
-              />
-            </Typography>
 
             {+values.amount > +safeLimitTokens && (
               <div css={styles.liquidationWarning}>

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -8,7 +8,11 @@ import { SAFE_BORROW_LIMIT_PERCENTAGE } from 'config';
 import { Asset, VTokenId } from 'types';
 import { AuthContext } from 'context/AuthContext';
 import { AmountForm, IAmountFormProps, ErrorCode } from 'containers/AmountForm';
-import { formatToReadablePercentage, convertCoinsToWei } from 'utilities/common';
+import {
+  formatToReadablePercentage,
+  formatCoinsToReadableValue,
+  convertCoinsToWei,
+} from 'utilities/common';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import toast from 'components/Basic/Toast';
 import { UiError } from 'utilities/errors';
@@ -44,7 +48,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
   isXvsEnabled,
   isBorrowLoading,
 }) => {
-  const { t } = useTranslation();
+  const { t, Trans } = useTranslation();
 
   const sharedStyles = useStyles();
   const borrowStyles = useBorrowStyles();
@@ -54,6 +58,15 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
   };
 
   const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
+
+  const readableTokenBorrowableAmount = React.useMemo(
+    () =>
+      formatCoinsToReadableValue({
+        value: new BigNumber(limitTokens),
+        tokenId: asset.id,
+      }),
+    [limitTokens],
+  );
 
   const onSubmit: IAmountFormProps['onSubmit'] = async amountTokens => {
     const formattedAmountTokens = new BigNumber(amountTokens);
@@ -90,6 +103,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
             <FormikTokenTextField
               name="amount"
               tokenId={asset.id}
+              css={styles.input}
               disabled={isBorrowLoading}
               rightMaxButton={{
                 label: t('borrowRepayModal.borrow.rightMaxButtonLabel', {
@@ -101,6 +115,20 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
               // Only display error state if amount is higher than borrow limit
               hasError={errors.amount === ErrorCode.HIGHER_THAN_MAX}
             />
+
+            <Typography
+              component="div"
+              variant="small2"
+              css={[styles.greyLabel, styles.borrowableBalance]}
+            >
+              <Trans
+                i18nKey="borrowRepayModal.borrow.borrowableAmount"
+                components={{
+                  White: <span css={styles.whiteLabel} />,
+                }}
+                values={{ amount: readableTokenBorrowableAmount }}
+              />
+            </Typography>
 
             {+values.amount > +safeLimitTokens && (
               <div css={styles.liquidationWarning}>

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/styles.ts
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/styles.ts
@@ -5,9 +5,6 @@ export const useStyles = () => {
   const theme = useTheme();
 
   return {
-    borrowableBalance: css`
-      margin-bottom: ${theme.spacing(3)};
-    `,
     liquidationWarning: css`
       border: ${theme.spacing(0.5)} solid ${theme.palette.interactive.error};
       margin-top: ${theme.spacing(3)};

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/styles.ts
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/styles.ts
@@ -5,6 +5,9 @@ export const useStyles = () => {
   const theme = useTheme();
 
   return {
+    borrowableBalance: css`
+      margin-bottom: ${theme.spacing(3)};
+    `,
     liquidationWarning: css`
       border: ${theme.spacing(0.5)} solid ${theme.palette.interactive.error};
       margin-top: ${theme.spacing(3)};

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -1,7 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
 import BigNumber from 'bignumber.js';
-import { Typography } from '@mui/material';
 
 import { Asset, VTokenId } from 'types';
 import { AuthContext } from 'context/AuthContext';
@@ -122,11 +121,10 @@ export const RepayForm: React.FC<IRepayFormProps> = ({
             {readableTokenBorrowBalance}
           </LabeledInlineContent>
 
-          <div css={[styles.getRow({ isLast: true })]}>
+          <div css={[styles.getRow({ isLast: false })]}>
             <TokenTextField
               name="amount"
               tokenId={asset.id}
-              css={styles.input}
               value={values.amount}
               onChange={amount => setFieldValue('amount', amount, true)}
               disabled={isRepayLoading}
@@ -138,22 +136,19 @@ export const RepayForm: React.FC<IRepayFormProps> = ({
               data-testid="token-text-field"
               // Only display error state if amount is higher than limit
               hasError={errors.amount === ErrorCode.HIGHER_THAN_MAX}
+              description={
+                <Trans
+                  i18nKey="borrowRepayModal.repay.walletBalance"
+                  components={{
+                    White: <span css={styles.whiteLabel} />,
+                  }}
+                  values={{ balance: readableTokenWalletBalance }}
+                />
+              }
             />
+          </div>
 
-            <Typography
-              component="div"
-              variant="small2"
-              css={[styles.greyLabel, styles.walletBalance]}
-            >
-              <Trans
-                i18nKey="borrowRepayModal.repay.walletBalance"
-                components={{
-                  White: <span css={styles.whiteLabel} />,
-                }}
-                values={{ balance: readableTokenWalletBalance }}
-              />
-            </Typography>
-
+          <div css={[styles.getRow({ isLast: true })]}>
             <div css={styles.selectButtonsContainer}>
               {[25, 50, 75, 100].map(percentage => (
                 <TertiaryButton

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/styles.ts
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/styles.ts
@@ -5,9 +5,6 @@ export const useStyles = () => {
   const theme = useTheme();
 
   return {
-    walletBalance: css`
-      margin-bottom: ${theme.spacing(3)};
-    `,
     selectButtonsContainer: css`
       display: flex;
       flex-direction: row;

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -23,6 +23,7 @@
   },
   "borrowRepayModal": {
     "borrow": {
+      "borrowableAmount": "Borrowable amount: <White>{{amount}}</White>",
       "borrowAPy": "Borrow APY",
       "borrowBalance": "Borrow balance",
       "borrowLimitUsed": "Borrow limit used",
@@ -101,7 +102,6 @@
     "remainingTimeHoursAndMinutes": "<Icon/> Remaining time:\u00a0<White>$t(convertVrt.hours, {\"count\": {{hours}} }) and $t(convertVrt.minutes, {\"count\": {{minutes}} })</White>",
     "remainingTimeMinutes": "<Icon/> Remaining time:\u00a0<White>{{count}} minute</White>",
     "remainingTimeMinutes_other": "<Icon/> Remaining time:\u00a0<White>{{count}} minutes</White>",
-    "remainingTimeMissing": "<Icon/> Remaining time:\u00a0<White>{{count}}</White>",
     "usedOverTotalVrt": "{{used}}/{{total}} VRT",
     "vrtEqualsXvs": "1 VRT = {{xvsToVrtRate}} XVS",
     "withdraw": "Withdraw",

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -132,11 +132,20 @@ export const formatCoinsToReadableValue = ({
   if (value === undefined) {
     return PLACEHOLDER_KEY;
   }
-  let valueString = value.times(1).dp(8).toFixed();
-  if (shorthand && value.gt(1)) {
-    valueString = value.times(1).dp(2).toFixed();
+
+  let decimalPlaces;
+  if (shorthand) {
+    // If value is greater than 1, use 2 decimal places, otherwise use 8
+    // see (https://app.clickup.com/24381231/v/dc/q81tf-9288/q81tf-1128)
+    decimalPlaces = value.gt(1) ? 2 : 8;
+  } else {
+    const token = getToken(tokenId);
+    decimalPlaces = token.decimals;
   }
-  return `${formatCommaThousandsPeriodDecimal(valueString)} ${tokenId.toUpperCase()}`;
+
+  return `${formatCommaThousandsPeriodDecimal(
+    value.dp(decimalPlaces).toFixed(),
+  )} ${tokenId.toUpperCase()}`;
 };
 
 type ConvertWeiToCoinsOutput<T> = T extends true ? string : BigNumber;


### PR DESCRIPTION
- update `formatCoinsToReadableValue` so it only uses shorthand when `shorthand` param is passed as `true`
- display borrowable token amount on borrow form