### PR TITLE
Update common utils

### DIFF
--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -57,8 +57,8 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
         render: () =>
           formatCoinsToReadableValue({
             value: asset.walletBalance,
-            tokenId: asset.id as TokenId,
-            shorthand: true,
+            tokenId: asset.id,
+            minimizeDecimals: true,
           }),
         value: asset.walletBalance.toFixed(),
         align: 'right',
@@ -68,7 +68,7 @@ const BorrowMarketTable: React.FC<IBorrowMarketTableProps> = ({
         render: () =>
           formatCentsToReadableValue({
             value: asset.liquidity.multipliedBy(100),
-            shorthand: true,
+            shortenLargeValue: true,
           }),
         value: asset.liquidity.toNumber(),
         align: 'right',

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
@@ -75,8 +75,8 @@ const BorrowingTable: React.FC<IBorrowingUiProps> = ({
             })}
             bottomValue={formatCoinsToReadableValue({
               value: asset.borrowBalance,
-              tokenId: asset.id as TokenId,
-              shorthand: true,
+              tokenId: asset.id,
+              minimizeDecimals: true,
             })}
           />
         ),

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -70,8 +70,8 @@ export const SuppliedTable: React.FC<ISuppliedTableUiProps> = ({
           })}
           bottomValue={formatCoinsToReadableValue({
             value: asset.supplyBalance,
-            tokenId: asset.id as TokenId,
-            shorthand: true,
+            tokenId: asset.id,
+            minimizeDecimals: true,
           })}
         />
       ),

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -62,8 +62,8 @@ export const SupplyMarketTable: React.FC<ISupplyMarketTableUiProps> = ({
         render: () =>
           formatCoinsToReadableValue({
             value: asset.walletBalance,
-            tokenId: asset.symbol as TokenId,
-            shorthand: true,
+            tokenId: asset.id,
+            minimizeDecimals: true,
           }),
         value: asset.walletBalance.toFixed(),
         align: 'right',

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -199,7 +199,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
             formatCoinsToReadableValue({
               value,
               tokenId: asset.id,
-              shorthand: true,
+              minimizeDecimals: true,
             })
           }
         />

--- a/src/pages/History/HistoryTable/index.tsx
+++ b/src/pages/History/HistoryTable/index.tsx
@@ -144,8 +144,8 @@ export const HistoryTableUi: React.FC<IHistoryTableProps> = ({ transactions }) =
           {formatCoinsToReadableValue({
             value: txn.amount,
             tokenId: getTokenIdFromVAddress(txn.vTokenAddress) as TokenId,
-            shorthand: true,
-            symbol: false,
+            minimizeDecimals: true,
+            addSymbol: false,
           })}
         </Typography>
       ),

--- a/src/pages/Market/MarketTable/index.tsx
+++ b/src/pages/Market/MarketTable/index.tsx
@@ -68,12 +68,12 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         <LayeredValues
           topValue={formatCentsToReadableValue({
             value: asset.treasuryTotalSupplyUsdCents,
-            shorthand: true,
+            shortenLargeValue: true,
           })}
           bottomValue={formatCoinsToReadableValue({
             value: asset.treasuryTotalSupplyUsdCents.div(asset.tokenPrice.times(100)),
-            tokenId: asset.id as TokenId,
-            shorthand: true,
+            tokenId: asset.id,
+            minimizeDecimals: true,
           })}
         />
       ),
@@ -97,12 +97,12 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         <LayeredValues
           topValue={formatCentsToReadableValue({
             value: asset.treasuryTotalBorrowsUsdCents,
-            shorthand: true,
+            shortenLargeValue: true,
           })}
           bottomValue={formatCoinsToReadableValue({
             value: asset.treasuryTotalBorrowsUsdCents.div(asset.tokenPrice.times(100)),
-            tokenId: asset.id as TokenId,
-            shorthand: true,
+            tokenId: asset.id,
+            minimizeDecimals: true,
           })}
         />
       ),
@@ -126,7 +126,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
         <Typography variant="small1" css={styles.whiteText}>
           {formatCentsToReadableValue({
             value: asset.liquidity.multipliedBy(100),
-            shorthand: true,
+            shortenLargeValue: true,
           })}
         </Typography>
       ),

--- a/src/pages/MarketDetails/__snapshots__/index.spec.tsx.snap
+++ b/src/pages/MarketDetails/__snapshots__/index.spec.tsx.snap
@@ -523,7 +523,7 @@ exports[`pages/MarketDetails fetches market details and displays them correctly 
           <span
             class="css-z29iu1-MarketInfo"
           >
-            52,965,104,736,226.06 AAVE
+            52,965,104,736,226.06
           </span>
         </div>
       </div>

--- a/src/pages/MarketDetails/index.tsx
+++ b/src/pages/MarketDetails/index.tsx
@@ -82,7 +82,7 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
       label: t('marketDetails.supplyInfo.stats.totalSupply'),
       value: formatCentsToReadableValue({
         value: totalSupplyBalanceCents,
-        shorthand: true,
+        shortenLargeValue: true,
       }),
     },
     {
@@ -107,7 +107,7 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
       label: t('marketDetails.borrowInfo.stats.totalBorrow'),
       value: formatCentsToReadableValue({
         value: totalBorrowBalanceCents,
-        shorthand: true,
+        shortenLargeValue: true,
       }),
     },
     {
@@ -151,7 +151,7 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
       label: t('marketDetails.marketInfo.stats.marketLiquidityLabel'),
       value: formatCoinsToReadableValue({
         value: marketLiquidityTokens,
-        shorthand: true,
+        minimizeDecimals: true,
         tokenId: vTokenId,
       }),
     },
@@ -182,7 +182,7 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
       label: t('marketDetails.marketInfo.stats.reserveTokensLabel'),
       value: formatCoinsToReadableValue({
         value: reserveTokens,
-        shorthand: true,
+        minimizeDecimals: true,
         tokenId: vTokenId,
       }),
     },
@@ -198,7 +198,8 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
       label: t('marketDetails.marketInfo.stats.mintedTokensLabel', { vTokenSymbol: vToken.symbol }),
       value: formatCoinsToReadableValue({
         value: mintedTokens,
-        shorthand: true,
+        minimizeDecimals: true,
+        addSymbol: false,
         tokenId: vTokenId,
       }),
     },

--- a/src/pages/Xvs/Header/index.tsx
+++ b/src/pages/Xvs/Header/index.tsx
@@ -43,7 +43,7 @@ export const HeaderUi: React.FC<IHeaderProps & IHeaderContainerProps> = ({
     return formatCoinsToReadableValue({
       value: dailyDistribution,
       tokenId: 'xvs',
-      shorthand: true,
+      minimizeDecimals: true,
     });
   }, [dailyVenus.toFixed(), venusVaiVaultRate]);
 
@@ -53,7 +53,7 @@ export const HeaderUi: React.FC<IHeaderProps & IHeaderContainerProps> = ({
         valueWei: remainingDistributionWei,
         tokenId: 'xvs',
         returnInReadableFormat: true,
-        shorthand: true,
+        minimizeDecimals: true,
       }),
     [remainingDistributionWei.toFixed()],
   );

--- a/src/pages/Xvs/Table/index.tsx
+++ b/src/pages/Xvs/Table/index.tsx
@@ -70,7 +70,7 @@ const XvsTableUi: React.FC<IXvsTableProps> = ({ assets }) => {
           {formatCoinsToReadableValue({
             value: asset.xvsPerDay,
             tokenId: 'xvs',
-            shorthand: true,
+            minimizeDecimals: true,
           })}
         </Typography>
       ),

--- a/src/utilities/common.spec.ts
+++ b/src/utilities/common.spec.ts
@@ -14,7 +14,7 @@ describe('utilities/formatCoinsToReadableValue', () => {
     const value = formatCoinsToReadableValue({
       value: new BigNumber(1000.1234),
       tokenId: 'eth',
-      shorthand: true,
+      minimizeDecimals: true,
     });
     expect(value).toBe('1,000.12 ETH');
   });
@@ -23,7 +23,7 @@ describe('utilities/formatCoinsToReadableValue', () => {
     const value = formatCoinsToReadableValue({
       value: new BigNumber(0.1234),
       tokenId: 'ada',
-      shorthand: true,
+      minimizeDecimals: true,
     });
     expect(value).toBe('0.1234 ADA');
   });
@@ -33,7 +33,7 @@ describe('utilities/formatCoinsToReadableValue', () => {
     const value = formatCoinsToReadableValue({
       value: trailingZeroNumber,
       tokenId: 'ada',
-      shorthand: true,
+      minimizeDecimals: true,
     });
     expect(trailingZeroNumber.toFixed(8)).toBe('0.00000050');
     expect(value).toBe('0.0000005 ADA');

--- a/src/utilities/common.ts
+++ b/src/utilities/common.ts
@@ -139,22 +139,22 @@ export const shortenNumberWithSuffix = (value: BigNumber) => {
 export const formatCoinsToReadableValue = ({
   value,
   tokenId,
-  shorthand = false,
-  suffix = false,
-  symbol = true,
+  minimizeDecimals = false,
+  shortenLargeValue = false,
+  addSymbol = true,
 }: {
   value: BigNumber | undefined;
   tokenId: TokenId;
-  shorthand?: boolean;
-  suffix?: boolean;
-  symbol?: boolean;
+  minimizeDecimals?: boolean;
+  shortenLargeValue?: boolean;
+  addSymbol?: boolean;
 }) => {
   if (value === undefined) {
     return PLACEHOLDER_KEY;
   }
 
   let decimalPlaces;
-  if (shorthand) {
+  if (minimizeDecimals) {
     // If value is greater than 1, use 2 decimal places, otherwise use 8
     // see (https://app.clickup.com/24381231/v/dc/q81tf-9288/q81tf-1128)
     decimalPlaces = value.gt(1) ? 2 : 8;
@@ -162,12 +162,14 @@ export const formatCoinsToReadableValue = ({
     const token = getToken(tokenId);
     decimalPlaces = token.decimals;
   }
+
   let symbolPlacement = '';
-  if (symbol) {
-    symbolPlacement = ` ${tokenId.toUpperCase()}`;
+  if (addSymbol) {
+    const token = getToken(tokenId);
+    symbolPlacement = ` ${token.symbol}`;
   }
 
-  if (suffix) {
+  if (shortenLargeValue) {
     return `${shortenNumberWithSuffix(value)}${symbolPlacement}`;
   }
 
@@ -182,12 +184,12 @@ export function convertWeiToCoins<T extends boolean | undefined = false>({
   valueWei,
   tokenId,
   returnInReadableFormat = false,
-  shorthand = false,
+  minimizeDecimals = false,
 }: {
   valueWei: BigNumber;
   tokenId: TokenId;
   returnInReadableFormat?: T;
-  shorthand?: boolean;
+  minimizeDecimals?: boolean;
 }): ConvertWeiToCoinsOutput<T> {
   const tokenDecimals = getToken(tokenId).decimals;
   const valueCoins = valueWei
@@ -196,7 +198,7 @@ export function convertWeiToCoins<T extends boolean | undefined = false>({
 
   return (
     returnInReadableFormat
-      ? formatCoinsToReadableValue({ value: valueCoins, tokenId, shorthand })
+      ? formatCoinsToReadableValue({ value: valueCoins, tokenId, minimizeDecimals })
       : valueCoins
   ) as ConvertWeiToCoinsOutput<T>;
 }
@@ -211,16 +213,16 @@ export const convertCentsToDollars = (value: number) =>
 
 export const formatCentsToReadableValue = ({
   value,
-  shorthand = false,
+  shortenLargeValue = false,
 }: {
   value: number | BigNumber | undefined;
-  shorthand?: boolean;
+  shortenLargeValue?: boolean;
 }) => {
   if (value === undefined) {
     return PLACEHOLDER_KEY;
   }
 
-  if (!shorthand) {
+  if (!shortenLargeValue) {
     return `$${formatCommaThousandsPeriodDecimal(
       convertCentsToDollars(typeof value === 'number' ? value : value.toNumber()),
     )}`;


### PR DESCRIPTION
- rename `shorthand` param of `formatCoinsToReadableValue` and `minimizeDecimals` to make its name more obvious
- rename `shorthand` param of `formatCentsToReadableValue` to `shortenLargeValue` to make its name more obvious
- rename `suffix` param of `formatCoinsToReadableValue` to `shortenLargeValue` to make its name more obvious
- rename `symbol` param of `formatCoinsToReadableValue` to `addSymbol` to make its name more obvious
- use `getToken` in `formatCoinsToReadableValue` to get the symbol of the token
- remove unnecessary type assertions when passing and asset ID to utils