### PR TITLE
Fix UI not refreshing after enabling token

### DIFF
--- a/src/clients/api/mutations/approveToken.ts
+++ b/src/clients/api/mutations/approveToken.ts
@@ -1,6 +1,7 @@
-import BigNumber from 'bignumber.js';
 import type { TransactionReceipt } from 'web3-core';
+
 import { Bep20, VaiToken, VrtToken, XvsToken } from 'types/contracts';
+import ALLOWANCE_AMOUNT_WEI from 'constants/allowanceAmountWei';
 
 export interface IApproveTokenInput {
   tokenContract: Bep20 | VaiToken | VrtToken | XvsToken;
@@ -15,7 +16,7 @@ const approveToken = ({
   tokenContract,
   accountAddress,
   vtokenAddress,
-  allowance = new BigNumber(2).pow(256).minus(1).toFixed(),
+  allowance = ALLOWANCE_AMOUNT_WEI,
 }: IApproveTokenInput): Promise<ApproveTokenOutput> =>
   tokenContract.methods.approve(vtokenAddress, allowance).send({ from: accountAddress });
 

--- a/src/components/v2/EnableToken/index.tsx
+++ b/src/components/v2/EnableToken/index.tsx
@@ -17,6 +17,7 @@ export interface IEnableTokenProps {
   tokenInfo: ILabeledInlineContentProps[];
   approveToken: () => void;
   vtokenAddress: string;
+  isApproveTokenLoading?: boolean;
   disabled?: boolean;
 }
 
@@ -27,23 +28,35 @@ export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> =
   isEnabled,
   children,
   approveToken,
+  isApproveTokenLoading = false,
   disabled = false,
 }) => {
   const styles = useStyles();
+
   if (isEnabled) {
     return <>{children}</>;
   }
+
   return (
     <div css={styles.container}>
       <Icon name={assetId as IconName} css={styles.mainLogo} />
+
       <Typography component="h3" variant="h3" css={styles.mainText}>
         {title}
       </Typography>
       <Delimiter />
+
       {tokenInfo.map(info => (
         <LabeledInlineContent {...info} key={info.label} css={styles.labeledInlineContent} />
       ))}
-      <SecondaryButton disabled={disabled} fullWidth css={styles.button} onClick={approveToken}>
+
+      <SecondaryButton
+        disabled={disabled || isApproveTokenLoading}
+        loading={isApproveTokenLoading}
+        fullWidth
+        css={styles.button}
+        onClick={approveToken}
+      >
         Enable
       </SecondaryButton>
     </div>
@@ -53,13 +66,15 @@ export const EnableTokenUi: React.FC<Omit<IEnableTokenProps, 'vtokenAddress'>> =
 export const EnableToken: React.FC<
   Omit<IEnableTokenProps, 'approveToken' | 'account' | 'disabled'>
 > = ({ vtokenAddress, assetId, ...rest }) => {
-  const { mutate: approveToken } = useApproveToken({ assetId });
+  const { mutate: approveToken, isLoading: isApproveTokenLoading } = useApproveToken({ assetId });
   const { account } = useContext(AuthContext);
+
   return (
     <EnableTokenUi
       {...rest}
       assetId={assetId}
       approveToken={() => approveToken({ accountAddress: account?.address, vtokenAddress })}
+      isApproveTokenLoading={isApproveTokenLoading}
       disabled={!account}
     />
   );

--- a/src/constants/allowanceAmountWei.ts
+++ b/src/constants/allowanceAmountWei.ts
@@ -1,0 +1,5 @@
+import BigNumber from 'bignumber.js';
+
+// Default allowance set when approving a token to be used from an account
+const ALLOWANCE_AMOUNT_WEI = new BigNumber(2).pow(256).minus(1).toFixed();
+export default ALLOWANCE_AMOUNT_WEI;

--- a/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
@@ -4,7 +4,7 @@ import BigNumber from 'bignumber.js';
 import { Paper } from '@mui/material';
 
 import { Delimiter } from 'components';
-import { Asset } from 'types';
+import { Asset, TokenId } from 'types';
 import BorrowRepayModal from 'pages/Dashboard/Modals/BorrowRepay';
 import BorrowMarketTable, { IBorrowMarketTableProps } from './BorrowMarketTable';
 import BorrowingTable, { IBorrowingUiProps } from './BorrowingTable';
@@ -25,21 +25,23 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
   isXvsEnabled,
   userTotalBorrowLimit,
 }) => {
-  const [selectedAsset, setSelectedAsset] = React.useState<Asset | undefined>(undefined);
+  const [selectedAssetId, setSelectedAssetId] = React.useState<Asset['id'] | undefined>(undefined);
   const styles = useStyles();
 
   const rowOnClick: IBorrowMarketTableProps['rowOnClick'] | IBorrowingUiProps['rowOnClick'] = (
     _e,
     row,
   ) => {
-    const asset = [...borrowingAssets, ...borrowMarketAssets].find(
-      (value: Asset) => value.id === row[0].value,
-    );
-
-    if (asset) {
-      setSelectedAsset(asset);
-    }
+    setSelectedAssetId(row[0].value as TokenId);
   };
+
+  const asset = React.useMemo(
+    () =>
+      [...borrowingAssets, ...borrowMarketAssets].find(
+        marketAsset => marketAsset.id === selectedAssetId,
+      ),
+    [selectedAssetId, JSON.stringify(borrowingAssets), JSON.stringify(borrowMarketAssets)],
+  );
 
   return (
     <>
@@ -63,10 +65,10 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
         />
       </Paper>
 
-      {selectedAsset && (
+      {asset && (
         <BorrowRepayModal
-          asset={selectedAsset}
-          onClose={() => setSelectedAsset(undefined)}
+          asset={asset}
+          onClose={() => setSelectedAssetId(undefined)}
           isXvsEnabled={isXvsEnabled}
         />
       )}

--- a/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/index.tsx
@@ -35,7 +35,7 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
     setSelectedAssetId(row[0].value as TokenId);
   };
 
-  const asset = React.useMemo(
+  const selectedAsset = React.useMemo(
     () =>
       [...borrowingAssets, ...borrowMarketAssets].find(
         marketAsset => marketAsset.id === selectedAssetId,
@@ -65,9 +65,9 @@ export const BorrowMarketUi: React.FC<IBorrowMarketUiProps> = ({
         />
       </Paper>
 
-      {asset && (
+      {selectedAsset && (
         <BorrowRepayModal
-          asset={asset}
+          asset={selectedAsset}
           onClose={() => setSelectedAssetId(undefined)}
           isXvsEnabled={isXvsEnabled}
         />

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React, { useState } from 'react';
 import { Paper } from '@mui/material';
-import { Asset } from 'types';
+import { Asset, TokenId } from 'types';
 import { UiError } from 'utilities/errors';
 import toast from 'components/Basic/Toast';
 import { useExitMarket, useEnterMarkets } from 'clients/api';
@@ -32,7 +32,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
   confirmCollateral,
   setConfirmCollateral,
 }) => {
-  const [selectedAsset, setSelectedAsset] = useState<Asset | undefined>(undefined);
+  const [selectedAssetId, setSelectedAssetId] = React.useState<Asset['id'] | undefined>(undefined);
   const styles = useStyles();
 
   const collateralOnChange = async (asset: Asset) => {
@@ -47,16 +47,21 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
       }
     }
   };
+
   const rowOnClick = (e: React.MouseEvent<HTMLElement>, row: ITableProps['data'][number]) => {
     if ((e.target as HTMLElement).ariaLabel !== switchAriaLabel) {
-      const asset = [...suppliedAssets, ...supplyMarketAssets].find(
-        (value: Asset) => value.id === row[0].value,
-      );
-      if (asset) {
-        setSelectedAsset(asset);
-      }
+      setSelectedAssetId(row[0].value as TokenId);
     }
   };
+
+  const selectedAsset = React.useMemo(
+    () =>
+      [...supplyMarketAssets, ...suppliedAssets].find(
+        marketAsset => marketAsset.id === selectedAssetId,
+      ),
+    [selectedAssetId, JSON.stringify(supplyMarketAssets), JSON.stringify(suppliedAssets)],
+  );
+
   return (
     <Paper className={className} css={styles.tableContainer}>
       {suppliedAssets.length > 0 && (
@@ -86,7 +91,7 @@ export const SupplyMarketUi: React.FC<ISupplyMarketProps> = ({
           asset={selectedAsset}
           assets={[...suppliedAssets, ...supplyMarketAssets]}
           isXvsEnabled={isXvsEnabled}
-          onClose={() => setSelectedAsset(undefined)}
+          onClose={() => setSelectedAssetId(undefined)}
         />
       )}
     </Paper>


### PR DESCRIPTION
The issue came from the fact we stored a copy of an asset to be used inside modals, which meant that although the right query was refetched after enabling a token the modals would not receive the update.
I fixed this by only storing the ID of the token passed to the Supply and Borrow modals and using it to grab the asset object from the assets passed to each modal and which are connected to React Query's cache.