### PR TITLE
Add errors to translation strings and improve wallet mismatch error

### DIFF
--- a/src/clients/web3/useAuth/index.ts
+++ b/src/clients/web3/useAuth/index.ts
@@ -11,6 +11,7 @@ import {
 } from '@web3-react/walletconnect-connector';
 import { toast } from 'components/v2/Toast';
 import { LS_KEY_CONNECTED_CONNECTOR } from 'config';
+import { useTranslation } from 'translation';
 import { connectorsByName } from '../connectors';
 import { Connector } from '../types';
 import setupNetwork from './setUpNetwork';
@@ -25,6 +26,8 @@ const getConnectedConnector = (): Connector | undefined => {
 };
 
 const useAuth = () => {
+  const { t } = useTranslation();
+
   const { activate, deactivate, account } = useWeb3React();
 
   const [connectedConnector, setConnectedConnector] = useState(getConnectedConnector());
@@ -37,7 +40,7 @@ const useAuth = () => {
         // an incorrect connectorID was passed to this function)
 
         toast.error({
-          message: 'An internal error occurred: unsupported wallet. Please try again later',
+          message: t('wallets.errors.unsupportedWallet'),
         });
         return;
       }
@@ -75,14 +78,14 @@ const useAuth = () => {
           error instanceof UserRejectedRequestErrorInjected ||
           error instanceof UserRejectedRequestErrorWalletConnect
         ) {
-          errorMessage = 'You need to authorize access to your account';
+          errorMessage = t('wallets.errors.authorizeAccess');
         } else if (
           error instanceof NoEthereumProviderError ||
           error instanceof NoBscProviderError
         ) {
           // TODO: log error to Sentry
 
-          errorMessage = 'An internal error occurred: no provider found. Please try again later';
+          errorMessage = t('wallets.errors.noProvider');
         } else {
           errorMessage = (error as Error).message;
         }

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -574,6 +574,11 @@
     "binanceChainWallet": "Binance Chain Wallet",
     "braveWallet": "Brave Wallet",
     "coinbaseWallet": "Coinbase Wallet",
+    "errors": {
+      "authorizeAccess": "You need to authorize access to your account",
+      "noProvider": "If you are connecting an external wallet, make sure you have a provider such as Metamask or compatible wallet such as Brave",
+      "unsupportedWallet": "Unable to connect. Make sure your selection matches your desired wallet."
+    },
     "ledger": "Ledger",
     "metamask": "MetaMask",
     "trustWallet": "Trust Wallet",

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -576,7 +576,7 @@
     "coinbaseWallet": "Coinbase Wallet",
     "errors": {
       "authorizeAccess": "You need to authorize access to your account",
-      "noProvider": "If you are connecting an external wallet, make sure you have a provider such as Metamask or compatible wallet such as Brave",
+      "noProvider": "If you are connecting an external wallet, make sure you have a provider such as MetaMask or compatible wallet such as Brave",
       "unsupportedWallet": "Unable to connect. Make sure your selection matches your desired wallet."
     },
     "ledger": "Ledger",


### PR DESCRIPTION
When testing connecting wrong wallets it came to my attention that the error message could be more useful.

In the process I added the errors to the translation strings.

We can refactor this to use our VError VEN-292 