### PR TITLE
Fix how VAI enabling is determined

### DIFF
--- a/src/context/VaiContext.tsx
+++ b/src/context/VaiContext.tsx
@@ -57,9 +57,14 @@ const VaiContextProvider = ({ children }: $TSFixMe) => {
       if (!isMounted) {
         return;
       }
+
+      const formattedAllowBalanceTemp = new BigNumber(allowBalanceTemp);
       setMintedAmount(new BigNumber(userVaiMintedTemp).div(1e18));
       setWalletAmount(new BigNumber(userVaiBalanceTemp).div(1e18));
-      setEnabled(new BigNumber(allowBalanceTemp).gte(new BigNumber(userVaiMintedTemp)));
+      setEnabled(
+        formattedAllowBalanceTemp.gt(0) &&
+          formattedAllowBalanceTemp.gte(new BigNumber(userVaiMintedTemp)),
+      );
       setMintableAmount(new BigNumber(mintableVaiTemp).div(1e18));
     };
     update();


### PR DESCRIPTION
For a fresh user who have not enabled VAI and have not minted any of it, `userVaiEnabled` was returned as `true` because both values were equal to 0.
This fixes this issue.