### PR TITLE
Refactor table to set alignment per column

### DIFF
--- a/src/components/v2/Table/Head.tsx
+++ b/src/components/v2/Table/Head.tsx
@@ -9,7 +9,14 @@ import { visuallyHidden } from '@mui/utils';
 import { Icon } from '../Icon';
 import { useStyles } from './styles';
 
-interface IHeadProps<C extends { key: string; label: string; orderable: boolean }[]> {
+interface IColProps {
+  key: string;
+  label: string;
+  orderable: boolean;
+  align?: 'left' | 'center' | 'right';
+}
+
+interface IHeadProps<C extends IColProps[]> {
   columns: C;
   orderBy: string | undefined;
   orderDirection: 'asc' | 'desc' | undefined;
@@ -17,7 +24,7 @@ interface IHeadProps<C extends { key: string; label: string; orderable: boolean 
   className?: string;
 }
 
-function Head<C extends { key: string; label: string; orderable: boolean }[]>({
+function Head<C extends IColProps[]>({
   columns,
   orderBy,
   orderDirection,
@@ -31,7 +38,11 @@ function Head<C extends { key: string; label: string; orderable: boolean }[]>({
         {columns.map((col: C[number]) => {
           const active = orderBy === col.key;
           return (
-            <TableCell key={col.key} sortDirection={active ? orderDirection : false}>
+            <TableCell
+              key={col.key}
+              sortDirection={active ? orderDirection : false}
+              align={col.align}
+            >
               <TableSortLabel
                 css={styles.tableSortLabel({ orderable: col.orderable })}
                 active={active}

--- a/src/components/v2/Table/index.tsx
+++ b/src/components/v2/Table/index.tsx
@@ -16,6 +16,7 @@ export interface ITableRowProps {
   key: string | number;
   render: () => React.ReactNode | string;
   value: string | number | boolean;
+  align?: 'left' | 'center' | 'right';
 }
 
 export interface ITableBaseProps {
@@ -138,7 +139,7 @@ export const Table = ({
                       : 'tr'
                   }
                 >
-                  {row.map(({ key, render }: ITableRowProps) => {
+                  {row.map(({ key, render, align }: ITableRowProps) => {
                     const cellContent = render();
                     const cellTitle = typeof cellContent === 'string' ? cellContent : undefined;
                     return (
@@ -146,6 +147,7 @@ export const Table = ({
                         css={styles.cellWrapper}
                         key={`${rowKey}-${key}-table`}
                         title={cellTitle}
+                        align={align}
                       >
                         {cellContent}
                       </TableCell>

--- a/src/components/v2/Table/styles.ts
+++ b/src/components/v2/Table/styles.ts
@@ -69,7 +69,7 @@ export const useStyles = () => {
       .MuiTableCell-root {
         border-width: 0;
         font-weight: ${theme.typography.body1.fontWeight};
-        text-align: right;
+        flex-direction: row;
         font-size: ${theme.spacing(3.5)};
         text-transform: none;
       }
@@ -80,7 +80,6 @@ export const useStyles = () => {
 
       .MuiTableCell-root:first-of-type {
         padding-left: ${theme.spacing(6)};
-        text-align: left;
       }
 
       .MuiTableCell-root:last-child {

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -27,10 +27,10 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
 
   const columns = useMemo(
     () => [
-      { key: 'asset', label: t('markets.columns.asset'), orderable: false },
-      { key: 'apy', label: t('markets.columns.apy'), orderable: true },
-      { key: 'wallet', label: t('markets.columns.wallet'), orderable: true },
-      { key: 'liquidity', label: t('markets.columns.liquidity'), orderable: true },
+      { key: 'asset', label: t('markets.columns.asset'), orderable: false, align: 'left' },
+      { key: 'apy', label: t('markets.columns.apy'), orderable: true, align: 'right' },
+      { key: 'wallet', label: t('markets.columns.wallet'), orderable: true, align: 'right' },
+      { key: 'liquidity', label: t('markets.columns.liquidity'), orderable: true, align: 'right' },
     ],
     [],
   );
@@ -44,11 +44,13 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
         key: 'asset',
         render: () => <Token symbol={asset.symbol as TokenId} />,
         value: asset.id,
+        align: 'left',
       },
       {
         key: 'apy',
         render: () => formatToReadablePercentage(borrowApy),
         value: borrowApy.toNumber(),
+        align: 'right',
       },
       {
         key: 'wallet',
@@ -59,6 +61,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
             shorthand: true,
           }),
         value: asset.walletBalance.toFixed(),
+        align: 'right',
       },
       {
         key: 'liquidity',
@@ -68,6 +71,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
             shorthand: true,
           }),
         value: asset.liquidity.toNumber(),
+        align: 'right',
       },
     ];
   });

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
@@ -33,10 +33,15 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
 
   const columns = useMemo(
     () => [
-      { key: 'asset', label: t('markets.columns.asset'), orderable: false },
-      { key: 'apy', label: t('markets.columns.apy'), orderable: true },
-      { key: 'balance', label: t('markets.columns.balance'), orderable: true },
-      { key: 'percentOfLimit', label: t('markets.columns.percentOfLimit'), orderable: true },
+      { key: 'asset', label: t('markets.columns.asset'), orderable: false, align: 'left' },
+      { key: 'apy', label: t('markets.columns.apy'), orderable: true, align: 'right' },
+      { key: 'balance', label: t('markets.columns.balance'), orderable: true, align: 'right' },
+      {
+        key: 'percentOfLimit',
+        label: t('markets.columns.percentOfLimit'),
+        orderable: true,
+        align: 'right',
+      },
     ],
     [],
   );
@@ -53,11 +58,13 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
         key: 'asset',
         render: () => <Token symbol={asset.symbol as TokenId} />,
         value: asset.id,
+        align: 'left',
       },
       {
         key: 'apy',
         render: () => <div>{formatToReadablePercentage(borrowApy)}</div>,
         value: borrowApy.toNumber(),
+        align: 'right',
       },
       {
         key: 'balance',
@@ -74,6 +81,7 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
           />
         ),
         value: asset.borrowBalance.toFixed(),
+        align: 'right',
       },
       {
         key: 'percentOfLimit',
@@ -94,6 +102,7 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
           </div>
         ),
         value: percentOfLimit.toFixed(),
+        align: 'right',
       },
     ];
   });

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -31,10 +31,15 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
 
   const columns = useMemo(
     () => [
-      { key: 'asset', label: t('markets.columns.asset'), orderable: false },
-      { key: 'apy', label: t('markets.columns.apy'), orderable: true },
-      { key: 'balance', label: t('markets.columns.balance'), orderable: true },
-      { key: 'collateral', label: t('markets.columns.collateral'), orderable: true },
+      { key: 'asset', label: t('markets.columns.asset'), orderable: false, align: 'left' },
+      { key: 'apy', label: t('markets.columns.apy'), orderable: true, align: 'right' },
+      { key: 'balance', label: t('markets.columns.balance'), orderable: true, align: 'right' },
+      {
+        key: 'collateral',
+        label: t('markets.columns.collateral'),
+        orderable: true,
+        align: 'right',
+      },
     ],
     [],
   );
@@ -45,6 +50,7 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
       key: 'asset',
       render: () => <Token symbol={asset.symbol as TokenId} />,
       value: asset.id,
+      align: 'left',
     },
     {
       key: 'apy',
@@ -53,6 +59,7 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
         return formatToReadablePercentage(apy);
       },
       value: asset.supplyApy.toFixed(),
+      align: 'right',
     },
     {
       key: 'balance',
@@ -69,16 +76,18 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
         />
       ),
       value: asset.supplyBalance.toFixed(),
+      align: 'right',
     },
     {
       key: 'collateral',
-      value: asset.collateral,
       render: () =>
         asset.collateralFactor.toNumber() ? (
           <Toggle onChange={() => collateralOnChange(asset)} value={asset.collateral} />
         ) : (
           PLACEHOLDER_KEY
         ),
+      value: asset.collateral,
+      align: 'right',
     },
   ]);
 

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -27,10 +27,15 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
 
   const columns = useMemo(
     () => [
-      { key: 'asset', label: t('markets.columns.asset'), orderable: false },
-      { key: 'apy', label: t('markets.columns.apy'), orderable: true },
-      { key: 'wallet', label: t('markets.columns.wallet'), orderable: true },
-      { key: 'collateral', label: t('markets.columns.collateral'), orderable: true },
+      { key: 'asset', label: t('markets.columns.asset'), orderable: false, align: 'left' },
+      { key: 'apy', label: t('markets.columns.apy'), orderable: true, align: 'right' },
+      { key: 'wallet', label: t('markets.columns.wallet'), orderable: true, align: 'right' },
+      {
+        key: 'collateral',
+        label: t('markets.columns.collateral'),
+        orderable: true,
+        align: 'right',
+      },
     ],
     [],
   );
@@ -44,11 +49,13 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
         key: 'asset',
         render: () => <Token symbol={asset.symbol as TokenId} />,
         value: asset.id,
+        align: 'left',
       },
       {
         key: 'apy',
         render: () => formatToReadablePercentage(supplyApy),
         value: supplyApy.toNumber(),
+        align: 'right',
       },
       {
         key: 'wallet',
@@ -59,16 +66,18 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
             shorthand: true,
           }),
         value: asset.walletBalance.toFixed(),
+        align: 'right',
       },
       {
         key: 'collateral',
-        value: asset.collateral,
         render: () =>
           asset.collateralFactor.toNumber() ? (
             <Toggle onChange={() => collateralOnChange(asset)} value={asset.collateral} />
           ) : (
             PLACEHOLDER_KEY
           ),
+        value: asset.collateral,
+        align: 'right',
       },
     ];
   });

--- a/src/pages/Market/MarketTable/index.tsx
+++ b/src/pages/Market/MarketTable/index.tsx
@@ -26,13 +26,23 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
 
   const columns = useMemo(
     () => [
-      { key: 'asset', label: t('market.columns.asset'), orderable: false },
-      { key: 'totalSupply', label: t('market.columns.totalSupply'), orderable: true },
-      { key: 'supplyApy', label: t('market.columns.supplyApy'), orderable: true },
-      { key: 'totalBorrows', label: t('market.columns.totalBorrow'), orderable: true },
-      { key: 'borrowApy', label: t('market.columns.borrowApy'), orderable: true },
-      { key: 'liquidity', label: t('market.columns.liquidity'), orderable: true },
-      { key: 'price', label: t('market.columns.price'), orderable: true },
+      { key: 'asset', label: t('market.columns.asset'), orderable: false, align: 'left' },
+      {
+        key: 'totalSupply',
+        label: t('market.columns.totalSupply'),
+        orderable: true,
+        align: 'right',
+      },
+      { key: 'supplyApy', label: t('market.columns.supplyApy'), orderable: true, align: 'right' },
+      {
+        key: 'totalBorrows',
+        label: t('market.columns.totalBorrow'),
+        orderable: true,
+        align: 'right',
+      },
+      { key: 'borrowApy', label: t('market.columns.borrowApy'), orderable: true, align: 'right' },
+      { key: 'liquidity', label: t('market.columns.liquidity'), orderable: true, align: 'right' },
+      { key: 'price', label: t('market.columns.price'), orderable: true, align: 'right' },
     ],
     [],
   );
@@ -50,6 +60,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
       key: 'asset',
       render: () => <Token symbol={asset.symbol as TokenId} />,
       value: asset.id,
+      align: 'left',
     },
     {
       key: 'totalSupply',
@@ -67,6 +78,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         />
       ),
       value: asset.treasuryTotalSupplyUsdCents.toFixed(),
+      align: 'right',
     },
     {
       key: 'supplyApy',
@@ -77,6 +89,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         />
       ),
       value: asset.supplyApy.plus(asset.xvsSupplyApy).toFixed(),
+      align: 'right',
     },
     {
       key: 'totalBorrows',
@@ -94,6 +107,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         />
       ),
       value: asset.treasuryTotalBorrowsUsdCents.toFixed(),
+      align: 'right',
     },
     {
       key: 'borrowApy',
@@ -104,6 +118,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         />
       ),
       value: asset.borrowApy.plus(asset.xvsBorrowApy).toFixed(),
+      align: 'right',
     },
     {
       key: 'liquidity',
@@ -116,6 +131,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         </Typography>
       ),
       value: asset.liquidity.toFixed(),
+      align: 'right',
     },
     {
       key: 'price',
@@ -125,6 +141,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         </Typography>
       ),
       value: asset.tokenPrice.toFixed(),
+      align: 'right',
     },
   ]);
 

--- a/src/pages/Xvs/Table/index.tsx
+++ b/src/pages/Xvs/Table/index.tsx
@@ -34,10 +34,20 @@ const XvsTableUi: React.FC<IXvsTableProps> = ({ assets }) => {
 
   const columns = useMemo(
     () => [
-      { key: 'asset', label: t('xvs.columns.asset'), orderable: false },
-      { key: 'xvsPerDay', label: t('xvs.columns.xvsPerDay'), orderable: true },
-      { key: 'supplyXvsApy', label: t('xvs.columns.supplyXvsApy'), orderable: true },
-      { key: 'borrowXvsApy', label: t('xvs.columns.borrowXvsApy'), orderable: true },
+      { key: 'asset', label: t('xvs.columns.asset'), orderable: false, align: 'left' },
+      { key: 'xvsPerDay', label: t('xvs.columns.xvsPerDay'), orderable: true, align: 'right' },
+      {
+        key: 'supplyXvsApy',
+        label: t('xvs.columns.supplyXvsApy'),
+        orderable: true,
+        align: 'right',
+      },
+      {
+        key: 'borrowXvsApy',
+        label: t('xvs.columns.borrowXvsApy'),
+        orderable: true,
+        align: 'right',
+      },
     ],
     [],
   );
@@ -51,6 +61,7 @@ const XvsTableUi: React.FC<IXvsTableProps> = ({ assets }) => {
       key: 'asset',
       render: () => <Token symbol={asset.symbol as TokenId} />,
       value: asset.id,
+      align: 'left',
     },
     {
       key: 'xvsPerDay',
@@ -64,6 +75,7 @@ const XvsTableUi: React.FC<IXvsTableProps> = ({ assets }) => {
         </Typography>
       ),
       value: asset.xvsPerDay?.toFixed() || 0,
+      align: 'right',
     },
     {
       key: 'supplyXvsApy',
@@ -73,6 +85,7 @@ const XvsTableUi: React.FC<IXvsTableProps> = ({ assets }) => {
         </Typography>
       ),
       value: asset.xvsSupplyApy?.toFixed() || 0,
+      align: 'right',
     },
     {
       key: 'borrowXvsApy',
@@ -82,6 +95,7 @@ const XvsTableUi: React.FC<IXvsTableProps> = ({ assets }) => {
         </Typography>
       ),
       value: asset.xvsBorrowApy?.toFixed() || 0,
+      align: 'right',
     },
   ]);
 


### PR DESCRIPTION
The History table differs in column alignment pattern from the rest of the tables. Our custom css was causing conflicts trying  to introduce a new alignment pattern.

The TableCell component takes a prop to set alignment which his PR uses to set custom alignments per column