### PR TITLE
Show negative net APY in red

### DIFF
--- a/src/pages/Dashboard/MyAccount/MyAccountUi.tsx
+++ b/src/pages/Dashboard/MyAccount/MyAccountUi.tsx
@@ -93,7 +93,15 @@ export const MyAccountUi = ({
           </Tooltip>
         </div>
 
-        <Typography variant="h1" color="interactive.success" component="span">
+        <Typography
+          variant="h1"
+          color={
+            netApyPercentage !== undefined && netApyPercentage >= 0
+              ? 'interactive.success'
+              : 'interactive.error'
+          }
+          component="span"
+        >
           {readableNetApyPercentage}
         </Typography>
       </div>


### PR DESCRIPTION
When a user's net APY is negative, we display it in red.