### PR TITLE
[VEN-282] Add modal to warn users to decollateralize LUNA and UST

### DIFF
--- a/src/pages/Dashboard/Modals/LunaUstWarning/index.tsx
+++ b/src/pages/Dashboard/Modals/LunaUstWarning/index.tsx
@@ -1,0 +1,24 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import Typography from '@mui/material/Typography';
+
+import { useTranslation } from 'translation';
+import { Modal, IModalProps } from 'components';
+import { useStyles } from './styles';
+
+export interface ILunaUstWarningModalProps {
+  onClose: IModalProps['handleClose'];
+}
+
+const LunaUstWarningModal: React.FC<ILunaUstWarningModalProps> = ({ onClose }) => {
+  const styles = useStyles();
+  const { t } = useTranslation();
+
+  return (
+    <Modal isOpened title={t('dashboard.lunaUstWarningModal.title')} handleClose={onClose}>
+      <Typography css={styles.text}>{t('dashboard.lunaUstWarningModal.content')}</Typography>
+    </Modal>
+  );
+};
+
+export default LunaUstWarningModal;

--- a/src/pages/Dashboard/Modals/LunaUstWarning/styles.ts
+++ b/src/pages/Dashboard/Modals/LunaUstWarning/styles.ts
@@ -1,0 +1,12 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  return {
+    text: css`
+      color: ${theme.palette.text.primary};
+    `,
+  };
+};

--- a/src/pages/Dashboard/Modals/index.ts
+++ b/src/pages/Dashboard/Modals/index.ts
@@ -1,2 +1,3 @@
 export { default as SupplyWithdrawModal } from './SupplyWithdraw';
 export { default as BorrowRepayModal } from './BorrowRepay';
+export { default as LunaUstWarningModal } from './LunaUstWarning';

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -7,7 +7,9 @@ import { Asset } from 'types';
 
 import MyAccount from './MyAccount';
 import MintRepayVai from './MintRepayVai';
+import { LunaUstWarningModal } from './Modals';
 import Markets from './Markets';
+import useLunaUstWarningModal from './useLunaUstWarningModal';
 import { useStyles } from './styles';
 
 interface IDashboardUiProps {
@@ -27,6 +29,8 @@ const DashboardUi: React.FC<IDashboardUiProps> = ({
 }) => {
   const styles = useStyles();
   const [isXvsEnabled, setIsXvsEnabled] = React.useState(true);
+  const [shouldShowLunaUstWarningModal, closeLunaUstWarningModal] = useLunaUstWarningModal(assets);
+
   const { suppliedAssets, supplyMarketAssets, borrowingAssets, borrowMarketAssets } =
     useMemo(() => {
       const sortedAssets = assets.reduce(
@@ -79,6 +83,8 @@ const DashboardUi: React.FC<IDashboardUiProps> = ({
         borrowingAssets={borrowingAssets}
         borrowMarketAssets={borrowMarketAssets}
       />
+
+      {shouldShowLunaUstWarningModal && <LunaUstWarningModal onClose={closeLunaUstWarningModal} />}
     </>
   );
 };

--- a/src/pages/Dashboard/useLunaUstWarningModal.ts
+++ b/src/pages/Dashboard/useLunaUstWarningModal.ts
@@ -1,0 +1,28 @@
+import { useState, useMemo } from 'react';
+
+import { Asset } from 'types';
+
+const SESSION_STORAGE_KEY = 'has-seen-modal-this-session';
+
+const useLunaUstWarningModal = (assets: Asset[]): [boolean, () => void] => {
+  const hasDeprecatedCollateral = useMemo(
+    () => assets.some(asset => (asset.id === 'luna' || asset.id === 'ust') && asset.collateral),
+    [JSON.stringify(assets)],
+  );
+
+  const hasSeenModalThisSession = !!sessionStorage.getItem(SESSION_STORAGE_KEY);
+
+  const [shouldShowModal, setShouldShowModal] = useState(
+    !!hasDeprecatedCollateral && !hasSeenModalThisSession,
+  );
+
+  const closeModal = () => {
+    // Mark modal as seen in session storage
+    sessionStorage.setItem(SESSION_STORAGE_KEY, '1');
+    setShouldShowModal(false);
+  };
+
+  return [shouldShowModal, closeModal];
+};
+
+export default useLunaUstWarningModal;

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -111,6 +111,10 @@
     "youWillReceive": "You will receive"
   },
   "dashboard": {
+    "lunaUstWarningModal": {
+      "content": "UST and LUNA are being deprecated, please ensure they are disabled as collateral. Failure to disable them will result in lost access to the protocol after deprecation.",
+      "title": "⚠️ WARNING ⚠️"
+    },
     "markets": {
       "tabBorrow": "Borrow",
       "tabSupply": "Supply",


### PR DESCRIPTION
This modal will only display to users who still have LUNA and/or UST enabled as collaterals, in every new session (so reloading the page doesn't show it again but reopening the app in a new tab does).