### PR TITLE
Merge master with develop

### DIFF
--- a/src/pages/Market/styles.ts
+++ b/src/pages/Market/styles.ts
@@ -133,12 +133,12 @@ export const useStyles = () => {
         ${theme.breakpoints.down('xxl')} {
           grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
           grid-template-rows: 1fr;
+          row-gap: ${theme.spacing(5)};
         }
 
         ${theme.breakpoints.down('md')} {
           grid-template-columns: 1fr 1fr 1fr;
           grid-template-rows: 1fr 1fr;
-          row-gap: ${theme.spacing(5)};
         }
       }
     `,

--- a/src/pages/MarketDetails/index.stories.tsx
+++ b/src/pages/MarketDetails/index.stories.tsx
@@ -65,7 +65,7 @@ export const Default = () => (
     liquidityCents={new BigNumber(10000000000)}
     supplierCount={1234}
     borrowerCount={76}
-    borrowCapCents={812963286}
+    borrowCapTokens={new BigNumber(812963286)}
     dailyInterestsCents={123212}
     reserveTokens={new BigNumber(100000)}
     reserveFactor={20}

--- a/src/pages/MarketDetails/index.tsx
+++ b/src/pages/MarketDetails/index.tsx
@@ -38,7 +38,7 @@ export interface IMarketDetailsUiProps {
   liquidityCents?: BigNumber;
   supplierCount?: number;
   borrowerCount?: number;
-  borrowCapCents?: number;
+  borrowCapTokens?: BigNumber;
   dailyInterestsCents?: number;
   reserveFactor?: number;
   collateralFactor?: number;
@@ -61,7 +61,7 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
   liquidityCents,
   supplierCount,
   borrowerCount,
-  borrowCapCents,
+  borrowCapTokens,
   dailyInterestsCents,
   reserveTokens,
   reserveFactor,
@@ -174,12 +174,12 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
       },
       {
         label: t('marketDetails.marketInfo.stats.borrowCapLabel'),
-        value:
-          borrowCapCents === 0
-            ? t('marketDetails.marketInfo.stats.unlimitedBorrowCap')
-            : formatCentsToReadableValue({
-                value: borrowCapCents,
-              }),
+        value: borrowCapTokens?.isEqualTo(0)
+          ? t('marketDetails.marketInfo.stats.unlimitedBorrowCap')
+          : formatCoinsToReadableValue({
+              value: borrowCapTokens,
+              tokenId: vTokenId,
+            }),
       },
       {
         label: t('marketDetails.marketInfo.stats.dailyInterestsLabel'),
@@ -230,7 +230,7 @@ export const MarketDetailsUi: React.FC<IMarketDetailsUiProps> = ({
       liquidityCents?.toFixed(),
       supplierCount,
       borrowerCount,
-      borrowCapCents?.toFixed(),
+      borrowCapTokens?.toFixed(),
       dailyInterestsCents?.toFixed(),
       reserveTokens?.toFixed(),
       vTokenId,

--- a/src/pages/MarketDetails/useGetMarketData.ts
+++ b/src/pages/MarketDetails/useGetMarketData.ts
@@ -37,7 +37,7 @@ const useGetMarketData = ({
     const liquidityCents = assetMarket && new BigNumber(assetMarket.liquidity).multipliedBy(100);
     const supplierCount = assetMarket?.supplierCount;
     const borrowerCount = assetMarket?.borrowerCount;
-    const borrowCapCents = assetMarket && +assetMarket.borrowCaps * +assetMarket.tokenPrice * 100;
+    const borrowCapTokens = assetMarket && new BigNumber(assetMarket.borrowCaps);
     const mintedTokens = assetMarket && new BigNumber(assetMarket.totalSupply2);
     const reserveFactorMantissa = assetMarket && new BigNumber(assetMarket.reserveFactor);
 
@@ -111,7 +111,7 @@ const useGetMarketData = ({
       liquidityCents,
       supplierCount,
       borrowerCount,
-      borrowCapCents,
+      borrowCapTokens,
       mintedTokens,
       dailyInterestsCents,
       reserveFactor,


### PR DESCRIPTION
Merge back `master` into `develop` to include the last hotfix that displays the borrow cap of a token in tokens rather than in dollars.