### PR TITLE
Call toast with valid argument

### DIFF
--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.tsx
@@ -91,7 +91,7 @@ export const BorrowForm: React.FC<IBorrowFormProps> = ({
         transactionHash,
       });
     } catch (error) {
-      toast.error(error as UiError);
+      toast.error({ title: (error as UiError).message });
     }
   };
 

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -106,7 +106,7 @@ export const RepayForm: React.FC<IRepayFormProps> = ({
         transactionHash,
       });
     } catch (error) {
-      toast.error(error as UiError);
+      toast.error({ title: (error as UiError).message });
     }
   };
 


### PR DESCRIPTION
We were calling toast with the text under the message key from the error which won't get picked up. It needs to be called as `title` or `description`