### PR TITLE
Claim rewards for all address

### DIFF
--- a/src/clients/api/mutations/claimXvsReward.spec.ts
+++ b/src/clients/api/mutations/claimXvsReward.spec.ts
@@ -1,6 +1,6 @@
 import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import address from '__mocks__/models/address';
-import { Comptroller, VenusLens } from 'types/contracts';
+import { Comptroller } from 'types/contracts';
 import { VBEP_TOKENS } from 'constants/tokens';
 import {
   ComptrollerErrorReporterError,
@@ -11,8 +11,6 @@ import getVTokenBalancesAll from '../queries/getVTokenBalancesAll';
 import claimXvsReward from './claimXvsReward';
 
 jest.mock('../queries/getVTokenBalancesAll');
-
-const fakeVenusLensContract = {} as unknown as VenusLens;
 
 describe('api/mutation/claimXvsReward', () => {
   test('throws an error when request fails', async () => {
@@ -31,7 +29,6 @@ describe('api/mutation/claimXvsReward', () => {
     try {
       await claimXvsReward({
         comptrollerContract: fakeContract,
-        venusLensContract: fakeVenusLensContract,
         fromAccountAddress: address,
       });
 
@@ -89,7 +86,6 @@ describe('api/mutation/claimXvsReward', () => {
     try {
       await claimXvsReward({
         comptrollerContract: fakeContract,
-        venusLensContract: fakeVenusLensContract,
         fromAccountAddress: address,
       });
 
@@ -146,16 +142,14 @@ describe('api/mutation/claimXvsReward', () => {
 
     const response = await claimXvsReward({
       comptrollerContract: fakeContract,
-      venusLensContract: fakeVenusLensContract,
       fromAccountAddress: address,
     });
 
     expect(response).toBe(fakeTransactionReceipt);
     expect(claimVenusMock).toHaveBeenCalledTimes(1);
 
-    // Only tokens for which borrowBalanceCurrent or/and balanceOfUnderlying
-    // is/are positive should be sent in the claim
-    const expectedVTokenAddresses = [VBEP_TOKENS.btcb.address, VBEP_TOKENS.bnb.address];
+    // @TODO [VEN-198] Currently claiming all address until the pendingVenus function is updated with pending rewards
+    const expectedVTokenAddresses = Object.values(VBEP_TOKENS).map(vToken => vToken.address);
     expect(claimVenusMock).toHaveBeenCalledWith(address, expectedVTokenAddresses);
     expect(sendMock).toHaveBeenCalledTimes(1);
     expect(sendMock).toHaveBeenCalledWith({ from: address });

--- a/src/clients/api/mutations/claimXvsReward.ts
+++ b/src/clients/api/mutations/claimXvsReward.ts
@@ -1,14 +1,11 @@
-import BigNumber from 'bignumber.js';
 import type { TransactionReceipt } from 'web3-core/types';
 
 import { VBEP_TOKENS } from 'constants/tokens';
-import { Comptroller, VenusLens } from 'types/contracts';
+import { Comptroller } from 'types/contracts';
 import { checkForComptrollerTransactionError } from 'errors';
-import getVTokenBalancesAll from '../queries/getVTokenBalancesAll';
 
 export interface IClaimXvsRewardInput {
   comptrollerContract: Comptroller;
-  venusLensContract: VenusLens;
   fromAccountAddress: string;
 }
 
@@ -16,31 +13,16 @@ export type ClaimXvsRewardOutput = TransactionReceipt;
 
 const claimXvsReward = async ({
   comptrollerContract,
-  venusLensContract,
   fromAccountAddress,
 }: IClaimXvsRewardInput): Promise<ClaimXvsRewardOutput> => {
   // Fetch list of tokens for which user have a positive balance, since these
   // are the tokens susceptible to have generated XVS rewards
   const vTokenAddresses = Object.values(VBEP_TOKENS).map(vToken => vToken.address);
-
-  const vTokenBalances = await getVTokenBalancesAll({
-    venusLensContract,
-    vTokenAddresses,
-    account: fromAccountAddress,
-  });
-
-  const filteredVTokenAddresses = vTokenBalances
-    .filter(
-      vTokenBalance =>
-        new BigNumber(vTokenBalance.borrowBalanceCurrent).isGreaterThan(0) ||
-        new BigNumber(vTokenBalance.balanceOfUnderlying).isGreaterThan(0),
-    )
-    .map(vTokenBalance => vTokenBalance.vToken);
-
+  // @TODO [VEN-198] - use venus lens to fetch rewards by addresses once it is upgraded with this functionality
   // Send query to claim XVS reward
   const resp = await comptrollerContract.methods['claimVenus(address,address[])'](
     fromAccountAddress,
-    filteredVTokenAddresses,
+    vTokenAddresses,
   ).send({
     from: fromAccountAddress,
   });

--- a/src/clients/api/mutations/useClaimXvsReward.ts
+++ b/src/clients/api/mutations/useClaimXvsReward.ts
@@ -7,7 +7,7 @@ import {
   ClaimXvsRewardOutput,
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
-import { useComptrollerContract, useVenusLensContract } from 'clients/contracts/hooks';
+import { useComptrollerContract } from 'clients/contracts/hooks';
 
 type Options = MutationObserverOptions<
   ClaimXvsRewardOutput,
@@ -17,14 +17,12 @@ type Options = MutationObserverOptions<
 
 const useClaimXvsReward = (options?: Options) => {
   const comptrollerContract = useComptrollerContract();
-  const venusLensContract = useVenusLensContract();
 
   return useMutation(
     FunctionKey.CLAIM_XVS_REWARD,
     (params: Omit<IClaimXvsRewardInput, 'comptrollerContract' | 'venusLensContract'>) =>
       claimXvsReward({
         comptrollerContract,
-        venusLensContract,
         ...params,
       }),
     {


### PR DESCRIPTION
Filtering claimed address by balances leaves out rewards for withdrawn or repaid balances.
We can claims rewards on all addresses until we upgrade venusLens to return pending rewards by address