### PR TITLE
Remove text-transform from body2

### DIFF
--- a/src/components/v2/Layout/Sidebar/styles.ts
+++ b/src/components/v2/Layout/Sidebar/styles.ts
@@ -126,7 +126,6 @@ export const useStyles = () => {
       }
     `,
     listItemText: css`
-      text-transform: none;
       display: block;
       ${theme.breakpoints.down('lg')} {
         display: none;

--- a/src/components/v2/Table/styles.ts
+++ b/src/components/v2/Table/styles.ts
@@ -53,7 +53,6 @@ export const useStyles = () => {
     `,
     columnLabelMobile: css`
       font-size: ${theme.spacing(3)};
-      text-transform: none;
       font-weight: 400;
     `,
     cellValueMobile: css`

--- a/src/theme/MuiThemeProvider/muiTheme.ts
+++ b/src/theme/MuiThemeProvider/muiTheme.ts
@@ -129,7 +129,6 @@ export default createTheme({
     body2: {
       fontSize: '1rem',
       fontWeight: 600,
-      textTransform: 'uppercase',
       letterSpacing: '0.3px',
     },
     small1: {


### PR DESCRIPTION
Remove the text-transform from body2 because it is used less often than not. Generally we don't have a lot of all uppercase text in the app. The only place where it is used was "Confirm Transaction" text but I wonder if that is intentional or not since we don't have much uppercase text.  