### PR TITLE
Fix full repayment

### DIFF
--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.tsx
@@ -216,7 +216,7 @@ const Repay: React.FC<IRepayProps> = ({ asset, onClose, isXvsEnabled }) => {
     }
 
     let repayAmount = amountWei;
-    if (repayAmount.eq(convertCoinsToWei({ value: limitTokens, tokenId: asset.id }))) {
+    if (repayAmount.eq(convertCoinsToWei({ value: asset.borrowBalance, tokenId: asset.id }))) {
       repayAmount = MAX_UINT256;
     }
 


### PR DESCRIPTION
This PR updates the repaying logic so `MAX_UINT256` is used when repaying the borrow balance of the given token rather than the limit provided to the Borrow/Repay form.