### PR TITLE
Remove check if form is dirty

### DIFF
--- a/src/components/v2/Form/FormikSubmitButton.tsx
+++ b/src/components/v2/Form/FormikSubmitButton.tsx
@@ -14,8 +14,8 @@ export const FormikSubmitButton = ({
   disabled,
   ...rest
 }: Omit<IFormikSubmitButtonProps, 'type'>) => {
-  const { isValid, dirty } = useFormikContext();
-  const showDisableLabel = !isValid || !dirty; // loading disabled
+  const { isValid } = useFormikContext();
+  const showDisableLabel = !isValid;
   return (
     <Button variant={variant} {...rest} disabled={disabled || showDisableLabel} type="submit">
       {(showDisableLabel && disabledLabel) || enabledLabel}

--- a/src/containers/AmountForm/index.tsx
+++ b/src/containers/AmountForm/index.tsx
@@ -42,6 +42,7 @@ export const AmountForm: React.FC<IAmountFormProps> = ({
       }}
       onSubmit={handleSubmit}
       validationSchema={getValidationSchema(maxAmount)}
+      isInitialValid={false}
       validateOnMount
       validateOnChange
     >

--- a/src/pages/Vote/CreateProposalModal/index.tsx
+++ b/src/pages/Vote/CreateProposalModal/index.tsx
@@ -151,6 +151,7 @@ export const CreateProposal: React.FC<ICreateProposal> = ({
         onSubmit={handleCreateProposal}
         validateOnBlur
         validateOnMount
+        isInitialValid={false}
       >
         {({ errors }) => {
           const getErrorsByStep = useCallback(

--- a/src/pages/Vote/DelegateModal/index.tsx
+++ b/src/pages/Vote/DelegateModal/index.tsx
@@ -64,6 +64,7 @@ const DelegateModal: React.FC<IDelegateModalProps> = ({
           }}
           onSubmit={({ address }) => onSubmit(address)}
           validationSchema={addressValidationSchema}
+          isInitialValid={false}
           validateOnMount
           validateOnChange
         >


### PR DESCRIPTION
## Changes

This change fixes an issue with the form in the vote modal where it is not initially valid. 

This form should be initially valid and clean. Other forms should be initially invalid and the validation schema should run and set it valid if the criteria are met. If we need this check there may be another issue going on. I check other forms on the market page and this change rendered those forms initially disabled
