### PR TITLE
Fix redirection issue

### DIFF
--- a/src/components/v2/ResetScrollOnRouteChange/index.tsx
+++ b/src/components/v2/ResetScrollOnRouteChange/index.tsx
@@ -1,12 +1,12 @@
 import React, { useEffect } from 'react';
 import { useLocation } from 'react-router';
 
-export const ResetScrollOnRouteChange: React.FC = ({ children }) => {
+export const ResetScrollOnRouteChange: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
     window.scrollTo(0, 0);
   }, [location]);
 
-  return <>{children}</>;
+  return null;
 };

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -52,50 +52,47 @@ const App = () => (
                       <BrowserRouter>
                         <ToastContainer />
                         <Layout>
+                          <ResetScrollOnRouteChange />
                           <Switch>
-                            <ResetScrollOnRouteChange>
-                              <Route exact path={Path.DASHBOARD} component={Dashboard} />
-                              <Route exact path={Path.VOTE} component={Vote} />
-                              <Route
-                                exact
-                                path={Path.XVS}
-                                component={process.env.REACT_APP_RUN_V2 ? Xvs : XVSV1}
-                              />
-                              <Route
-                                exact
-                                path={Path.MARKET}
-                                component={process.env.REACT_APP_RUN_V2 ? Market : MarketV1}
-                              />
-                              <Route
-                                exact
-                                path={Path.MARKET_DETAILS}
-                                component={
-                                  process.env.REACT_APP_RUN_V2 ? MarketDetails : MarketDetailsV1
-                                }
-                              />
-                              <Route
-                                exact
-                                path={
-                                  process.env.REACT_APP_RUN_V2 ? Path.HISTORY : Path.TRANSACTION
-                                }
-                                component={process.env.REACT_APP_RUN_V2 ? History : TransactionV1}
-                              />
-                              <Route
-                                exact
-                                path={Path.VAULT}
-                                component={process.env.REACT_APP_RUN_V2 ? Vault : VaultV1}
-                              />
-                              <Route
-                                exact
-                                path={Path.VOTE_LEADER_BOARD}
-                                component={VoterLeaderboard}
-                              />
-                              <Route exact path={Path.VOTE_PROPOSAL} component={VoteOverview} />
-                              <Route exact path={Path.VOTE_ADDRESS} component={ProposerDetail} />
-                              <Route exact path={Path.CONVERT_VRT} component={ConvertVrt} />
-                              {isOnTestnet && <Route exact path={Path.FAUCET} component={Faucet} />}
-                              <Redirect from={Path.ROOT} to={Path.DASHBOARD} />
-                            </ResetScrollOnRouteChange>
+                            <Route exact path={Path.DASHBOARD} component={Dashboard} />
+                            <Route exact path={Path.VOTE} component={Vote} />
+                            <Route
+                              exact
+                              path={Path.XVS}
+                              component={process.env.REACT_APP_RUN_V2 ? Xvs : XVSV1}
+                            />
+                            <Route
+                              exact
+                              path={Path.MARKET}
+                              component={process.env.REACT_APP_RUN_V2 ? Market : MarketV1}
+                            />
+                            <Route
+                              exact
+                              path={Path.MARKET_DETAILS}
+                              component={
+                                process.env.REACT_APP_RUN_V2 ? MarketDetails : MarketDetailsV1
+                              }
+                            />
+                            <Route
+                              exact
+                              path={process.env.REACT_APP_RUN_V2 ? Path.HISTORY : Path.TRANSACTION}
+                              component={process.env.REACT_APP_RUN_V2 ? History : TransactionV1}
+                            />
+                            <Route
+                              exact
+                              path={Path.VAULT}
+                              component={process.env.REACT_APP_RUN_V2 ? Vault : VaultV1}
+                            />
+                            <Route
+                              exact
+                              path={Path.VOTE_LEADER_BOARD}
+                              component={VoterLeaderboard}
+                            />
+                            <Route exact path={Path.VOTE_PROPOSAL} component={VoteOverview} />
+                            <Route exact path={Path.VOTE_ADDRESS} component={ProposerDetail} />
+                            <Route exact path={Path.CONVERT_VRT} component={ConvertVrt} />
+                            {isOnTestnet && <Route exact path={Path.FAUCET} component={Faucet} />}
+                            <Redirect to={Path.DASHBOARD} />
                           </Switch>
                         </Layout>
                       </BrowserRouter>


### PR DESCRIPTION
The `ResetScrollOnRouteChange` component caused a bug where reloading the app would always redirect to the dashboard page, because it was located right underneath the `Switch` instance.
This PR fixes that by placing it outside the `Switch` instance.