### PR TITLE
Correctly translate missing account error

### DIFF
--- a/src/errors/formatVErrorToReadableString.ts
+++ b/src/errors/formatVErrorToReadableString.ts
@@ -22,5 +22,5 @@ export const formatVErrorToReadableString = (error: VError<ErrorCodes>) => {
       phrase = translationPhrase;
     }
   }
-  return phrase;
+  return phrase || unexpectedErrorPhrases.somethingWentWrong;
 };

--- a/src/errors/interactionErrorPhrases.ts
+++ b/src/errors/interactionErrorPhrases.ts
@@ -6,4 +6,5 @@ export const interactionErrorPhrases = {
     t('markets.errors.collateralEnableError', args),
   collateralDisableError: (args: { assetName: string }) =>
     t('markets.errors.collateralDisableError', args),
+  accountError: t('markets.errors.accountError'),
 };

--- a/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/index.tsx
@@ -13,7 +13,6 @@ import {
   getHypotheticalAccountLiquidity,
   getVTokenBalanceOf,
 } from 'clients/api';
-import { useTranslation } from 'translation';
 import { SupplyWithdrawModal } from '../../Modals';
 import { CollateralConfirmModal } from './CollateralConfirmModal';
 import SupplyMarketTable from './SupplyMarketTable';
@@ -113,7 +112,6 @@ const SupplyMarket: React.FC<
   const comptrollerContract = useComptrollerContract();
 
   const [confirmCollateral, setConfirmCollateral] = useState<Asset | undefined>(undefined);
-  const { t } = useTranslation();
 
   const { mutateAsync: enterMarkets } = useEnterMarkets({
     onSettled: () => setConfirmCollateral(undefined),
@@ -127,7 +125,7 @@ const SupplyMarket: React.FC<
     if (!accountAddress) {
       throw new VError({
         type: 'interaction',
-        code: t('markets.errors.accountError'),
+        code: 'accountError',
       });
     } else if (!asset || !asset.borrowBalance.isZero()) {
       throw new VError({


### PR DESCRIPTION
- Correctly fetch the translation for if a user toggles collateral without a wallet
- add a fallback message in the event something goes wrong and we end up with an undefined translation