### PR TITLE
Fix function key 

### DIFF
--- a/src/clients/api/index.ts
+++ b/src/clients/api/index.ts
@@ -107,7 +107,7 @@ export { default as useGetXvsReward } from './queries/useGetXvsReward';
 
 export { default as getAllowance } from './queries/getAllowance';
 export * from './queries/getAllowance';
-export { default as useGetAllowance } from './queries/useGetAllowance';
+export { default as useGetAllowance } from './queries/getAllowance/useGetAllowance';
 
 export { default as getBalanceOf } from './queries/getBalanceOf';
 export * from './queries/getBalanceOf';

--- a/src/clients/api/mutations/useApproveToken.ts
+++ b/src/clients/api/mutations/useApproveToken.ts
@@ -4,7 +4,7 @@ import { TokenId } from 'types';
 import { queryClient, approveToken, IApproveTokenInput, ApproveTokenOutput } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useTokenContract } from 'clients/contracts/hooks';
-import setCachedTokenAllowanceToMax from './setCachedTokenAllowanceToMax';
+import setCachedTokenAllowanceToMax from '../queries/getAllowance/setCachedTokenAllowanceToMax';
 
 const useApproveToken = (
   { tokenId }: { tokenId: TokenId },

--- a/src/clients/api/queries/getAllowance/index.spec.ts
+++ b/src/clients/api/queries/getAllowance/index.spec.ts
@@ -1,5 +1,7 @@
+import BigNumber from 'bignumber.js';
+
 import { VrtToken } from 'types/contracts';
-import getAllowance, { GetAllowanceOutput } from './getAllowance';
+import getAllowance from '.';
 
 const fakeAccountAddress = '0x000000000000000000000000000000000AcCoUnt';
 const fakeSpenderAddress = '0x000000000000000000000000000000000sPeNdEr';
@@ -30,9 +32,9 @@ describe('api/queries/getAllowance', () => {
   });
 
   test('returns the Allowance on success', async () => {
-    const fakeOutput: GetAllowanceOutput = '0';
+    const fakeAllowanceWei = '10000';
 
-    const callMock = jest.fn(async () => fakeOutput);
+    const callMock = jest.fn(async () => fakeAllowanceWei);
     const vrtAllowanceMock = jest.fn(() => ({
       call: callMock,
     }));
@@ -52,6 +54,7 @@ describe('api/queries/getAllowance', () => {
     expect(vrtAllowanceMock).toHaveBeenCalledTimes(1);
     expect(callMock).toHaveBeenCalledTimes(1);
     expect(vrtAllowanceMock).toHaveBeenCalledWith(fakeAccountAddress, fakeSpenderAddress);
-    expect(response).toBe(fakeOutput);
+    expect(response instanceof BigNumber).toBe(true);
+    expect(response.toFixed()).toBe(fakeAllowanceWei);
   });
 });

--- a/src/clients/api/queries/getAllowance/index.ts
+++ b/src/clients/api/queries/getAllowance/index.ts
@@ -1,3 +1,5 @@
+import BigNumber from 'bignumber.js';
+
 import { VrtToken, XvsToken, Bep20, VaiToken } from 'types/contracts';
 
 export interface IGetAllowanceInput {
@@ -6,13 +8,15 @@ export interface IGetAllowanceInput {
   spenderAddress: string;
 }
 
-export type GetAllowanceOutput = string;
+export type GetAllowanceOutput = BigNumber;
 
-const getVenusVaiState = ({
+const getVenusVaiState = async ({
   tokenContract,
   accountAddress,
   spenderAddress,
-}: IGetAllowanceInput): Promise<GetAllowanceOutput> =>
-  tokenContract.methods.allowance(accountAddress, spenderAddress).call();
+}: IGetAllowanceInput): Promise<GetAllowanceOutput> => {
+  const res = await tokenContract.methods.allowance(accountAddress, spenderAddress).call();
+  return new BigNumber(res);
+};
 
 export default getVenusVaiState;

--- a/src/clients/api/queries/getAllowance/setCachedTokenAllowanceToMax.ts
+++ b/src/clients/api/queries/getAllowance/setCachedTokenAllowanceToMax.ts
@@ -5,6 +5,7 @@ import { GetAllowanceOutput } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { TokenId } from 'types';
 import { getTokenSpenderAddress } from 'utilities';
+import type { UseGetAllowanceQueryKey } from './useGetAllowance';
 
 const setCachedTokenAllowanceToMax = ({
   queryClient,
@@ -13,8 +14,15 @@ const setCachedTokenAllowanceToMax = ({
   queryClient: QueryClient;
   tokenId: TokenId;
 }) => {
-  const queryKey = [FunctionKey.GET_TOKEN_ALLOWANCE, tokenId, getTokenSpenderAddress(tokenId)];
-  queryClient.setQueryData<GetAllowanceOutput>(queryKey, `${MAX_UINT256.toFixed()}`);
+  const queryKey: UseGetAllowanceQueryKey = [
+    FunctionKey.GET_TOKEN_ALLOWANCE,
+    {
+      spenderAddress: getTokenSpenderAddress(tokenId),
+      tokenId,
+    },
+  ];
+
+  queryClient.setQueryData<GetAllowanceOutput>(queryKey, MAX_UINT256);
 };
 
 export default setCachedTokenAllowanceToMax;

--- a/src/clients/api/queries/getAllowance/useGetAllowance.ts
+++ b/src/clients/api/queries/getAllowance/useGetAllowance.ts
@@ -8,27 +8,46 @@ import FunctionKey from 'constants/functionKey';
 import { useTokenContract } from 'clients/contracts/hooks';
 import { TokenId } from 'types';
 
+export type UseGetAllowanceQueryKey = [
+  FunctionKey.GET_TOKEN_ALLOWANCE,
+  {
+    tokenId: TokenId;
+    spenderAddress: string;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetAllowanceOutput,
   Error,
   GetAllowanceOutput,
   GetAllowanceOutput,
-  [FunctionKey.GET_TOKEN_ALLOWANCE, string, string]
+  UseGetAllowanceQueryKey
 >;
 
 const useGetAllowance = (
   {
-    accountAddress,
-    spenderAddress,
     tokenId,
+    spenderAddress,
+    accountAddress,
   }: Omit<IGetAllowanceInput, 'tokenContract'> & { tokenId: TokenId },
   options?: Options,
 ) => {
   const tokenContract = useTokenContract(tokenId);
 
   return useQuery(
-    [FunctionKey.GET_TOKEN_ALLOWANCE, spenderAddress, tokenId],
-    () => getAllowance({ tokenContract, spenderAddress, accountAddress }),
+    [
+      FunctionKey.GET_TOKEN_ALLOWANCE,
+      {
+        tokenId,
+        spenderAddress,
+      },
+    ],
+    () =>
+      getAllowance({
+        tokenContract,
+        spenderAddress,
+        accountAddress,
+      }),
     options,
   );
 };

--- a/src/components/v2/EnableToken/index.spec.tsx
+++ b/src/components/v2/EnableToken/index.spec.tsx
@@ -29,7 +29,7 @@ describe('components/EnableToken', () => {
   });
 
   it('renders content when token is enabled', async () => {
-    (getAllowance as jest.Mock).mockImplementationOnce(() => MAX_UINT256.toFixed());
+    (getAllowance as jest.Mock).mockImplementationOnce(() => MAX_UINT256);
 
     const { getByText } = renderComponent(
       <EnableToken vTokenId={fakeAsset.id} title="Enable token to proceed">

--- a/src/components/v2/EnableToken/index.tsx
+++ b/src/components/v2/EnableToken/index.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource @emotion/react */
 import React, { useContext } from 'react';
-import BigNumber from 'bignumber.js';
 import Typography from '@mui/material/Typography';
 
 import { useTranslation } from 'translation';
@@ -106,7 +105,7 @@ export const EnableToken: React.FC<EnableTokenProps> = ({ vTokenId, ...rest }) =
   );
 
   const isTokenApproved =
-    vTokenId === 'bnb' || (!!tokenAllowance && new BigNumber(tokenAllowance).isGreaterThan(0));
+    vTokenId === 'bnb' || (!!tokenAllowance && tokenAllowance.isGreaterThan(0));
 
   const { mutate: contractApproveToken, isLoading: isApproveTokenLoading } = useApproveToken({
     tokenId: vTokenId,

--- a/src/pages/ConvertVrt/Convert/index.spec.tsx
+++ b/src/pages/ConvertVrt/Convert/index.spec.tsx
@@ -20,7 +20,7 @@ describe('pages/ConvertVRT/Convert', () => {
   beforeEach(() => {
     jest.useFakeTimers('modern').setSystemTime(new Date('2022-03-01'));
     // Mark token as enabled
-    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256.toFixed());
+    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256);
     (useGetUserMarketInfo as jest.Mock).mockImplementation(() => ({
       data: {
         assets: assetData,

--- a/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/MintVai/index.spec.tsx
@@ -28,7 +28,7 @@ const fakeVaiTreasuryPercentage = 7.19;
 describe('pages/Dashboard/MintRepayVai/MintVai', () => {
   beforeEach(() => {
     // Mark token as enabled
-    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256.toFixed());
+    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256);
     (useGetUserMarketInfo as jest.Mock).mockImplementation(() => ({
       data: {
         assets: [...assetData, fakeVai],

--- a/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
+++ b/src/pages/Dashboard/MintRepayVai/RepayVai/index.spec.tsx
@@ -27,7 +27,7 @@ const fakeVai = { ...assetData, id: 'vai', symbol: 'VAI' };
 describe('pages/Dashboard/MintRepayVai/RepayVai', () => {
   beforeEach(() => {
     // Mark token as enabled
-    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256.toFixed());
+    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256);
     (useGetUserMarketInfo as jest.Mock).mockImplementation(() => ({
       data: {
         assets: [...assetData, fakeVai],

--- a/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Borrow/index.spec.tsx
@@ -31,7 +31,7 @@ jest.mock('hooks/useSuccessfulTransactionModal');
 describe('pages/Dashboard/BorrowRepayModal/Borrow', () => {
   beforeEach(() => {
     // Mark token as enabled
-    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256.toFixed());
+    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256);
     (useGetUserMarketInfo as jest.Mock).mockImplementation(() => ({
       data: {
         assets: [], // Not used in these tests

--- a/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/Repay/index.spec.tsx
@@ -27,7 +27,7 @@ jest.mock('hooks/useSuccessfulTransactionModal');
 describe('pages/Dashboard/BorrowRepayModal/Repay', () => {
   beforeEach(() => {
     // Mark token as enabled
-    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256.toFixed());
+    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256);
     (useGetUserMarketInfo as jest.Mock).mockImplementation(() => ({
       data: {
         assets: [],

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -41,7 +41,7 @@ jest.mock('hooks/useSuccessfulTransactionModal');
 describe('pages/Dashboard/SupplyWithdrawUi', () => {
   beforeEach(() => {
     // Mark token as enabled
-    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256.toFixed());
+    (getAllowance as jest.Mock).mockImplementation(() => MAX_UINT256);
     (useGetUserMarketInfo as jest.Mock).mockImplementation(() => ({
       data: {
         assets: [], // Not used in these tests

--- a/src/stories/decorators.tsx
+++ b/src/stories/decorators.tsx
@@ -10,7 +10,7 @@ import { Web3Wrapper } from 'clients/web3';
 import { MarketContextProvider } from 'context/MarketContext';
 import { VaiContextProvider } from 'context/VaiContext';
 import { AuthContext, IAuthContextValue } from 'context/AuthContext';
-import setCachedTokenAllowanceToMax from 'clients/api/mutations/useApproveToken/setCachedTokenAllowanceToMax';
+import setCachedTokenAllowanceToMax from 'clients/api/queries/getAllowance/setCachedTokenAllowanceToMax';
 import Theme from 'theme';
 // resolves mui theme issue in storybook https://github.com/mui/material-ui/issues/24282#issuecomment-952211989
 import { ThemeProvider as EmotionThemeProvider } from 'emotion-theming';


### PR DESCRIPTION
While testing the app, I realized enabling a token doesn't update the cache properly, thus not updating the UI correctly.
The issue came from an incorrect order of params that were used for the function key of the query that fetches the token allowance.
To fix the issue, the function key for the allowance query now passes the params as an object.

## Changes

- update function key of `useGetAllowance`
- move files related to the `getAllowance` query to a separate `getAllowance` folder within the API client directory
- change return type of `getAllowance` to be a `BigNumber` instead of a string
