### PR TITLE
Allow disabling LUNA and UST as collaterals

### DIFF
--- a/src/components/Dashboard/Market/SupplyMarket.tsx
+++ b/src/components/Dashboard/Market/SupplyMarket.tsx
@@ -132,10 +132,12 @@ function SupplyMarket({ settings, suppliedAssets, remainAssets }: Props & StateP
       key: 'collateral',
 
       render(collateral: $TSFixMe, asset: Asset) {
+        const isLunaOrUstAsset = asset.id === 'luna' || asset.id === 'ust';
         return {
-          // Temporary fix to prevent users from entering LUNA and UST collateral markets
+          // Allow allow users to disable lune and ust collateral
           children:
-            +asset.collateralFactor.toString() && asset.id !== 'luna' && asset.id !== 'ust' ? (
+            (+asset.collateralFactor.toString() && !isLunaOrUstAsset) ||
+            (isLunaOrUstAsset && collateral) ? (
               <Toggle checked={collateral} onChecked={() => handleToggleCollateral(asset)} />
             ) : null,
         };


### PR DESCRIPTION
I mistakingly merged @coreyar 's PR that allows users to disable LUNA and UST as collateral and had to revert the change.
This PR puts back the change in place so it can be merged later on today.