### PR TITLE
Allow users to close positions by repaying max amount with uint256

### DIFF
--- a/src/clients/api/mutations/approveToken.spec.ts
+++ b/src/clients/api/mutations/approveToken.spec.ts
@@ -1,5 +1,5 @@
-import BigNumber from 'bignumber.js';
 import transactionReceipt from '__mocks__/models/transactionReceipt';
+import MAX_UINT256 from 'constants/maxUint256';
 import approveToken from './approveToken';
 
 describe('api/mutations/approveToken', () => {
@@ -18,7 +18,7 @@ describe('api/mutations/approveToken', () => {
       await approveToken({
         tokenContract: fakeContract,
         accountAddress: '0x32asdf',
-        allowance: new BigNumber(2).pow(256).minus(1).toString(10),
+        allowance: MAX_UINT256.toFixed(),
         vtokenAddress: '0x32asdf',
       });
 
@@ -31,7 +31,7 @@ describe('api/mutations/approveToken', () => {
   test('returns Transaction Receipt when request succeeds', async () => {
     const accountAddress = '0x3d7598124C212d2121234cd36aFe1c685FbEd848';
     const vtokenAddress = '0x3d759121234cd36F8124C21aFe1c6852d2bEd848';
-    const allowance = new BigNumber(2).pow(256).minus(1).toString(10);
+    const allowance = MAX_UINT256.toFixed();
 
     const sendMock = jest.fn(async () => transactionReceipt);
     const approveTokenMock = jest.fn(() => ({

--- a/src/components/Basic/BorrowTabs/RepayBorrowTab.tsx
+++ b/src/components/Basic/BorrowTabs/RepayBorrowTab.tsx
@@ -10,6 +10,7 @@ import coinImg from 'assets/img/coins/xvs.svg';
 import vaiImg from 'assets/img/coins/vai.svg';
 import { Progress } from 'antd';
 import { TabSection, Tabs, TabContent } from 'components/Basic/BorrowModal';
+import MAX_UINT256 from 'constants/maxUint256';
 import { getBigNumber, formatToReadablePercentage, format } from 'utilities/common';
 import { Asset, Setting, VTokenId } from 'types';
 import { State } from 'core/modules/initialState';
@@ -83,7 +84,7 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
       setIsLoading(true);
       try {
         await tokenContract.methods
-          .approve(asset.vtokenAddress, new BigNumber(2).pow(256).minus(1).toString(10))
+          .approve(asset.vtokenAddress, MAX_UINT256.toFixed())
           .send({ from: account.address });
         setIsEnabled(true);
       } catch (error) {
@@ -108,7 +109,7 @@ function RepayBorrowTab({ asset, changeTab, onCancel, setSetting }: Props & Disp
       });
       if (asset.id !== 'bnb') {
         const repayAmount = amount.eq(asset.borrowBalance)
-          ? new BigNumber(2).pow(256).minus(1).toString(10)
+          ? MAX_UINT256.toFixed()
           : amount.times(new BigNumber(10).pow(asset.decimals)).integerValue().toString(10);
         try {
           await vbepContract.methods.repayBorrow(repayAmount).send({ from: account.address });

--- a/src/components/Basic/SupplyTabs/SupplyTab.tsx
+++ b/src/components/Basic/SupplyTabs/SupplyTab.tsx
@@ -11,6 +11,7 @@ import coinImg from 'assets/img/coins/xvs.svg';
 import arrowRightImg from 'assets/img/arrow-right.png';
 import vaiImg from 'assets/img/coins/vai.svg';
 import { TabSection, Tabs, TabContent } from 'components/Basic/SupplyModal';
+import MAX_UINT256 from 'constants/maxUint256';
 import { getBigNumber, format, convertCoinsToWei } from 'utilities/common';
 import { Asset, Setting, VTokenId } from 'types';
 import { useTokenContract, useVTokenContract } from 'clients/contracts/hooks';
@@ -91,7 +92,7 @@ function SupplyTab({ asset, changeTab, onCancel, setSetting }: SupplyTabProps) {
     setIsLoading(true);
     try {
       await tokenContract.methods
-        .approve(asset.vtokenAddress, new BigNumber(2).pow(256).minus(1).toString(10))
+        .approve(asset.vtokenAddress, MAX_UINT256.toFixed())
         .send({ from: account?.address });
       setIsEnabled(true);
     } catch (error) {

--- a/src/components/Basic/VaiTabs/RepayVaiTab.tsx
+++ b/src/components/Basic/VaiTabs/RepayVaiTab.tsx
@@ -4,6 +4,7 @@ import NumberFormat from 'react-number-format';
 import BigNumber from 'bignumber.js';
 import vaiImg from 'assets/img/coins/vai.svg';
 import { TabSection, TabContent } from 'components/Basic/BorrowModal';
+import MAX_UINT256 from 'constants/maxUint256';
 import { getContractAddress } from 'utilities';
 import { format } from 'utilities/common';
 import { useVaiUser } from 'hooks/useVaiUser';
@@ -32,10 +33,7 @@ function RepayVaiTab() {
     setIsLoading(true);
     try {
       await vaiContract.methods
-        .approve(
-          getContractAddress('vaiUnitroller'),
-          new BigNumber(2).pow(256).minus(1).toString(10),
-        )
+        .approve(getContractAddress('vaiUnitroller'), MAX_UINT256.toFixed())
         .send({
           from: account?.address,
         });

--- a/src/components/Vault/VestingVault/CardContent.tsx
+++ b/src/components/Vault/VestingVault/CardContent.tsx
@@ -9,6 +9,7 @@ import { useXvsVaultProxyContract } from 'clients/contracts/hooks';
 import useRefresh from 'hooks/useRefresh';
 import { getTokenContractByAddress } from 'clients/contracts/getters';
 import { useWeb3 } from 'clients/web3';
+import MAX_UINT256 from 'constants/maxUint256';
 import { TokenId } from 'types';
 import { AuthContext } from 'context/AuthContext';
 import WithdrawHistoryModal from './WithdrawHistoryModal';
@@ -232,10 +233,7 @@ function CardContent({
                   try {
                     if (!userStakedTokenAllowance.gt(0)) {
                       await stakedTokenContract.methods
-                        .approve(
-                          xvsVaultContract.options.address,
-                          new BigNumber(2).pow(256).minus(1).toString(10),
-                        )
+                        .approve(xvsVaultContract.options.address, MAX_UINT256.toFixed())
                         .send({
                           from: account?.address,
                         });

--- a/src/constants/maxUint256.ts
+++ b/src/constants/maxUint256.ts
@@ -1,0 +1,5 @@
+import BigNumber from 'bignumber.js';
+
+const MAX_UINT256 = new BigNumber(2).pow(256).minus(1);
+
+export default MAX_UINT256;


### PR DESCRIPTION
If we close out the position with `limitTokens` some dust will be left on the account. To account for this we can repay the borrow with the max spending limit to ensure any incremental interest is also closed out