### PR TITLE
Render italic in markdown preview

### DIFF
--- a/src/components/v2/Markdown/previewOptions.ts
+++ b/src/components/v2/Markdown/previewOptions.ts
@@ -2,7 +2,7 @@ import rehypeSanitize from 'rehype-sanitize';
 
 const previewOptions = {
   skipHtml: true,
-  allowedElements: ['h1', 'h2', 'h3', 'h4', 'p', 'a', 'ul', 'li', 'strong', 'italic'],
+  allowedElements: ['h1', 'h2', 'h3', 'h4', 'p', 'a', 'ul', 'li', 'strong', 'em'],
   rehypePlugins: [rehypeSanitize],
 };
 


### PR DESCRIPTION
## Changes

Adds the `em` tag name to allowed elements for rendering italic
