### PR TITLE
Show full cell value without wrap

### DIFF
--- a/src/components/v2/Table/styles.ts
+++ b/src/components/v2/Table/styles.ts
@@ -47,7 +47,6 @@ export const useStyles = () => {
     cellMobile: css`
       display: flex;
       flex-direction: column;
-      overflow: hidden;
       padding-left: ${theme.spacing(4)};
       padding-right: ${theme.spacing(4)};
     `,

--- a/src/pages/Market/MarketTable/index.tsx
+++ b/src/pages/Market/MarketTable/index.tsx
@@ -75,6 +75,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
             tokenId: asset.id,
             minimizeDecimals: true,
           })}
+          css={styles.noWrap}
         />
       ),
       value: asset.treasuryTotalSupplyUsdCents.toFixed(),
@@ -104,6 +105,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
             tokenId: asset.id,
             minimizeDecimals: true,
           })}
+          css={styles.noWrap}
         />
       ),
       value: asset.treasuryTotalBorrowsUsdCents.toFixed(),
@@ -151,7 +153,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ assets, getRowHref 
       cardColumns={cardColumns}
       data={rows}
       initialOrder={{
-        orderBy: 'totalSupply',
+        orderBy: 'asset',
         orderDirection: 'desc',
       }}
       rowKeyIndex={0}

--- a/src/pages/Market/MarketTable/styles.ts
+++ b/src/pages/Market/MarketTable/styles.ts
@@ -7,6 +7,11 @@ export const useStyles = () => {
     whiteText: css`
       color: ${theme.palette.text.primary};
     `,
+    noWrap: css`
+      > span {
+        white-space: nowrap;
+      }
+    `,
     cardContentGrid: `
       .table__table-cards__card-content {
         grid-template-columns: 1fr 1fr 1fr;


### PR DESCRIPTION
Currently long values will wrap the symbol to the next line and be hidden. This allows the cards to scale based on the length of the input without wrapping