### PR TITLE
Fix type error after return of getMarkets changed

### DIFF
--- a/src/pages/MarketDetails/index.tsx
+++ b/src/pages/MarketDetails/index.tsx
@@ -294,7 +294,9 @@ const MarketDetails: React.FC<MarketDetailsProps> = ({
     },
   );
 
-  const { data: markets = [] } = useGetMarkets({ placeholderData: [] });
+  const { data: { markets } = { markets: [] } } = useGetMarkets({
+    placeholderData: { markets: [], dailyVenus: undefined },
+  });
   const assetMarket = markets.find(
     market => market.address.toLowerCase() === vToken.address.toLowerCase(),
   );


### PR DESCRIPTION
Fix accessing returned `getMarkets` after return signature changed