### PR TITLE
Only allow users to disable luna ust collateral

### DIFF
--- a/src/components/Dashboard/Market/SupplyMarket.tsx
+++ b/src/components/Dashboard/Market/SupplyMarket.tsx
@@ -132,10 +132,12 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
       key: 'collateral',
 
       render(collateral: $TSFixMe, asset: Asset) {
+        const isLunaOrUstAsset = asset.id === 'luna' || asset.id === 'ust';
         return {
-          // Temporary fix to prevent users from entering LUNA and UST collateral markets
+          // Allow allow users to disable lune and ust collateral
           children:
-            +asset.collateralFactor.toString() && asset.id !== 'luna' && asset.id !== 'ust' ? (
+            (+asset.collateralFactor.toString() && !isLunaOrUstAsset) ||
+            (isLunaOrUstAsset && collateral) ? (
               <Toggle checked={collateral} onChecked={() => handleToggleCollateral(asset)} />
             ) : null,
         };


### PR DESCRIPTION
Updates UST and Lune collateral switches to only be rendered if collateral is enabled so that users can disable it