### PR TITLE
Use toFixed() to transform BigNumbers to string

### DIFF
--- a/src/clients/api/mutations/approveToken.ts
+++ b/src/clients/api/mutations/approveToken.ts
@@ -15,7 +15,7 @@ const approveToken = ({
   tokenContract,
   accountAddress,
   vtokenAddress,
-  allowance = new BigNumber(2).pow(256).minus(1).toString(10),
+  allowance = new BigNumber(2).pow(256).minus(1).toFixed(),
 }: IApproveTokenInput): Promise<ApproveTokenOutput> =>
   tokenContract.methods.approve(vtokenAddress, allowance).send({ from: accountAddress });
 

--- a/src/clients/api/mutations/mintVai.spec.ts
+++ b/src/clients/api/mutations/mintVai.spec.ts
@@ -50,7 +50,7 @@ describe('api/mutation/mintVai', () => {
 
     expect(response).toBe(undefined);
     expect(mintVaiMock).toHaveBeenCalledTimes(1);
-    expect(mintVaiMock).toHaveBeenCalledWith(fakeAmountWei.toString());
+    expect(mintVaiMock).toHaveBeenCalledWith(fakeAmountWei.toFixed());
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock).toHaveBeenCalledWith({ from: fakeFromAccountsAddress });
   });

--- a/src/clients/api/mutations/mintVai.ts
+++ b/src/clients/api/mutations/mintVai.ts
@@ -15,6 +15,6 @@ const mintVai = async ({
   fromAccountAddress,
   amountWei,
 }: IMintVaiInput): Promise<MintVaiOutput> =>
-  vaiControllerContract.methods.mintVAI(amountWei.toString()).send({ from: fromAccountAddress });
+  vaiControllerContract.methods.mintVAI(amountWei.toFixed()).send({ from: fromAccountAddress });
 
 export default mintVai;

--- a/src/clients/api/mutations/repayVai.spec.ts
+++ b/src/clients/api/mutations/repayVai.spec.ts
@@ -43,13 +43,13 @@ describe('api/mutation/repayVai', () => {
 
     const response = await repayVai({
       vaiControllerContract: fakeContract,
-      amountWei: fakeAmountWei.toString(),
+      amountWei: fakeAmountWei.toFixed(),
       fromAccountAddress: fakeFromAccountsAddress,
     });
 
     expect(response).toBe(undefined);
     expect(repayVAIMock).toHaveBeenCalledTimes(1);
-    expect(repayVAIMock).toHaveBeenCalledWith(fakeAmountWei.toString());
+    expect(repayVAIMock).toHaveBeenCalledWith(fakeAmountWei.toFixed());
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock).toHaveBeenCalledWith({ from: fakeFromAccountsAddress });
   });

--- a/src/clients/api/queries/useUserMarketInfo.ts
+++ b/src/clients/api/queries/useUserMarketInfo.ts
@@ -184,7 +184,7 @@ const useUserMarketInfo = ({
           .div(totalBorrowLimit)
           .times(100)
           .dp(0, 1)
-          .toString(10),
+          .toFixed(),
   }));
   return {
     assets: assetList,

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -60,7 +60,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
             tokenId: asset.id as TokenId,
             shorthand: true,
           }),
-        value: asset.walletBalance.toString(),
+        value: asset.walletBalance.toFixed(),
       },
       {
         key: 'liquidity',

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
@@ -72,7 +72,7 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
             })}
           />
         ),
-        value: asset.borrowBalance.toString(),
+        value: asset.borrowBalance.toFixed(),
       },
       {
         key: 'percentOfLimit',

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -53,7 +53,7 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
         const apy = isXvsEnabled ? asset.xvsSupplyApy.plus(asset.supplyApy) : asset.supplyApy;
         return formatToReadablePercentage(apy);
       },
-      value: asset.supplyApy.toString(),
+      value: asset.supplyApy.toFixed(),
     },
     {
       key: 'balance',
@@ -69,13 +69,13 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
           })}
         />
       ),
-      value: asset.supplyBalance.toString(),
+      value: asset.supplyBalance.toFixed(),
     },
     {
       key: 'collateral',
       value: asset.collateral,
       render: () =>
-        +asset.collateralFactor.toString() ? (
+        asset.collateralFactor.toNumber() ? (
           <Toggle onChange={() => collateralOnChange(asset)} value={asset.collateral} />
         ) : (
           PLACEHOLDER_KEY

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -61,7 +61,7 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
             tokenId: asset.symbol as TokenId,
             shorthand: true,
           }),
-        value: asset.walletBalance.toString(),
+        value: asset.walletBalance.toFixed(),
       },
       {
         key: 'collateral',

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -94,7 +94,7 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
 
     // Check input value updated to max amount of mintable VAI
     const tokenTextFieldInput = getByPlaceholderText('0.00') as HTMLInputElement;
-    await waitFor(() => expect(tokenTextFieldInput.value).toBe(fakeMintableVai.toString()));
+    await waitFor(() => expect(tokenTextFieldInput.value).toBe(fakeMintableVai.toFixed()));
 
     // Submit repayment request
     const submitButton = getByText('Mint VAI').closest('button') as HTMLButtonElement;

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
@@ -52,8 +52,8 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
 
   const vaiToken = getToken(VAI_ID);
   const limitTokens = useMemo(
-    () => (limitWei ? convertWeiToCoins({ value: limitWei, tokenId: VAI_ID }).toString() : '0'),
-    [limitWei?.toString()],
+    () => (limitWei ? convertWeiToCoins({ value: limitWei, tokenId: VAI_ID }).toFixed() : '0'),
+    [limitWei?.toFixed()],
   );
 
   // Convert limit into VAI
@@ -187,7 +187,7 @@ const MintVai: React.FC = () => {
   // Convert limit into wei of VAI
   const limitWei = React.useMemo(
     () => convertCoinsToWei({ value: mintableVai, tokenId: VAI_ID }),
-    [mintableVai.toString()],
+    [mintableVai.toFixed()],
   );
 
   const mintVai: IMintVaiUiProps['mintVai'] = async amountWei => {

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -85,10 +85,10 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
 
     // Input amount
     const tokenTextFieldInput = getByPlaceholderText('0.00') as HTMLInputElement;
-    fireEvent.change(tokenTextFieldInput, { target: { value: fakeUserVaiMinted.toString() } });
+    fireEvent.change(tokenTextFieldInput, { target: { value: fakeUserVaiMinted.toFixed() } });
 
     // Check input value updated correctly
-    expect(tokenTextFieldInput.value).toBe(fakeUserVaiMinted.toString());
+    expect(tokenTextFieldInput.value).toBe(fakeUserVaiMinted.toFixed());
 
     // Submit repayment request
     const submitButton = getByText('Repay VAI').closest('button') as HTMLButtonElement;
@@ -100,7 +100,7 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
     const fakeUserWeiMinted = fakeUserVaiMinted.multipliedBy(new BigNumber(10).pow(18));
     expect(repayVai).toHaveBeenCalledWith({
       fromAccountAddress: fakeAccountAddress,
-      amountWei: fakeUserWeiMinted.toString(),
+      amountWei: fakeUserWeiMinted.toFixed(),
     });
 
     // Check successful transaction modal is displayed

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
@@ -55,8 +55,8 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
         ? BigNumber.minimum(userBalanceWei, userMintedWei)
         : new BigNumber(0);
 
-    return convertWeiToCoins({ value: limitWei, tokenId: VAI_ID }).toString();
-  }, [userBalanceWei?.toString(), userMintedWei?.toString()]);
+    return convertWeiToCoins({ value: limitWei, tokenId: VAI_ID }).toFixed();
+  }, [userBalanceWei?.toFixed(), userMintedWei?.toFixed()]);
 
   // Convert minted wei into VAI
   const readableRepayableVai = useConvertToReadableCoinString({
@@ -157,13 +157,13 @@ const RepayVai: React.FC = () => {
   // Convert minted VAI balance into wei of VAI
   const userMintedWei = React.useMemo(
     () => convertCoinsToWei({ value: userVaiMinted, tokenId: VAI_ID }),
-    [userVaiMinted.toString()],
+    [userVaiMinted.toFixed()],
   );
 
   // Convert user VAI balance into wei of VAI
   const userBalanceWei = React.useMemo(
     () => convertCoinsToWei({ value: userVaiBalance, tokenId: VAI_ID }),
-    [userVaiBalance.toString()],
+    [userVaiBalance.toFixed()],
   );
 
   const repayVai: IRepayVaiUiProps['repayVai'] = amountWei => {
@@ -176,7 +176,7 @@ const RepayVai: React.FC = () => {
 
     return contractRepayVai({
       fromAccountAddress: account.address,
-      amountWei: amountWei.toString(),
+      amountWei: amountWei.toFixed(),
     });
   };
 

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -218,7 +218,7 @@ const Borrow: React.FC<IBorrowProps> = ({ asset, onClose, isXvsEnabled }) => {
 
     const tokenDecimals = getToken(asset.id as VTokenId).decimals;
     const formatValue = (value: BigNumber) =>
-      value.dp(tokenDecimals, BigNumber.ROUND_DOWN).toString(10);
+      value.dp(tokenDecimals, BigNumber.ROUND_DOWN).toFixed();
 
     return [formatValue(maxCoins), formatValue(safeMaxCoins)];
   }, [

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -63,7 +63,7 @@ export const RepayForm: React.FC<IRepayFormProps> = ({
       asset.borrowBalance
         .multipliedBy(percentage / 100)
         .decimalPlaces(asset.decimals)
-        .toString(),
+        .toFixed(),
     [asset.borrowBalance.toFixed(), asset.decimals],
   );
 


### PR DESCRIPTION
`toString()` can produce unexpected results, for example big values will be expressed using exponentials (1e23), which can create issues like this one: https://app.clickup.com/t/2a8znn2.
This PR replaces the usage of `toString()` in the new code we've added with `toFixed()`. I didn't update the old code we didn't touch to prevent creating further issues (especially since we don't have any tests covering it).