### PR TITLE
Update tooltip about XVS distribution

### DIFF
--- a/src/hooks/useDailyXvsWei.ts
+++ b/src/hooks/useDailyXvsWei.ts
@@ -6,10 +6,10 @@ import { XVS_TOKEN_ID } from 'constants/xvs';
 import { AuthContext } from 'context/AuthContext';
 
 export const useDailyXvsWei = () => {
-  const { account: { address: accountAddress = '' } = {} } = useContext(AuthContext);
+  const { account } = useContext(AuthContext);
   const { data: dailyXvsWei, isLoading: isGetDailyXvsLoading } = useGetDailyXvsWei(
-    { accountAddress: accountAddress || '' },
-    { enabled: !!accountAddress },
+    { accountAddress: account?.address || '' },
+    { enabled: !!account?.address },
   );
 
   const { data: getMarketsData, isLoading: isGetMarketsLoading } = useGetMarkets();
@@ -28,11 +28,11 @@ export const useDailyXvsWei = () => {
 
     return {
       dailyXvsDistributionInterestsCents:
-        accountAddress && xvsPriceDollars
+        account?.address && xvsPriceDollars
           ? dailyXvsTokens?.multipliedBy(xvsPriceDollars).times(100)
           : new BigNumber(0),
     };
-  }, [JSON.stringify(dailyXvsWei), JSON.stringify(getMarketsData?.markets), accountAddress]);
+  }, [JSON.stringify(dailyXvsWei), JSON.stringify(getMarketsData?.markets), account?.address]);
 
   return {
     isLoading: isGetDailyXvsLoading || isGetMarketsLoading,

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -305,7 +305,7 @@
   },
   "myAccount": {
     "apyWithXvs": "APY with XVS",
-    "apyWithXvsTooltip": "Choose whether to include the XVS distribution APY in calculations",
+    "apyWithXvsTooltip": "Choose whether to include the XVS distribution APR in calculations",
     "borrowBalance": "Borrow balance",
     "dailyEarnings": "Daily earnings",
     "includingMintedVai": "Including minted VAI",


### PR DESCRIPTION
## Jira ticket(s)

N/A

## Changes

- Now that we use the XVS distribution APR to calculate the net APY, the tooltip needs to be updated
