### PR TITLE
0.6.0 - Fixes

### DIFF
--- a/src/clients/api/queries/getAssetsInAccount.ts
+++ b/src/clients/api/queries/getAssetsInAccount.ts
@@ -1,6 +1,8 @@
+import { Comptroller } from 'types/contracts';
+
 export interface IGetAssetsInAccountInput {
-  comptrollerContract: $TSFixMe; // @TODO: use contract type (through Typechain?)
-  account: string | undefined | null;
+  comptrollerContract: Comptroller;
+  account: string;
 }
 
 export type GetAssetsInAccountOutput = string[];

--- a/src/clients/api/queries/useGetAllowance.ts
+++ b/src/clients/api/queries/useGetAllowance.ts
@@ -27,8 +27,8 @@ const useGetAllowance = (
   const tokenContract = useTokenContract(tokenId);
 
   return useQuery(
-    [FunctionKey.GET_TOKEN_ALLOWANCE, tokenId, spenderAddress],
-    () => getAllowance({ tokenContract, accountAddress, spenderAddress }),
+    [FunctionKey.GET_TOKEN_ALLOWANCE, spenderAddress, tokenId],
+    () => getAllowance({ tokenContract, spenderAddress, accountAddress }),
     options,
   );
 };

--- a/src/clients/api/queries/useGetAssetsInAccount.ts
+++ b/src/clients/api/queries/useGetAssetsInAccount.ts
@@ -12,7 +12,7 @@ type Options = QueryObserverOptions<
   Error,
   GetAssetsInAccountOutput,
   GetAssetsInAccountOutput,
-  FunctionKey.GET_ASSETS_IN_ACCOUNT
+  [FunctionKey.GET_ASSETS_IN_ACCOUNT, string]
 >;
 
 const useGetAssetsInAccount = (
@@ -21,7 +21,7 @@ const useGetAssetsInAccount = (
 ) => {
   const comptrollerContract = useComptrollerContract();
   return useQuery(
-    FunctionKey.GET_ASSETS_IN_ACCOUNT,
+    [FunctionKey.GET_ASSETS_IN_ACCOUNT, account],
     () => getAssetsInAccount({ comptrollerContract, account }),
     options,
   );

--- a/src/clients/api/queries/useGetBalanceOf.ts
+++ b/src/clients/api/queries/useGetBalanceOf.ts
@@ -23,7 +23,7 @@ const useGetBalanceOf = (
   const tokenContract = useTokenContract(tokenId);
 
   return useQuery(
-    [FunctionKey.GET_BALANCE_OF, tokenId, accountAddress],
+    [FunctionKey.GET_BALANCE_OF, accountAddress, tokenId],
     () => getBalanceOf({ tokenContract, accountAddress }),
     options,
   );

--- a/src/clients/api/queries/useGetMintedVai.ts
+++ b/src/clients/api/queries/useGetMintedVai.ts
@@ -9,14 +9,14 @@ type Options = QueryObserverOptions<
   Error,
   GetMintedVaiOutput,
   GetMintedVaiOutput,
-  FunctionKey.GET_MINTED_VAI
+  [FunctionKey.GET_MINTED_VAI, string]
 >;
 
 const useGetMintedVai = (accountAddress: string, options?: Options) => {
   const comptrollerContract = useComptrollerContract();
 
   return useQuery(
-    FunctionKey.GET_MINTED_VAI,
+    [FunctionKey.GET_MINTED_VAI, accountAddress],
     () => getMintedVai({ accountAddress, comptrollerContract }),
     options,
   );

--- a/src/clients/api/queries/useGetUserMarketInfo.ts
+++ b/src/clients/api/queries/useGetUserMarketInfo.ts
@@ -70,7 +70,7 @@ const useGetUserMarketInfo = ({
 
   const { data: assetsInAccount = [], isLoading: isGetAssetsInAccountLoading } =
     useGetAssetsInAccount(
-      { account: accountAddress },
+      { account: accountAddress || '' },
       { enabled: !!accountAddress, placeholderData: [] },
     );
 

--- a/src/clients/api/queries/useGetVTokenBalanceOf.ts
+++ b/src/clients/api/queries/useGetVTokenBalanceOf.ts
@@ -13,7 +13,7 @@ type Options = QueryObserverOptions<
   Error,
   GetVTokenBalanceOfOutput,
   GetVTokenBalanceOfOutput,
-  [FunctionKey.GET_V_TOKEN_BALANCE, VTokenId]
+  [FunctionKey.GET_V_TOKEN_BALANCE, string, VTokenId]
 >;
 
 const useGetVTokenBalanceOf = (
@@ -22,7 +22,7 @@ const useGetVTokenBalanceOf = (
 ) => {
   const tokenContract = useVTokenContract(vTokenId as VTokenId);
   return useQuery(
-    [FunctionKey.GET_V_TOKEN_BALANCE, vTokenId],
+    [FunctionKey.GET_V_TOKEN_BALANCE, account, vTokenId],
     () => getVTokenBalanceOf({ tokenContract, account }),
     options,
   );

--- a/src/clients/api/queries/useGetVTokenBorrowBalance.ts
+++ b/src/clients/api/queries/useGetVTokenBorrowBalance.ts
@@ -12,7 +12,7 @@ type Options = QueryObserverOptions<
   Error,
   GetVTokenBorrowBalanceOutput,
   GetVTokenBorrowBalanceOutput,
-  [FunctionKey.GET_V_TOKEN_BORROW_BALANCE, VTokenId]
+  [FunctionKey.GET_V_TOKEN_BORROW_BALANCE, string, VTokenId]
 >;
 
 const useGetVTokenBorrowBalance = (
@@ -22,7 +22,7 @@ const useGetVTokenBorrowBalance = (
   const vTokenContract = useVTokenContract(vTokenId);
 
   return useQuery(
-    [FunctionKey.GET_V_TOKEN_BORROW_BALANCE, vTokenId],
+    [FunctionKey.GET_V_TOKEN_BORROW_BALANCE, accountAddress, vTokenId],
     () => getVTokenBorrowBalance({ accountAddress, vTokenContract }),
     options,
   );

--- a/src/clients/api/queries/useGetXvsReward.ts
+++ b/src/clients/api/queries/useGetXvsReward.ts
@@ -8,14 +8,14 @@ type Options = QueryObserverOptions<
   Error,
   GetXvsRewardOutput,
   GetXvsRewardOutput,
-  FunctionKey.GET_XVS_REWARD
+  [FunctionKey.GET_XVS_REWARD, string]
 >;
 
 const useGetXvsReward = (accountAddress: string | undefined, options?: Options) => {
   const lensContract = useVenusLensContract();
 
   return useQuery(
-    FunctionKey.GET_XVS_REWARD,
+    [FunctionKey.GET_XVS_REWARD, accountAddress],
     () =>
       getXvsReward({
         lensContract,

--- a/src/components/v2/ProgressBar/LabeledProgressBar/styles.tsx
+++ b/src/components/v2/ProgressBar/LabeledProgressBar/styles.tsx
@@ -13,9 +13,21 @@ export const useStyles = () => {
     `,
     inlineContainer: css`
       display: flex;
+
+      ${theme.breakpoints.down('md')} {
+        flex-direction: column;
+
+        :last-of-type {
+          text-align: right;
+        }
+      }
     `,
     inlineLabel: css`
       margin-right: ${theme.spacing(1)};
+
+      ${theme.breakpoints.down('md')} {
+        margin-right: 0;
+      }
     `,
     inlineValue: css`
       color: ${theme.palette.text.primary};

--- a/src/pages/Market/MarketTable/index.tsx
+++ b/src/pages/Market/MarketTable/index.tsx
@@ -54,96 +54,102 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
   }, [columns]);
 
   // Format markets to rows
-  const rows: TableProps['data'] = markets.map(market => [
-    {
-      key: 'market',
-      render: () => <Token tokenId={market.id as TokenId} css={styles.whiteText} />,
-      value: market.id,
-    },
-    {
-      key: 'totalSupply',
-      render: () => (
-        <LayeredValues
-          topValue={formatCentsToReadableValue({
-            value: market.treasuryTotalSupplyUsdCents,
-            shortenLargeValue: true,
-          })}
-          bottomValue={formatCoinsToReadableValue({
-            value: market.treasuryTotalSupplyUsdCents.div(market.tokenPrice.times(100)),
-            tokenId: market.id as TokenId,
-            minimizeDecimals: true,
-          })}
-          css={styles.noWrap}
-        />
-      ),
-      align: 'right',
-      value: market.treasuryTotalSupplyUsdCents.toFixed(),
-    },
-    {
-      key: 'supplyApy',
-      render: () => (
-        <LayeredValues
-          topValue={formatToReadablePercentage(market.supplyApy.plus(market.supplyVenusApy))}
-          bottomValue={formatToReadablePercentage(market.supplyVenusApy)}
-        />
-      ),
-      value: market.supplyApy.plus(market.supplyVenusApy).toFixed(),
-      align: 'right',
-    },
-    {
-      key: 'totalBorrows',
-      render: () => (
-        <LayeredValues
-          topValue={formatCentsToReadableValue({
-            value: market.treasuryTotalBorrowsUsdCents,
-            shortenLargeValue: true,
-          })}
-          bottomValue={formatCoinsToReadableValue({
-            value: market.treasuryTotalBorrowsUsdCents.div(market.tokenPrice.times(100)),
-            tokenId: market.id as TokenId,
-            minimizeDecimals: true,
-          })}
-          css={styles.noWrap}
-        />
-      ),
-      value: market.treasuryTotalBorrowsUsdCents.toFixed(),
-      align: 'right',
-    },
-    {
-      key: 'borrowApy',
-      render: () => (
-        <LayeredValues
-          topValue={formatToReadablePercentage(market.borrowApy.plus(market.borrowVenusApy))}
-          bottomValue={formatToReadablePercentage(market.borrowVenusApy)}
-        />
-      ),
-      value: market.borrowApy.plus(market.borrowVenusApy).toFixed(),
-      align: 'right',
-    },
-    {
-      key: 'liquidity',
-      render: () => (
-        <Typography variant="small1" css={styles.whiteText}>
-          {formatCentsToReadableValue({
-            value: market.liquidity.multipliedBy(100),
-            shortenLargeValue: true,
-          })}
-        </Typography>
-      ),
-      value: market.liquidity.toFixed(),
-      align: 'right',
-    },
-    {
-      key: 'price',
-      render: () => (
-        <Typography variant="small1" css={styles.whiteText}>
-          {formatCentsToReadableValue({ value: market.tokenPrice.multipliedBy(100) })}
-        </Typography>
-      ),
-      align: 'right',
-      value: market.tokenPrice.toFixed(),
-    },
-  ]);
+  const rows: TableProps['data'] = useMemo(
+    () =>
+      markets.map(market => [
+        {
+          key: 'market',
+          render: () => <Token tokenId={market.id as TokenId} css={styles.whiteText} />,
+          value: market.id,
+        },
+        {
+          key: 'totalSupply',
+          render: () => (
+            <LayeredValues
+              topValue={formatCentsToReadableValue({
+                value: market.treasuryTotalSupplyUsdCents,
+                shortenLargeValue: true,
+              })}
+              bottomValue={formatCoinsToReadableValue({
+                value: market.treasuryTotalSupplyUsdCents.div(market.tokenPrice.times(100)),
+                tokenId: market.id as TokenId,
+                minimizeDecimals: true,
+                shortenLargeValue: true,
+              })}
+              css={styles.noWrap}
+            />
+          ),
+          align: 'right',
+          value: market.treasuryTotalSupplyUsdCents.toFixed(),
+        },
+        {
+          key: 'supplyApy',
+          render: () => (
+            <LayeredValues
+              topValue={formatToReadablePercentage(market.supplyApy.plus(market.supplyVenusApy))}
+              bottomValue={formatToReadablePercentage(market.supplyVenusApy)}
+            />
+          ),
+          value: market.supplyApy.plus(market.supplyVenusApy).toFixed(),
+          align: 'right',
+        },
+        {
+          key: 'totalBorrows',
+          render: () => (
+            <LayeredValues
+              topValue={formatCentsToReadableValue({
+                value: market.treasuryTotalBorrowsUsdCents,
+                shortenLargeValue: true,
+              })}
+              bottomValue={formatCoinsToReadableValue({
+                value: market.treasuryTotalBorrowsUsdCents.div(market.tokenPrice.times(100)),
+                tokenId: market.id as TokenId,
+                minimizeDecimals: true,
+                shortenLargeValue: true,
+              })}
+              css={styles.noWrap}
+            />
+          ),
+          value: market.treasuryTotalBorrowsUsdCents.toFixed(),
+          align: 'right',
+        },
+        {
+          key: 'borrowApy',
+          render: () => (
+            <LayeredValues
+              topValue={formatToReadablePercentage(market.borrowApy.plus(market.borrowVenusApy))}
+              bottomValue={formatToReadablePercentage(market.borrowVenusApy)}
+            />
+          ),
+          value: market.borrowApy.plus(market.borrowVenusApy).toFixed(),
+          align: 'right',
+        },
+        {
+          key: 'liquidity',
+          render: () => (
+            <Typography variant="small1" css={styles.whiteText}>
+              {formatCentsToReadableValue({
+                value: market.liquidity.multipliedBy(100),
+                shortenLargeValue: true,
+              })}
+            </Typography>
+          ),
+          value: market.liquidity.toFixed(),
+          align: 'right',
+        },
+        {
+          key: 'price',
+          render: () => (
+            <Typography variant="small1" css={styles.whiteText}>
+              {formatCentsToReadableValue({ value: market.tokenPrice.multipliedBy(100) })}
+            </Typography>
+          ),
+          align: 'right',
+          value: market.tokenPrice.toFixed(),
+        },
+      ]),
+    [JSON.stringify(markets)],
+  );
 
   return (
     <Table

--- a/src/pages/Xvs/Header/index.tsx
+++ b/src/pages/Xvs/Header/index.tsx
@@ -69,6 +69,7 @@ export const HeaderUi: React.FC<IHeaderProps & IHeaderContainerProps> = ({
         <div css={styles.xvsIconContainer}>
           <Icon name="xvs" size={styles.iconSize} />
         </div>
+
         <Typography
           className="ellipse-text"
           href={generateBscScanUrl('xvs')}
@@ -78,10 +79,12 @@ export const HeaderUi: React.FC<IHeaderProps & IHeaderContainerProps> = ({
           component="a"
           css={[styles.whiteText, styles.addressText]}
         />
+
         <div css={styles.copyIconContainer}>
           <Icon name="copy" onClick={copyAddress} css={styles.copyIcon} size={styles.iconSizeXl} />
         </div>
       </EllipseText>
+
       <div css={styles.slider}>
         <LabeledProgressBar
           css={styles.progressBar}


### PR DESCRIPTION
- add account address to query keys of query functions that are linked to a specific account. My original thoughts were that since we'd reset the cache when logging a user out we didn't need to do that, but I've realized that adding the account address to the keys directly means switching between accounts (through MetaMask for example) is now doable. This probably concerns a very small portion of users, but it's a small modification that won't make our life harder (getting the current account address is quite easy through context)
- shorten large token values on Market page
- update legends on `ProgressBar` component to correspond to how it is represented on the designs of the XVS page on mobile (on two lines). This makes us gain space and means larger values can be displayed without overflowing (which is currently an issue for accounts with large sums of money on the Borrow/Supply modals)
- memoize markets on Market page