### PR TITLE
Decouple logic from MarketDetails page container

### DIFF
--- a/src/components/v2/charts/ApyChart/index.tsx
+++ b/src/components/v2/charts/ApyChart/index.tsx
@@ -52,7 +52,7 @@ export const ApyChart: React.FC<IApyChartProps> = ({ className, data, type }) =>
           {/* Gradient used as filler */}
           <defs>
             <linearGradient id={gradientId} x1="0" y1="0" x2="0" y2="1">
-              <stop offset="0%" stopColor={chartColor} stopOpacity={0.3} />
+              <stop offset="0%" stopColor={chartColor} stopOpacity={0.2} />
               <stop offset="100%" stopColor={chartColor} stopOpacity={0} />
             </linearGradient>
           </defs>

--- a/src/pages/MarketDetails/index.spec.tsx
+++ b/src/pages/MarketDetails/index.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createMemoryHistory } from 'history';
 import { waitFor } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
 
 import { markets } from '__mocks__/models/markets';
 import { marketSnapshots } from '__mocks__/models/marketSnapshots';
@@ -15,7 +16,10 @@ jest.mock('clients/api');
 describe('pages/MarketDetails', () => {
   beforeEach(() => {
     (getMarketHistory as jest.Mock).mockImplementation(() => marketSnapshots);
-    (getMarkets as jest.Mock).mockImplementation(() => markets);
+    (getMarkets as jest.Mock).mockImplementation(() => ({
+      markets,
+      dailyVenus: new BigNumber(0),
+    }));
   });
 
   it('renders without crashing', () => {

--- a/src/pages/MarketDetails/useGetChartData.ts
+++ b/src/pages/MarketDetails/useGetChartData.ts
@@ -7,14 +7,9 @@ import { formatPercentage } from 'utilities/common';
 import { useGetMarketHistory } from 'clients/api';
 
 const useGetChartData = ({ vTokenId }: { vTokenId: IVBepToken['id'] }) => {
-  const { data: marketSnapshots = [] } = useGetMarketHistory(
-    {
-      vTokenId,
-    },
-    {
-      placeholderData: [],
-    },
-  );
+  const { data: marketSnapshots = [] } = useGetMarketHistory({
+    vTokenId,
+  });
 
   return React.useMemo(() => {
     const supplyChartData: IApyChartProps['data'] = [];

--- a/src/pages/MarketDetails/useGetChartData.ts
+++ b/src/pages/MarketDetails/useGetChartData.ts
@@ -1,0 +1,54 @@
+import React from 'react';
+import BigNumber from 'bignumber.js';
+
+import { IApyChartProps } from 'components';
+import { IVBepToken } from 'types';
+import { formatPercentage } from 'utilities/common';
+import { useGetMarketHistory } from 'clients/api';
+
+const useGetChartData = ({ vTokenId }: { vTokenId: IVBepToken['id'] }) => {
+  const { data: marketSnapshots = [] } = useGetMarketHistory(
+    {
+      vTokenId,
+    },
+    {
+      placeholderData: [],
+    },
+  );
+
+  return React.useMemo(() => {
+    const supplyChartData: IApyChartProps['data'] = [];
+    const borrowChartData: IApyChartProps['data'] = [];
+
+    [...marketSnapshots]
+      // Snapshots are returned from earliest to oldest, so we reverse them to
+      // pass them to the charts in the right order
+      .reverse()
+      .forEach(marketSnapshot => {
+        const timestampMs = new Date(marketSnapshot.createdAt).getTime();
+
+        supplyChartData.push({
+          apyPercentage: formatPercentage(marketSnapshot.supplyApy),
+          timestampMs,
+          balanceCents: new BigNumber(marketSnapshot.totalSupply).multipliedBy(
+            marketSnapshot.priceUSD,
+          ),
+        });
+
+        borrowChartData.push({
+          apyPercentage: formatPercentage(marketSnapshot.borrowApy),
+          timestampMs,
+          balanceCents: new BigNumber(marketSnapshot.totalBorrow).multipliedBy(
+            marketSnapshot.priceUSD,
+          ),
+        });
+      });
+
+    return {
+      supplyChartData,
+      borrowChartData,
+    };
+  }, [JSON.stringify(marketSnapshots)]);
+};
+
+export default useGetChartData;

--- a/src/pages/MarketDetails/useGetMarketData.ts
+++ b/src/pages/MarketDetails/useGetMarketData.ts
@@ -14,8 +14,8 @@ const useGetMarketData = ({
   vTokenId: IVBepToken['id'];
   vTokenAddress: IVBepToken['address'];
 }) => {
-  const { data: markets = [] } = useGetMarkets({ placeholderData: [] });
-  const assetMarket = markets.find(
+  const { data: getMarketData } = useGetMarkets();
+  const assetMarket = (getMarketData?.markets || []).find(
     market => market.address.toLowerCase() === vTokenAddress.toLowerCase(),
   );
 

--- a/src/pages/MarketDetails/useGetMarketData.ts
+++ b/src/pages/MarketDetails/useGetMarketData.ts
@@ -1,0 +1,113 @@
+import React from 'react';
+import BigNumber from 'bignumber.js';
+
+import { IVBepToken } from 'types';
+import { getToken } from 'utilities';
+import { convertWeiToCoins } from 'utilities/common';
+import { VTOKEN_DECIMALS } from 'config';
+import { useGetMarkets } from 'clients/api';
+
+const useGetMarketData = ({
+  vTokenId,
+  vTokenAddress,
+}: {
+  vTokenId: IVBepToken['id'];
+  vTokenAddress: IVBepToken['address'];
+}) => {
+  const { data: markets = [] } = useGetMarkets({ placeholderData: [] });
+  const assetMarket = markets.find(
+    market => market.address.toLowerCase() === vTokenAddress.toLowerCase(),
+  );
+
+  const props = React.useMemo(() => {
+    const totalBorrowBalanceCents = assetMarket && +assetMarket.totalBorrowsUsd * 100;
+    const totalSupplyBalanceCents = assetMarket && +assetMarket.totalSupplyUsd * 100;
+    const borrowApyPercentage = assetMarket?.borrowApy;
+    const supplyApyPercentage = assetMarket && +assetMarket.supplyApy;
+    const borrowDistributionApyPercentage = assetMarket && +assetMarket.borrowVenusApy;
+    const supplyDistributionApyPercentage = assetMarket && +assetMarket.supplyVenusApy;
+    const tokenPriceDollars = assetMarket && +assetMarket.tokenPrice;
+    const marketLiquidityTokens = assetMarket && new BigNumber(assetMarket.liquidity);
+    const supplierCount = assetMarket?.supplierCount;
+    const borrowerCount = assetMarket?.borrowerCount;
+    const borrowCapCents = assetMarket && +assetMarket.borrowCaps * +assetMarket.tokenPrice * 100;
+    const mintedTokens = assetMarket && new BigNumber(assetMarket.totalSupply2);
+
+    const dailyInterestsCents =
+      assetMarket &&
+      convertWeiToCoins({
+        valueWei: new BigNumber(assetMarket.supplierDailyVenus).plus(
+          new BigNumber(assetMarket.borrowerDailyVenus),
+        ),
+        tokenId: 'xvs',
+      })
+        // Convert XVS to dollars
+        .multipliedBy(assetMarket.tokenPrice)
+        // Convert to cents
+        .multipliedBy(100)
+        .toNumber();
+
+    const reserveFactor =
+      assetMarket &&
+      convertWeiToCoins({
+        valueWei: new BigNumber(assetMarket.reserveFactor),
+        tokenId: vTokenId,
+      })
+        // Convert to percentage
+        .multipliedBy(100)
+        .toNumber();
+
+    const collateralFactor =
+      assetMarket &&
+      convertWeiToCoins({
+        valueWei: new BigNumber(assetMarket.collateralFactor),
+        tokenId: vTokenId,
+      })
+        // Convert to percentage
+        .multipliedBy(100)
+        .toNumber();
+
+    const reserveTokens =
+      assetMarket &&
+      convertWeiToCoins({
+        valueWei: new BigNumber(assetMarket.totalReserves),
+        tokenId: vTokenId,
+      });
+
+    const exchangeRateVTokens =
+      assetMarket &&
+      new BigNumber(1).div(
+        new BigNumber(assetMarket.exchangeRate).div(
+          new BigNumber(10).pow(18 + getToken(vTokenId).decimals - VTOKEN_DECIMALS),
+        ),
+      );
+
+    // TODO: calculate actual value (see https://app.clickup.com/t/29xmavh)
+    const currentUtilizationRate = 46;
+
+    return {
+      totalBorrowBalanceCents,
+      totalSupplyBalanceCents,
+      borrowApyPercentage,
+      supplyApyPercentage,
+      borrowDistributionApyPercentage,
+      supplyDistributionApyPercentage,
+      tokenPriceDollars,
+      marketLiquidityTokens,
+      supplierCount,
+      borrowerCount,
+      borrowCapCents,
+      mintedTokens,
+      dailyInterestsCents,
+      reserveFactor,
+      collateralFactor,
+      reserveTokens,
+      exchangeRateVTokens,
+      currentUtilizationRate,
+    };
+  }, [JSON.stringify(assetMarket)]);
+
+  return props;
+};
+
+export default useGetMarketData;


### PR DESCRIPTION
The file of the `MarketDetails` page is getting quite big, so before I add even more logic I thought I'd decouple the code a bit to make it easier to digest.