### PR TITLE
Remove unnecessary css that causes hover issues on safari

### DIFF
--- a/src/components/v2/Table/styles.ts
+++ b/src/components/v2/Table/styles.ts
@@ -102,8 +102,6 @@ export const useStyles = () => {
       .MuiSvgIcon-root {
         display: block;
         margin-left: ${theme.spacing(2)};
-        transition: opacity 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms,
-          transform 200ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
         transform: rotate(0deg);
       }
       .MuiTableSortLabel-iconDirectionDesc {


### PR DESCRIPTION
On Safari the transition css was causing weird behavior. It isn't necessary so this PR removes it.