### PR TITLE
Prettify json separately

### DIFF
--- a/.lintstagedrc
+++ b/.lintstagedrc
@@ -1,5 +1,6 @@
 {
-  "*{.ts,*.tsx,*.js,*.jsx,*.json}": ["eslint --fix", "prettier --write --check", "stylelint --fix"],
+  "*{.ts,*.tsx,*.js,*.jsx}": ["eslint --fix", "prettier --write --check", "stylelint --fix"],
+  "*.json": ["prettier --write --check"],
   "*.html": ["prettier --write --check"],
   "*.scss": ["stylelint --fix"]
 }


### PR DESCRIPTION
## Changes

We should prettify json in pre commit because it errors in CI but it needs to be a separate command because we can't pass json files explicitly to eslint
