### PR TITLE
Minimize decimals of XVS reward

### DIFF
--- a/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
+++ b/src/components/v2/Layout/ClaimXvsRewardButton/index.spec.tsx
@@ -12,7 +12,7 @@ import ClaimXvsRewardButton, { TEST_ID } from '.';
 jest.mock('clients/api');
 jest.mock('hooks/useSuccessfulTransactionModal');
 
-describe('pages/Dashboard/MintRepayVai', () => {
+describe('pages/Dashboard/ClaimXvsRewardButton', () => {
   it('renders without crashing', () => {
     renderComponent(<ClaimXvsRewardButton />);
   });
@@ -35,7 +35,7 @@ describe('pages/Dashboard/MintRepayVai', () => {
 
   it('renders correct XVS reward when user are connected and have claimable XVS reward', async () => {
     (getXvsReward as jest.Mock).mockImplementationOnce(
-      async () => new BigNumber('10000000000000000000000'),
+      async () => new BigNumber('10000000000000000'),
     );
 
     const { getByTestId } = renderComponent(() => <ClaimXvsRewardButton />, {
@@ -47,11 +47,11 @@ describe('pages/Dashboard/MintRepayVai', () => {
     });
 
     await waitFor(() => expect(getByTestId(TEST_ID)));
-    expect(getByTestId(TEST_ID).textContent).toContain('10,000 XVS');
+    expect(getByTestId(TEST_ID).textContent).toContain('0.01 XVS');
   });
 
   it('it claims XVS reward on click and displays successful transaction modal on success', async () => {
-    const fakeXvsReward = new BigNumber('10000000000000000000000');
+    const fakeXvsReward = new BigNumber('10000000000000000');
 
     const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
     (getXvsReward as jest.Mock).mockImplementationOnce(async () => fakeXvsReward);

--- a/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
+++ b/src/components/v2/Layout/ClaimXvsRewardButton/index.tsx
@@ -7,8 +7,8 @@ import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import { useGetXvsReward, useClaimXvsReward } from 'clients/api';
 import { useTranslation } from 'translation';
 import { TokenId } from 'types';
-import { convertWeiToCoins } from 'utilities/common';
 import { VError } from 'errors';
+import useConvertToReadableCoinString from 'hooks/useConvertToReadableCoinString';
 import { transactionErrorPhrases } from 'errors/transactionErrorPhrases';
 import { toast } from '../../Toast';
 import { Icon } from '../../Icon';
@@ -34,7 +34,14 @@ export const ClaimXvsRewardButtonUi: React.FC<IClaimXvsRewardButton> = ({
 
   const { openSuccessfulTransactionModal } = useSuccessfulTransactionModal();
 
-  if (!amountWei || amountWei.isEqualTo(0)) {
+  const readableAmount = useConvertToReadableCoinString({
+    valueWei: amountWei,
+    tokenId: XVS_SYMBOL,
+    minimizeDecimals: true,
+  });
+
+  // Check readable amount isn't 0 (since we strip out decimals)
+  if (!amountWei || readableAmount.split(' ')[0] === '0') {
     return null;
   }
 
@@ -63,12 +70,6 @@ export const ClaimXvsRewardButtonUi: React.FC<IClaimXvsRewardButton> = ({
       });
     }
   };
-
-  const readableAmount = convertWeiToCoins({
-    valueWei: amountWei,
-    tokenId: XVS_SYMBOL,
-    returnInReadableFormat: true,
-  });
 
   return (
     <SecondaryButton


### PR DESCRIPTION
- use `useConvertToReadableCoinString` hook with `minimizeDecimals` prop to minimize the decimals displayed for the claimable XVS reward