### PR TITLE
Add tooltip explaining minted VAI is included in borrow limit used

### DIFF
--- a/src/components/v2/ProgressBar/AccountHealth/index.tsx
+++ b/src/components/v2/ProgressBar/AccountHealth/index.tsx
@@ -5,7 +5,10 @@ import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { formatCentsToReadableValue, formatToReadablePercentage } from 'utilities/common';
 import calculatePercentage from 'utilities/calculatePercentage';
 import { useTranslation } from 'translation';
+import { Tooltip } from '../../Tooltip';
+import { Icon } from '../../Icon';
 import { LabeledProgressBar } from '../LabeledProgressBar';
+import { useStyles } from './styles';
 
 export interface IAccountHealthProps {
   borrowBalanceCents: number | undefined;
@@ -25,6 +28,7 @@ export const AccountHealth: React.FC<IAccountHealthProps> = ({
   safeBorrowLimitPercentage,
 }) => {
   const { t, Trans } = useTranslation();
+  const styles = useStyles();
 
   const borrowLimitUsedPercentage =
     typeof borrowBalanceCents === 'number' && typeof borrowLimitCents === 'number'
@@ -70,7 +74,14 @@ export const AccountHealth: React.FC<IAccountHealthProps> = ({
             : t('accountHealth.borrowLimitUsed')
         }
         whiteLeftText={
-          variant === 'borrowBalance' ? readableBorrowBalance : readableBorrowLimitUsedPercentage
+          <span css={styles.textWithTooltip}>
+            {variant === 'borrowBalance'
+              ? readableBorrowBalance
+              : readableBorrowLimitUsedPercentage}
+            <Tooltip css={styles.tooltip} title={t('myAccount.includingMintedVai')}>
+              <Icon css={styles.infoIcon} name="info" />
+            </Tooltip>
+          </span>
         }
         greyRightText={
           variant === 'borrowBalance' ? t('accountHealth.max') : t('accountHealth.limit')

--- a/src/components/v2/ProgressBar/AccountHealth/styles.ts
+++ b/src/components/v2/ProgressBar/AccountHealth/styles.ts
@@ -1,0 +1,20 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+  return {
+    textWithTooltip: css`
+      display: inline-flex;
+      align-items: center;
+    `,
+    tooltip: css`
+      align-items: center;
+      display: inline-flex;
+      margin-left: ${theme.spacing(2)};
+    `,
+    infoIcon: css`
+      cursor: help;
+    `,
+  };
+};

--- a/src/components/v2/ProgressBar/LabeledProgressBar/index.tsx
+++ b/src/components/v2/ProgressBar/LabeledProgressBar/index.tsx
@@ -6,7 +6,7 @@ import { useStyles } from './styles';
 
 interface ILabeledProgressBar extends IProgressBarProps {
   greyLeftText?: string;
-  whiteLeftText?: string;
+  whiteLeftText?: string | React.ReactElement;
   greyRightText?: string;
   whiteRightText?: string;
   className?: string;

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -293,6 +293,7 @@
     "apyWithXvsTooltip": "Choose whether to include the XVS distribution APY in calculations",
     "borrowBalance": "Borrow balance",
     "dailyEarnings": "Daily earnings",
+    "includingMintedVai": "Including minted VAI",
     "netApy": "Net APY",
     "netApyTooltip": "Percentage of your total supply balance received as yearly interests",
     "safeLimit": "Your safe limit:",


### PR DESCRIPTION
This will help a user understand why this percentage is different than the sum of the borrowed percentages in the borrowed market