### PR TITLE
Show antd tooltip on our button

### DIFF
--- a/src/components/Vote/Proposals.tsx
+++ b/src/components/Vote/Proposals.tsx
@@ -113,6 +113,8 @@ interface Props {
   total: number;
   onChangePage: (page: number, total: number, size: number) => void;
 }
+// @ts-expect-error Hack to get antd tooltip to work on non antd button
+PrimaryButton.__ANT_BUTTON = true; // eslint-disable-line @typescript-eslint/no-unused-vars, no-underscore-dangle
 
 function Proposals({
   address,


### PR DESCRIPTION
This bug appeared when when we swapped the original button with the button from our component library.
This PR adds a hack to show it again.