### PR TITLE
Allow non proposer to cancel if they meet requirements

### DIFF
--- a/src/containers/Main/VoteOverview.tsx
+++ b/src/containers/Main/VoteOverview.tsx
@@ -315,7 +315,6 @@ function VoteOverview({ getVoters, getProposalById, match }: Props) {
                   <SecondaryButton
                     disabled={
                       !account ||
-                      account.address.toLowerCase() !== proposalInfo.proposer?.toLowerCase() ||
                       isCancelLoading ||
                       proposerVotingWeight < proposalThreshold ||
                       cancelStatus === 'success'


### PR DESCRIPTION
Kirill followed up on my question in slack and informed that we actually have different cancel requirements than Compound.

The cancel proposal requirements are 
- Proposer
- Guardian
- Anyone if the proposer's voting power is less than govBravo.proposalThreshold()