### PR TITLE
Add history filters

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './v2/charts/InterestRateChart';
 export * from './v2/AuthModal';
 export * from './v2/Button';
 export * from './v2/BscLink';
+export * from './v2/Checkbox';
 export * from './v2/ConnectWallet';
 export * from './v2/Delimiter';
 export * from './v2/EllipseText';

--- a/src/components/v2/Checkbox/index.tsx
+++ b/src/components/v2/Checkbox/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
 import MuiCheckbox from '@mui/material/Checkbox';
-import { Icon } from 'components';
+import { Icon } from '../Icon';
 import { useStyles } from './styles';
 
 export interface ICheckboxProps {

--- a/src/pages/History/Filters/index.stories.tsx
+++ b/src/pages/History/Filters/index.stories.tsx
@@ -1,25 +1,23 @@
 import React from 'react';
+import noop from 'lodash';
 import { ComponentMeta } from '@storybook/react';
-import { noop } from 'lodash';
-import { ALL_VALUE } from './Filters';
-import { HistoryUi } from '.';
+import Filters, { ALL_VALUE } from '.';
 
 export default {
-  title: 'Pages/History',
-  component: HistoryUi,
+  title: 'Pages/Filters',
+  component: Filters,
   parameters: {
     backgrounds: {
       default: 'White',
     },
   },
-} as ComponentMeta<typeof HistoryUi>;
+} as ComponentMeta<typeof Filters>;
 
 export const Default = () => (
-  <HistoryUi
+  <Filters
     eventType={ALL_VALUE}
     setEventType={noop}
     showOnlyMyTxns={false}
     setShowOnlyMyTxns={noop}
-    transactions={[]}
   />
 );

--- a/src/pages/History/Filters/index.tsx
+++ b/src/pages/History/Filters/index.tsx
@@ -1,0 +1,63 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { Paper, Typography } from '@mui/material';
+import { Checkbox, Select } from 'components';
+import { useTranslation } from 'translation';
+import { TransactionEvent } from 'types';
+import { useStyles } from './styles';
+
+export const ALL_VALUE = 'All';
+
+export interface IFilterProps {
+  eventType: TransactionEvent | typeof ALL_VALUE;
+  setEventType: (eventType: TransactionEvent | typeof ALL_VALUE) => void;
+  showOnlyMyTxns: boolean;
+  setShowOnlyMyTxns: (showOnlyMyTxns: boolean) => void;
+}
+
+export const Filters: React.FC<IFilterProps> = ({
+  eventType,
+  setEventType,
+  showOnlyMyTxns,
+  setShowOnlyMyTxns,
+}) => {
+  const { t } = useTranslation();
+  const styles = useStyles();
+  const selectOptions = [
+    { label: t('history.all'), value: 'All' },
+    { label: t('history.mint'), value: 'Mint' },
+    { label: t('history.transfer'), value: 'Transfer' },
+    { label: t('history.repayBorrow'), value: 'RepayBorrow' },
+    { label: t('history.redeem'), value: 'Redeem' },
+    { label: t('history.approval'), value: 'Approval' },
+    { label: t('history.liquidateBorrow'), value: 'LiquidateBorrow' },
+    { label: t('history.reservesAdded'), value: 'ReservesAdded' },
+    { label: t('history.reservesReduced'), value: 'ReservesReduced' },
+    { label: t('history.mintVAI'), value: 'MintVAI' },
+    { label: t('history.withdraw'), value: 'Withdraw' },
+    { label: t('history.repayVAI'), value: 'RepayVAI' },
+    { label: t('history.deposit'), value: 'Deposit' },
+    { label: t('history.voteCast'), value: 'VoteCast' },
+    { label: t('history.proposalCreated'), value: 'ProposalCreated' },
+    { label: t('history.proposalQueued'), value: 'ProposalQueued' },
+    { label: t('history.proposalExecuted'), value: 'ProposalExecuted' },
+    { label: t('history.proposalCanceled'), value: 'ProposalCanceled' },
+  ];
+  return (
+    <Paper css={styles.root}>
+      <div css={styles.myTransactions}>
+        <Checkbox onChange={e => setShowOnlyMyTxns(e.target.checked)} value={showOnlyMyTxns} />
+        <Typography variant="small2">{t('history.myTransactions')}</Typography>
+      </div>
+      <Select
+        options={selectOptions}
+        value={eventType}
+        onChange={e => setEventType(e.target.value as TransactionEvent | typeof ALL_VALUE)}
+        ariaLabel={t('history.type')}
+        title={t('history.type')}
+        css={styles.select}
+      />
+    </Paper>
+  );
+};
+export default Filters;

--- a/src/pages/History/Filters/styles.ts
+++ b/src/pages/History/Filters/styles.ts
@@ -1,0 +1,22 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+  return {
+    root: css`
+      display: flex;
+      margin: ${theme.spacing(6)};
+      flex-direction: row;
+      justify-content: space-between;
+    `,
+    myTransactions: css`
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+    `,
+    select: css`
+      width: ${theme.spacing(41)};
+    `,
+  };
+};

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -1,13 +1,42 @@
 /** @jsxImportSource @emotion/react */
-import React from 'react';
+import React, { useState } from 'react';
+import { TransactionEvent } from 'types';
 import HistoryTable from './HistoryTable';
+import Filters, { ALL_VALUE, IFilterProps } from './Filters';
 
-export const HistoryUi: React.FC = () => (
+interface IHistoryUiProps extends IFilterProps {
+  transactions: [];
+}
+
+export const HistoryUi: React.FC<IHistoryUiProps> = ({
+  eventType,
+  setEventType,
+  showOnlyMyTxns,
+  setShowOnlyMyTxns,
+}) => (
   <div>
+    <Filters
+      eventType={eventType}
+      setEventType={setEventType}
+      showOnlyMyTxns={showOnlyMyTxns}
+      setShowOnlyMyTxns={setShowOnlyMyTxns}
+    />
     <HistoryTable />
   </div>
 );
 
-const History: React.FC = () => <HistoryUi />;
+const History: React.FC = () => {
+  const [eventType, setEventType] = useState<TransactionEvent | typeof ALL_VALUE>(ALL_VALUE);
+  const [showOnlyMyTxns, setShowOnlyMyTxns] = useState(false);
+  return (
+    <HistoryUi
+      eventType={eventType}
+      setEventType={setEventType}
+      showOnlyMyTxns={showOnlyMyTxns}
+      setShowOnlyMyTxns={setShowOnlyMyTxns}
+      transactions={[]}
+    />
+  );
+};
 
 export default History;

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -139,6 +139,8 @@
     "latestNumber": "Latest Block:\u00a0"
   },
   "history": {
+    "all": "All",
+    "approval": "Approval",
     "columns": {
       "amount": "Amount",
       "block": "Block",
@@ -149,7 +151,25 @@
       "txnHash": "Txn Hash",
       "type": "Type"
     },
-    "createdAt": "{{ date, distanceToNow }} ago"
+    "createdAt": "{{ date, distanceToNow }} ago",
+    "deposit": "Deposit",
+    "liquidateBorrow": "Liquidate Borrow",
+    "mint": "Mint",
+    "mintVAI": "Mint VAI",
+    "myTransactions": "My Transactions",
+    "proposalCanceled": "Proposal Canceled",
+    "proposalCreated": "Proposal Created",
+    "proposalExecuted": "Proposal Executed",
+    "proposalQueued": "Proposal Queued",
+    "redeem": "Redeem",
+    "repayBorrow": "Repay Borrow",
+    "repayVAI": "Repay VAI",
+    "reservesAdded": "Reserves Added",
+    "reservesReduced": "Reserves Reduced",
+    "transfer": "Transfer",
+    "type": "Type",
+    "voteCast": "Vote Cast",
+    "withdraw": "Withdraw"
   },
   "interestRateChart": {
     "currentUtilizationRateLabelValue": "Current ({{percentage}})",


### PR DESCRIPTION
This PR adds the UI for filters on the history page.
It also includes some import fixes for the checkbox and updates the TransactionEvent to be an enum