### PR TITLE
Remove token info from `EnableToken` component on MintRepayVai

### DIFF
--- a/src/components/v2/EnableToken/index.stories.tsx
+++ b/src/components/v2/EnableToken/index.stories.tsx
@@ -16,6 +16,18 @@ export const Disabled = () => (
     isEnabled={false}
     title="To withdraw BNB to the Venus Protocol, you need to enable it first."
     assetId="eth"
+    approveToken={noop}
+    disabled
+  >
+    <Typography>Invisible Content</Typography>
+  </EnableTokenUi>
+);
+
+export const DisabledWithTokenInfo = () => (
+  <EnableTokenUi
+    isEnabled={false}
+    title="To withdraw BNB to the Venus Protocol, you need to enable it first."
+    assetId="eth"
     tokenInfo={[
       { iconName: 'vai', label: 'Supply APY', children: '77.36' },
       { iconName: 'vai', label: 'Distribution APY', children: '0.82' },

--- a/src/components/v2/EnableToken/index.tsx
+++ b/src/components/v2/EnableToken/index.tsx
@@ -1,6 +1,8 @@
 /** @jsxImportSource @emotion/react */
 import React, { useContext } from 'react';
 import Typography from '@mui/material/Typography';
+
+import { useTranslation } from 'translation';
 import { AuthContext } from 'context/AuthContext';
 import { TokenId } from 'types';
 import useApproveToken from 'clients/api/mutations/useApproveToken';
@@ -14,23 +16,23 @@ export interface IEnableTokenProps {
   assetId: TokenId;
   isEnabled: boolean;
   title: string | React.ReactElement;
-  tokenInfo: ILabeledInlineContentProps[];
   approveToken: () => void;
   vtokenAddress: string;
-  isApproveTokenLoading?: boolean;
+  tokenInfo?: ILabeledInlineContentProps[];
   disabled?: boolean;
 }
 
 export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> = ({
   assetId,
   title,
-  tokenInfo,
+  tokenInfo = [],
   isEnabled,
   children,
   approveToken,
   isApproveTokenLoading = false,
   disabled = false,
 }) => {
+  const { t } = useTranslation();
   const styles = useStyles();
 
   if (isEnabled) {
@@ -44,20 +46,19 @@ export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> =
       <Typography component="h3" variant="h3" css={styles.mainText}>
         {title}
       </Typography>
-      <Delimiter />
 
-      {tokenInfo.map(info => (
-        <LabeledInlineContent {...info} key={info.label} css={styles.labeledInlineContent} />
-      ))}
+      {tokenInfo.length > 0 && (
+        <div css={styles.tokenInfoContainer}>
+          <Delimiter css={styles.delimiter} />
 
-      <SecondaryButton
-        disabled={disabled || isApproveTokenLoading}
-        loading={isApproveTokenLoading}
-        fullWidth
-        css={styles.button}
-        onClick={approveToken}
-      >
-        Enable
+          {tokenInfo.map(info => (
+            <LabeledInlineContent {...info} key={info.label} css={styles.labeledInlineContent} />
+          ))}
+        </div>
+      )}
+
+      <SecondaryButton disabled={disabled} fullWidth onClick={approveToken}>
+        {t('enableToken.enableButtonLabel')}
       </SecondaryButton>
     </div>
   );

--- a/src/components/v2/EnableToken/index.tsx
+++ b/src/components/v2/EnableToken/index.tsx
@@ -20,6 +20,7 @@ export interface IEnableTokenProps {
   vtokenAddress: string;
   tokenInfo?: ILabeledInlineContentProps[];
   disabled?: boolean;
+  isApproveTokenLoading?: boolean;
 }
 
 export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> = ({
@@ -57,7 +58,12 @@ export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> =
         </div>
       )}
 
-      <SecondaryButton disabled={disabled} fullWidth onClick={approveToken}>
+      <SecondaryButton
+        disabled={disabled || isApproveTokenLoading}
+        loading={isApproveTokenLoading}
+        fullWidth
+        onClick={approveToken}
+      >
         {t('enableToken.enableButtonLabel')}
       </SecondaryButton>
     </div>

--- a/src/components/v2/EnableToken/styles.ts
+++ b/src/components/v2/EnableToken/styles.ts
@@ -21,13 +21,19 @@ export const styles = () => {
     `,
     mainText: css`
       text-align: center;
-      margin-bottom: ${theme.spacing(10)};
+      margin-bottom: ${theme.spacing(8)};
     `,
-    button: css`
-      margin-top: ${theme.spacing(9)};
+    delimiter: css`
+      margin-bottom: ${theme.spacing(8)};
+    `,
+    tokenInfoContainer: css`
+      width: 100%;
+      margin-bottom: ${theme.spacing(12)};
     `,
     labeledInlineContent: css`
-      margin-bottom: ${theme.spacing(3)};
+      :not(:last-of-type) {
+        margin-bottom: ${theme.spacing(3)};
+      }
     `,
   };
 };

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import BigNumber from 'bignumber.js';
 import { waitFor, fireEvent } from '@testing-library/react';
 
+import en from 'translation/translations/en.json';
 import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import { mintVai, getVaiTreasuryPercentage, useUserMarketInfo } from 'clients/api';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
@@ -40,7 +41,7 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
         },
       },
     });
-    await waitFor(() => getByText('Available VAI limit'));
+    await waitFor(() => getByText(en.mintRepayVai.mintVai.enableToken));
   });
 
   it('displays the correct available VAI limit and mint fee', async () => {
@@ -61,7 +62,6 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
         userVaiBalance: new BigNumber(0),
       },
     });
-    await waitFor(() => getByText('Available VAI limit'));
 
     // Check available VAI limit displays correctly
     await waitFor(() => getByText(formattedFakeUserVaiMinted));
@@ -86,10 +86,12 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
         userVaiBalance: new BigNumber(0),
       },
     });
-    await waitFor(() => getByText('Available VAI limit'));
+    await waitFor(() => getByText(en.mintRepayVai.mintVai.btnMintVai));
 
     // Click on "SAFE MAX" button
-    const safeMaxButton = getByText('SAFE MAX').closest('button') as HTMLButtonElement;
+    const safeMaxButton = getByText(en.mintRepayVai.mintVai.rightMaxButtonLabel).closest(
+      'button',
+    ) as HTMLButtonElement;
     fireEvent.click(safeMaxButton);
 
     // Check input value updated to max amount of mintable VAI
@@ -97,8 +99,10 @@ describe('pages/Dashboard/MintRepayVai/MintVai', () => {
     await waitFor(() => expect(tokenTextFieldInput.value).toBe(fakeMintableVai.toFixed()));
 
     // Submit repayment request
-    const submitButton = getByText('Mint VAI').closest('button') as HTMLButtonElement;
-    await waitFor(() => expect(submitButton).toHaveProperty('disabled', false));
+    const submitButton = getByText(en.mintRepayVai.mintVai.btnMintVai).closest(
+      'button',
+    ) as HTMLButtonElement;
+    await waitFor(() => expect(submitButton).toBeEnabled());
     fireEvent.click(submitButton);
 
     // Check mintVai was called correctly

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.tsx
@@ -12,8 +12,6 @@ import { AmountForm, IAmountFormProps } from 'containers/AmountForm';
 import {
   FormikSubmitButton,
   EnableToken,
-  IconName,
-  ILabeledInlineContentProps,
   LabeledInlineContent,
   FormikTokenTextField,
   ConnectWallet,
@@ -104,25 +102,11 @@ export const MintVaiUi: React.FC<IMintVaiUiProps> = ({
     }
   };
 
-  const tokenInfo: ILabeledInlineContentProps[] = [
-    {
-      label: t('mintRepayVai.mintVai.vaiLimitLabel'),
-      iconName: VAI_ID as IconName,
-      children: readableVaiLimit,
-    },
-    {
-      label: t('mintRepayVai.mintVai.mintFeeLabel'),
-      iconName: 'xvs' as IconName,
-      children: getReadableMintFee(limitWei?.toFixed() || '0'),
-    },
-  ];
-
   return (
     <ConnectWallet message={t('mintRepayVai.mintVai.connectWallet')}>
       <EnableToken
         assetId={VAI_ID}
         title={t('mintRepayVai.mintVai.enableToken')}
-        tokenInfo={tokenInfo}
         isEnabled={!!userVaiEnabled}
         vtokenAddress={vaiToken.address}
       >

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import BigNumber from 'bignumber.js';
 import { waitFor, fireEvent } from '@testing-library/react';
 
+import en from 'translation/translations/en.json';
 import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import { repayVai, useUserMarketInfo } from 'clients/api';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
@@ -39,7 +40,7 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
         },
       },
     });
-    await waitFor(() => getByText('Repay VAI balance'));
+    await waitFor(() => getByText(en.mintRepayVai.repayVai.enableToken));
   });
 
   it('displays the correct repay VAI balance', async () => {
@@ -56,7 +57,7 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
         userVaiBalance: new BigNumber(0),
       },
     });
-    await waitFor(() => getByText('Repay VAI balance'));
+    await waitFor(() => getByText(en.mintRepayVai.repayVai.btnRepayVai));
 
     // Check user repay VAI balance displays correctly
     await waitFor(() => getByText(formattedFakeUserVaiMinted));
@@ -81,7 +82,7 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
         userVaiBalance: fakeUserVaiBalance,
       },
     });
-    await waitFor(() => getByText('Repay VAI balance'));
+    await waitFor(() => getByText(en.mintRepayVai.repayVai.btnRepayVai));
 
     // Input amount
     const tokenTextFieldInput = getByPlaceholderText('0.00') as HTMLInputElement;
@@ -91,8 +92,10 @@ describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
     expect(tokenTextFieldInput.value).toBe(fakeUserVaiMinted.toFixed());
 
     // Submit repayment request
-    const submitButton = getByText('Repay VAI').closest('button') as HTMLButtonElement;
-    await waitFor(() => expect(submitButton).toHaveProperty('disabled', false));
+    const submitButton = getByText(en.mintRepayVai.repayVai.btnRepayVai).closest(
+      'button',
+    ) as HTMLButtonElement;
+    await waitFor(() => expect(submitButton).toBeEnabled());
     fireEvent.click(submitButton);
 
     // Check repayVai was called correctly

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.tsx
@@ -13,8 +13,6 @@ import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import {
   ConnectWallet,
   EnableToken,
-  IconName,
-  ILabeledInlineContentProps,
   FormikSubmitButton,
   LabeledInlineContent,
   FormikTokenTextField,
@@ -90,20 +88,12 @@ export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
       toast.error({ title: (error as Error).message });
     }
   };
-  const tokenInfo: ILabeledInlineContentProps[] = [
-    {
-      label: t('mintRepayVai.repayVai.repayVaiBalance'),
-      iconName: VAI_ID as IconName,
-      children: readableRepayableVai,
-    },
-  ];
 
   return (
     <ConnectWallet message={t('mintRepayVai.repayVai.connectWallet')}>
       <EnableToken
         assetId={VAI_ID}
         title={t('mintRepayVai.repayVai.enableToken')}
-        tokenInfo={tokenInfo}
         isEnabled={!!userVaiEnabled}
         vtokenAddress={vaiToken.address}
       >

--- a/src/pages/Dashboard/MintRepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/index.spec.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import BigNumber from 'bignumber.js';
 import { waitFor, fireEvent } from '@testing-library/react';
+
+import en from 'translation/translations/en.json';
 import { useUserMarketInfo } from 'clients/api';
 import renderComponent from 'testUtils/renderComponent';
 import { assetData } from '__mocks__/models/asset';
@@ -28,7 +30,7 @@ describe('pages/Dashboard/MintRepayVai', () => {
         },
       },
     });
-    await waitFor(() => getByText('Mint/Repay VAI'));
+    await waitFor(() => getByText(en.mintRepayVai.title));
   });
 
   it('renders mint tab by default and lets user switch to repay tab', async () => {
@@ -41,13 +43,15 @@ describe('pages/Dashboard/MintRepayVai', () => {
     });
 
     // Check mint tab is display by default
-    await waitFor(() => getByText('Available VAI limit'));
+    await waitFor(() => getByText(en.mintRepayVai.mintVai.enableToken));
 
     // Click on "Repay VAI" tab
-    const repayVaiTabButton = getByText('Repay VAI').closest('button') as HTMLButtonElement;
+    const repayVaiTabButton = getByText(en.mintRepayVai.tabRepay).closest(
+      'button',
+    ) as HTMLButtonElement;
     fireEvent.click(repayVaiTabButton);
 
     // Check repay tab is now displaying
-    await waitFor(() => getByText('Repay VAI balance'));
+    await waitFor(() => getByText(en.mintRepayVai.repayVai.enableToken));
   });
 });

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -125,6 +125,9 @@
       "title": "Markets"
     }
   },
+  "enableToken": {
+    "enableButtonLabel": "Enable"
+  },
   "errors": {
     "walletNotConnected": "Wallet not connected"
   },


### PR DESCRIPTION
<img width="505" alt="Screen Shot 2022-05-11 at 23 06 10" src="https://user-images.githubusercontent.com/44675210/167955391-f16205aa-bf33-41eb-8b85-7759c113ee7f.png">

- make `tokenInfo` optional on `EnableToken`
- remove token info from Mint VAI and Repay VAI tabs