### PR TITLE
Fix formatting of liquidity value on Market Details page

### DIFF
--- a/src/pages/MarketDetails/__snapshots__/index.spec.tsx.snap
+++ b/src/pages/MarketDetails/__snapshots__/index.spec.tsx.snap
@@ -6,4 +6,4 @@ exports[`pages/MarketDetails fetches market details and displays them correctly 
 
 exports[`pages/MarketDetails fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`pages/MarketDetails fetches market details and displays them correctly 4`] = `"Market infoPrice$399.24Market liquidity4,198,428.82 AAVE# of suppliers144# of borrowers6Borrow capUncappedInterest paid/day$9,981.00Reserves0 AAVEReserve factor0%Collateral factor55%vAAVE minted52,965,104,736,226.06Exchange rate1 AAVE=4997145456.364805 vAAVE"`;
+exports[`pages/MarketDetails fetches market details and displays them correctly 4`] = `"Market infoPrice$399.24Market liquidity$4,198,428.82# of suppliers144# of borrowers6Borrow capUncappedInterest paid/day$9,981.00Reserves0 AAVEReserve factor0%Collateral factor55%vAAVE minted52,965,104,736,226.06Exchange rate1 AAVE=4997145456.364805 vAAVE"`;

--- a/src/pages/MarketDetails/index.stories.tsx
+++ b/src/pages/MarketDetails/index.stories.tsx
@@ -62,7 +62,7 @@ export const Default = () => (
     supplyDistributionApyPercentage={0.45}
     currentUtilizationRate={46}
     tokenPriceDollars="1.14"
-    marketLiquidityTokens={new BigNumber(100000000)}
+    liquidityCents={new BigNumber(10000000000)}
     supplierCount={1234}
     borrowerCount={76}
     borrowCapCents={812963286}

--- a/src/pages/MarketDetails/index.tsx
+++ b/src/pages/MarketDetails/index.tsx
@@ -34,7 +34,7 @@ export interface IMarketDetailsUiProps {
   borrowDistributionApyPercentage?: number;
   supplyDistributionApyPercentage?: number;
   tokenPriceDollars?: string;
-  marketLiquidityTokens?: BigNumber;
+  liquidityCents?: BigNumber;
   supplierCount?: number;
   borrowerCount?: number;
   borrowCapCents?: number;
@@ -57,7 +57,7 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
   supplyDistributionApyPercentage,
   currentUtilizationRate,
   tokenPriceDollars,
-  marketLiquidityTokens,
+  liquidityCents,
   supplierCount,
   borrowerCount,
   borrowCapCents,
@@ -149,10 +149,8 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
     },
     {
       label: t('marketDetails.marketInfo.stats.marketLiquidityLabel'),
-      value: formatCoinsToReadableValue({
-        value: marketLiquidityTokens,
-        minimizeDecimals: true,
-        tokenId: vTokenId,
+      value: formatCentsToReadableValue({
+        value: liquidityCents,
       }),
     },
     {

--- a/src/pages/MarketDetails/index.tsx
+++ b/src/pages/MarketDetails/index.tsx
@@ -11,6 +11,7 @@ import {
   formatCentsToReadableValue,
   formatToReadablePercentage,
   formatCoinsToReadableValue,
+  formatCommaThousandsPeriodDecimal,
 } from 'utilities/common';
 import { ApyChart, IApyChartProps, InterestRateChart, IInterestRateChartProps } from 'components';
 import LoadingSpinner from 'components/Basic/LoadingSpinner';
@@ -77,23 +78,26 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
   const token = getToken(vTokenId);
   const vToken = getVBepToken(vTokenId);
 
-  const supplyInfoStats: ICardProps['stats'] = [
-    {
-      label: t('marketDetails.supplyInfo.stats.totalSupply'),
-      value: formatCentsToReadableValue({
-        value: totalSupplyBalanceCents,
-        shortenLargeValue: true,
-      }),
-    },
-    {
-      label: t('marketDetails.supplyInfo.stats.apy'),
-      value: formatToReadablePercentage(supplyApyPercentage),
-    },
-    {
-      label: t('marketDetails.supplyInfo.stats.distributionApy'),
-      value: formatToReadablePercentage(supplyDistributionApyPercentage),
-    },
-  ];
+  const supplyInfoStats: ICardProps['stats'] = React.useMemo(
+    () => [
+      {
+        label: t('marketDetails.supplyInfo.stats.totalSupply'),
+        value: formatCentsToReadableValue({
+          value: totalSupplyBalanceCents,
+          shortenLargeValue: true,
+        }),
+      },
+      {
+        label: t('marketDetails.supplyInfo.stats.apy'),
+        value: formatToReadablePercentage(supplyApyPercentage),
+      },
+      {
+        label: t('marketDetails.supplyInfo.stats.distributionApy'),
+        value: formatToReadablePercentage(supplyDistributionApyPercentage),
+      },
+    ],
+    [totalSupplyBalanceCents?.toFixed(), supplyApyPercentage, supplyDistributionApyPercentage],
+  );
 
   const supplyInfoLegends: ICardProps['legends'] = [
     {
@@ -102,23 +106,26 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
     },
   ];
 
-  const borrowInfoStats: ICardProps['stats'] = [
-    {
-      label: t('marketDetails.borrowInfo.stats.totalBorrow'),
-      value: formatCentsToReadableValue({
-        value: totalBorrowBalanceCents,
-        shortenLargeValue: true,
-      }),
-    },
-    {
-      label: t('marketDetails.borrowInfo.stats.apy'),
-      value: formatToReadablePercentage(borrowApyPercentage),
-    },
-    {
-      label: t('marketDetails.borrowInfo.stats.distributionApy'),
-      value: formatToReadablePercentage(borrowDistributionApyPercentage),
-    },
-  ];
+  const borrowInfoStats: ICardProps['stats'] = React.useMemo(
+    () => [
+      {
+        label: t('marketDetails.borrowInfo.stats.totalBorrow'),
+        value: formatCentsToReadableValue({
+          value: totalBorrowBalanceCents,
+          shortenLargeValue: true,
+        }),
+      },
+      {
+        label: t('marketDetails.borrowInfo.stats.apy'),
+        value: formatToReadablePercentage(borrowApyPercentage),
+      },
+      {
+        label: t('marketDetails.borrowInfo.stats.distributionApy'),
+        value: formatToReadablePercentage(borrowDistributionApyPercentage),
+      },
+    ],
+    [totalBorrowBalanceCents?.toFixed(), borrowApyPercentage, borrowDistributionApyPercentage],
+  );
 
   const borrowInfoLegends: ICardProps['legends'] = [
     {
@@ -142,76 +149,97 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
     },
   ];
 
-  const marketInfoStats: IMarketInfoProps['stats'] = [
-    {
-      label: t('marketDetails.marketInfo.stats.priceLabel'),
-      value: tokenPriceDollars === undefined ? PLACEHOLDER_KEY : `$${tokenPriceDollars}`,
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.marketLiquidityLabel'),
-      value: formatCentsToReadableValue({
-        value: liquidityCents,
-      }),
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.supplierCountLabel'),
-      value: supplierCount ?? '-',
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.borrowerCountLabel'),
-      value: borrowerCount ?? '-',
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.borrowCapLabel'),
-      value:
-        borrowCapCents === 0
-          ? t('marketDetails.marketInfo.stats.unlimitedBorrowCap')
-          : formatCentsToReadableValue({
-              value: borrowCapCents,
-            }),
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.dailyInterestsLabel'),
-      value: formatCentsToReadableValue({
-        value: dailyInterestsCents,
-      }),
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.reserveTokensLabel'),
-      value: formatCoinsToReadableValue({
-        value: reserveTokens,
-        minimizeDecimals: true,
-        tokenId: vTokenId,
-      }),
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.reserveFactorLabel'),
-      value: formatToReadablePercentage(reserveFactor),
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.collateralFactorLabel'),
-      value: formatToReadablePercentage(collateralFactor),
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.mintedTokensLabel', { vTokenSymbol: vToken.symbol }),
-      value: formatCoinsToReadableValue({
-        value: mintedTokens,
-        minimizeDecimals: true,
-        addSymbol: false,
-        tokenId: vTokenId,
-      }),
-    },
-    {
-      label: t('marketDetails.marketInfo.stats.exchangeRateLabel'),
-      value: exchangeRateVTokens
-        ? t('marketDetails.marketInfo.stats.exchangeRateValue', {
-            tokenSymbol: token.symbol,
-            vTokenSymbol: vToken.symbol,
-            rate: exchangeRateVTokens.dp(6).toFixed(),
-          })
-        : PLACEHOLDER_KEY,
-    },
-  ];
+  const marketInfoStats: IMarketInfoProps['stats'] = React.useMemo(
+    () => [
+      {
+        label: t('marketDetails.marketInfo.stats.priceLabel'),
+        value:
+          tokenPriceDollars === undefined
+            ? PLACEHOLDER_KEY
+            : `$${formatCommaThousandsPeriodDecimal(tokenPriceDollars)}`,
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.marketLiquidityLabel'),
+        value: formatCentsToReadableValue({
+          value: liquidityCents,
+        }),
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.supplierCountLabel'),
+        value: supplierCount ?? '-',
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.borrowerCountLabel'),
+        value: borrowerCount ?? '-',
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.borrowCapLabel'),
+        value:
+          borrowCapCents === 0
+            ? t('marketDetails.marketInfo.stats.unlimitedBorrowCap')
+            : formatCentsToReadableValue({
+                value: borrowCapCents,
+              }),
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.dailyInterestsLabel'),
+        value: formatCentsToReadableValue({
+          value: dailyInterestsCents,
+        }),
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.reserveTokensLabel'),
+        value: formatCoinsToReadableValue({
+          value: reserveTokens,
+          minimizeDecimals: true,
+          tokenId: vTokenId,
+        }),
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.reserveFactorLabel'),
+        value: formatToReadablePercentage(reserveFactor),
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.collateralFactorLabel'),
+        value: formatToReadablePercentage(collateralFactor),
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.mintedTokensLabel', {
+          vTokenSymbol: vToken.symbol,
+        }),
+        value: formatCoinsToReadableValue({
+          value: mintedTokens,
+          minimizeDecimals: true,
+          addSymbol: false,
+          tokenId: vTokenId,
+        }),
+      },
+      {
+        label: t('marketDetails.marketInfo.stats.exchangeRateLabel'),
+        value: exchangeRateVTokens
+          ? t('marketDetails.marketInfo.stats.exchangeRateValue', {
+              tokenSymbol: token.symbol,
+              vTokenSymbol: vToken.symbol,
+              rate: exchangeRateVTokens.dp(6).toFixed(),
+            })
+          : PLACEHOLDER_KEY,
+      },
+    ],
+    [
+      tokenPriceDollars,
+      liquidityCents?.toFixed(),
+      supplierCount,
+      borrowerCount,
+      borrowCapCents?.toFixed(),
+      dailyInterestsCents?.toFixed(),
+      reserveTokens?.toFixed(),
+      vTokenId,
+      reserveFactor?.toFixed(),
+      collateralFactor?.toFixed(),
+      mintedTokens?.toFixed(),
+      exchangeRateVTokens?.toFixed(),
+    ],
+  );
 
   if (!supplyChartData.length || !borrowChartData.length || !interestRateChartData.length) {
     return <LoadingSpinner />;

--- a/src/pages/MarketDetails/useGetMarketData.ts
+++ b/src/pages/MarketDetails/useGetMarketData.ts
@@ -31,7 +31,7 @@ const useGetMarketData = ({
     const borrowDistributionApyPercentage = assetMarket && +assetMarket.borrowVenusApy;
     const supplyDistributionApyPercentage = assetMarket && +assetMarket.supplyVenusApy;
     const tokenPriceDollars = assetMarket && assetMarket.tokenPrice.toFixed(2);
-    const marketLiquidityTokens = assetMarket && new BigNumber(assetMarket.liquidity);
+    const liquidityCents = assetMarket && new BigNumber(assetMarket.liquidity).multipliedBy(100);
     const supplierCount = assetMarket?.supplierCount;
     const borrowerCount = assetMarket?.borrowerCount;
     const borrowCapCents = assetMarket && +assetMarket.borrowCaps * +assetMarket.tokenPrice * 100;
@@ -109,7 +109,7 @@ const useGetMarketData = ({
       borrowDistributionApyPercentage,
       supplyDistributionApyPercentage,
       tokenPriceDollars,
-      marketLiquidityTokens,
+      liquidityCents,
       supplierCount,
       borrowerCount,
       borrowCapCents,


### PR DESCRIPTION
The liquidity displayed on the Market Details page assumed it was expressed in tokens, but it's expressed in dollars.
The values were also not getting memoized, which this PR now does.