### PR TITLE
Fix style of warning icon on Notice component

### DIFF
--- a/src/components/v2/Notice/styles.ts
+++ b/src/components/v2/Notice/styles.ts
@@ -55,9 +55,6 @@ export const useStyles = () => {
           `;
         case 'warning':
           return css`
-            width: ${theme.spacing(6)};
-            height: ${theme.spacing(6)};
-            margin-top: ${theme.spacing(-0.5)};
             color: ${theme.palette.interactive.warning};
           `;
       }


### PR DESCRIPTION
The icon used on a warning `Notice` instance used a larger width and height than on the other variants, which I'm guessing is because of the warning banner we previously had: https://www.figma.com/file/GYJwWWLbC4B8DrJOPcETz3/Venus-2.0?node-id=4992%3A41803

However for consistency (and since we don't have a warning banner displayed anymore), the icon on the `Notice` component should always use the same dimensions regardless of the variant.