### PR TITLE
Fix conversion rate on Convert VRT page

### DIFF
--- a/src/pages/ConvertVrt/constants.ts
+++ b/src/pages/ConvertVrt/constants.ts
@@ -2,5 +2,5 @@ import { getToken } from 'utilities';
 
 export const VRT_ID = 'vrt';
 export const XVS_ID = 'xvs';
-export const CONVERSION_RATIO_DECIMAL = getToken(XVS_ID).decimals;
+export const XVS_DECIMAL = getToken(XVS_ID).decimals;
 export const VRT_DECIMAL = getToken(VRT_ID).decimals;

--- a/src/pages/ConvertVrt/index.tsx
+++ b/src/pages/ConvertVrt/index.tsx
@@ -16,7 +16,8 @@ import { Tabs } from 'components';
 import LoadingSpinner from 'components/Basic/LoadingSpinner';
 import { UiError } from 'utilities/errors';
 import { useTranslation } from 'translation';
-import { CONVERSION_RATIO_DECIMAL, VRT_ID } from './constants';
+import { convertWeiToCoins } from 'utilities/common';
+import { VRT_ID, XVS_ID } from './constants';
 import Withdraw, { IWithdrawProps } from './Withdraw';
 import Convert, { IConvertProps } from './Convert';
 import { useStyles } from './styles';
@@ -112,7 +113,10 @@ const ConvertVrt = () => {
 
   const conversionRatio = useMemo(() => {
     if (vrtConversionRatio) {
-      return new BigNumber(vrtConversionRatio).div(CONVERSION_RATIO_DECIMAL);
+      return convertWeiToCoins({
+        valueWei: new BigNumber(vrtConversionRatio),
+        tokenId: XVS_ID,
+      });
     }
     return undefined;
   }, [vrtConversionRatio]);


### PR DESCRIPTION
The conversion rate returned by the contract was divided by the decimals of the XVS, rather than converted from wei to coins.