### PR TITLE
Update "start" script to always compile

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,4 +1,6 @@
 NODE_ENV=development
+ESLINT_NO_DEV_ERRORS=true
+TSC_COMPILE_ON_ERROR=true
 #REACT_APP_CHAIN_ID should be 97 for testnet
 REACT_APP_CHAIN_ID=97
 FAST_REFRESH=true

--- a/package.json
+++ b/package.json
@@ -183,7 +183,9 @@
     "workerDirectory": "public"
   },
   "jest": {
-    "transformIgnorePatterns": ["/node_modules/?!(react-markdown)"],
+    "transformIgnorePatterns": [
+      "/node_modules/?!(react-markdown)"
+    ],
     "moduleNameMapper": {
       "^.+\\.css$": "<rootDir>/src/__mocks__/CSSStub.js"
     }


### PR DESCRIPTION
## Jira ticket(s)

N/A

## Changes

- set `ESLINT_NO_DEV_ERRORS` and `TSC_COMPILE_ON_ERROR` environment variables in `.env.template` file. Enabling both these variables means the dApp will always compile when running/building locally and TS/ESLint errors will be printed in the console rather than blocking the dApp from rendering and displaying them in the browser

The goal of this PR is to make the environment friendlier to devs. I personally find it annoying that while I'm coding the dApp stops compiling whenever there's a TypeScript or ESlint error, since I often want to run imperfect code to test an assumption before writing production worthy code.
I've added these variables to the default environment variables file, which means you can either opt in by adding these variables to your local `.env` file, or do nothing if you prefer to keep the existing behavior.

Note that if a developer disables the errors when coding locally and pushes code containing errors, our pipelines we'll pick them up and warn us on PRs so this change doesn't impact the solidity of the codebase.
