### PR TITLE
Better responsive card for market page

### DIFF
--- a/src/pages/Market/MarketTable/index.tsx
+++ b/src/pages/Market/MarketTable/index.tsx
@@ -22,7 +22,6 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
   const { t } = useTranslation();
   const sharedStyles = useSharedStyles();
   const localStyles = useLocalStyles();
-  const styles = { ...sharedStyles, ...localStyles };
 
   const columns = useMemo(
     () => [
@@ -66,7 +65,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
       markets.map(market => [
         {
           key: 'asset',
-          render: () => <Token tokenId={market.id as TokenId} css={styles.whiteText} />,
+          render: () => <Token tokenId={market.id as TokenId} css={localStyles.whiteText} />,
           value: market.id,
         },
         {
@@ -83,7 +82,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
                 minimizeDecimals: true,
                 shortenLargeValue: true,
               })}
-              css={styles.noWrap}
+              css={localStyles.noWrap}
             />
           ),
           align: 'right',
@@ -114,7 +113,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
                 minimizeDecimals: true,
                 shortenLargeValue: true,
               })}
-              css={styles.noWrap}
+              css={localStyles.noWrap}
             />
           ),
           value: market.treasuryTotalBorrowsCents.toFixed(),
@@ -134,7 +133,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
         {
           key: 'liquidity',
           render: () => (
-            <Typography variant="small1" css={styles.whiteText}>
+            <Typography variant="small1" css={localStyles.whiteText}>
               {formatCentsToReadableValue({
                 value: market.liquidity.multipliedBy(100),
                 shortenLargeValue: true,
@@ -147,7 +146,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
         {
           key: 'collateralFactor',
           render: () => (
-            <Typography variant="small1" css={styles.whiteText}>
+            <Typography variant="small1" css={localStyles.whiteText}>
               {formatToReadablePercentage(
                 convertPercentageFromSmartContract(market.collateralFactor),
               )}
@@ -159,7 +158,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
         {
           key: 'price',
           render: () => (
-            <Typography variant="small1" css={styles.whiteText}>
+            <Typography variant="small1" css={localStyles.whiteText}>
               {formatCentsToReadableValue({ value: market.tokenPrice.multipliedBy(100) })}
             </Typography>
           ),
@@ -183,7 +182,7 @@ export const MarketTableUi: React.FC<IMarketTableProps> = ({ markets, getRowHref
       getRowHref={getRowHref}
       tableCss={sharedStyles.table}
       cardsCss={sharedStyles.cards}
-      css={sharedStyles.cardContentGrid}
+      css={localStyles.cardContentGrid}
     />
   );
 };

--- a/src/pages/Market/MarketTable/styles.ts
+++ b/src/pages/Market/MarketTable/styles.ts
@@ -12,10 +12,24 @@ export const useStyles = () => {
         white-space: nowrap;
       }
     `,
-    cardContentGrid: `
+    cardContentGrid: css`
+      ${theme.breakpoints.down('xxl')} {
+        background-color: initial;
+        padding-top: 0;
+      }
+
       .table__table-cards__card-content {
-        grid-template-columns: 1fr 1fr 1fr;
-        grid-template-rows: 1fr;
+        ${theme.breakpoints.down('xxl')} {
+          grid-template-columns: 1fr 1fr 1fr 1fr;
+          grid-template-rows: 1fr 1fr;
+          row-gap: ${theme.spacing(5)};
+        }
+
+        ${theme.breakpoints.down('md')} {
+          grid-template-columns: 1fr 1fr 1fr;
+          grid-template-rows: 1fr 1fr;
+        }
+      }
     `,
   };
 };

--- a/src/pages/Market/styles.ts
+++ b/src/pages/Market/styles.ts
@@ -123,24 +123,5 @@ export const useStyles = () => {
         display: initial;
       }
     `,
-    cardContentGrid: css`
-      ${theme.breakpoints.down('xxl')} {
-        background-color: initial;
-        padding-top: 0;
-      }
-
-      .table__table-cards__card-content {
-        ${theme.breakpoints.down('xxl')} {
-          grid-template-columns: 1fr 1fr 1fr 1fr 1fr 1fr;
-          grid-template-rows: 1fr;
-          row-gap: ${theme.spacing(5)};
-        }
-
-        ${theme.breakpoints.down('md')} {
-          grid-template-columns: 1fr 1fr 1fr;
-          grid-template-rows: 1fr 1fr;
-        }
-      }
-    `,
   };
 };


### PR DESCRIPTION
## Changes
Current: 
<img width="553" alt="Screen Shot 2022-06-28 at 6 26 38 PM" src="https://user-images.githubusercontent.com/7258308/176300819-4710f98d-a639-49a5-9672-147369413c62.png">

New:
<img width="568" alt="Screen Shot 2022-06-28 at 6 25 00 PM" src="https://user-images.githubusercontent.com/7258308/176300210-d97287f4-27c3-47e0-93fc-0c92573866b4.png">

