### PR TITLE
Clear mocks between tests instead of resetting them

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,6 +186,8 @@
     ],
     "moduleNameMapper": {
       "^.+\\.css$": "<rootDir>/src/__mocks__/CSSStub.js"
-    }
+    },
+    "resetMocks": false,
+    "clearMocks": true
   }
 }

--- a/src/clients/api/__mocks__/index.ts
+++ b/src/clients/api/__mocks__/index.ts
@@ -120,7 +120,7 @@ export const getVoters = jest.fn();
 export const useGetVoters = () => useQuery(FunctionKey.GET_VOTERS, getVoters);
 
 export const getVoteReceipt = jest.fn();
-export const useVoteReceipt = () => useQuery(FunctionKey.GET_VOTE_RECEIPT, getVoteReceipt);
+export const useGetVoteReceipt = () => useQuery(FunctionKey.GET_VOTE_RECEIPT, getVoteReceipt);
 
 export const useGetVaults = jest.fn();
 
@@ -276,8 +276,6 @@ export const castVoteWithReason = jest.fn();
 export const useCastVoteWithReason = (options?: MutationObserverOptions) =>
   useMutation(FunctionKey.CAST_VOTE_WITH_REASON, castVoteWithReason, options);
 
-export const useVote = jest.fn().mockReturnValue({ vote: jest.fn() });
-
 export const stakeInVrtVault = jest.fn();
 export const useStakeInVrtVault = (options?: MutationObserverOptions) =>
   useMutation(FunctionKey.STAKE_IN_VRT_VAULT, stakeInVrtVault, options);
@@ -305,3 +303,5 @@ export const useExecuteWithdrawalFromXvsVault = (options?: MutationObserverOptio
     executeWithdrawalFromXvsVault,
     options,
   );
+
+export const useVote = jest.fn(() => ({ vote: jest.fn() }));

--- a/src/pages/Proposal/index.spec.tsx
+++ b/src/pages/Proposal/index.spec.tsx
@@ -2,10 +2,9 @@ import React from 'react';
 import renderComponent from 'testUtils/renderComponent';
 import Proposal from '.';
 
+jest.mock('clients/api');
+
 describe('pages/Proposal', () => {
-  beforeAll(() => {
-    jest.mock('clients/api');
-  });
   it('renders without crashing', async () => {
     renderComponent(<Proposal />);
   });

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,7 +2,3 @@
 // this adds jest-dom's custom assertions
 import '@testing-library/jest-dom';
 import 'jest-canvas-mock';
-
-beforeEach(() => {
-  jest.resetAllMocks();
-});


### PR DESCRIPTION
## Jira ticket(s)

N/A

## Changes

- remove logic that reset mocks between each test, in favor of clearing them instead (using Jest's config)
- fix mock for `useGetVoteReceipt` hook
