### PR TITLE
Fix VAI vault

### DIFF
--- a/src/constants/daysPerYear.ts
+++ b/src/constants/daysPerYear.ts
@@ -1,0 +1,1 @@
+export const DAYS_PER_YEAR = 365;


### PR DESCRIPTION
The current implementation of the VAI vault relies on getting the APY and the total VAI staked from `settings` set through Redux. These values were being fetched and initialized from the sidebar, but since we've now moved away from that they aren't fetched anymore.

This PR adds a temporary fix to the current Vault page so the values are fetched again.