### PR TITLE
Add action to report code coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -88,6 +88,8 @@ jobs:
 
   test:
     runs-on: ubuntu-20.04
+    container:
+      image: node:14.15.1-buster
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -101,4 +103,11 @@ jobs:
         run: yarn
 
       - name: Run tests
-        run: yarn test
+        run: yarn test --ci --json --coverage --testLocationInResults --outputFile=./coverage/report.json
+
+      - uses: ArtiomTr/jest-coverage-report-action@v2
+        with:
+          package-manager: yarn
+          coverage-file: ./coverage/report.json
+          skip-step: all
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds test coverage comparing diff in coverage between base branch and PR branch. 
[Action](https://github.com/ArtiomTr/jest-coverage-report-action)

Adds exporting coverage to a file from current test run.
Skips steps in action to install and run tests
Action will still run tests against base branch and post results/ diff to PR.