### PR TITLE
Fix yearly earnings calculation

### DIFF
--- a/src/pages/Dashboard/MyAccount/index.tsx
+++ b/src/pages/Dashboard/MyAccount/index.tsx
@@ -44,6 +44,7 @@ const MyAccount: React.FC<IMyAccountProps> = ({
         isXvsEnabled,
         dailyXvsDistributionInterestsCents,
       });
+
     const netApyPercentage =
       userTotalSupplyBalanceCents &&
       yearlyEarningsCents &&

--- a/src/utilities/calculateYearlyEarnings.spec.ts
+++ b/src/utilities/calculateYearlyEarnings.spec.ts
@@ -3,25 +3,34 @@ import { assetData as assets } from '__mocks__/models/asset';
 import BigNumber from 'bignumber.js';
 import {
   calculateYearlyEarningsForAssets,
-  calculateYearlyEarningsCents,
+  calculateYearlyEarningsForAsset,
 } from './calculateYearlyEarnings';
 
 describe('utilities/calculateYearlyEarnings', () => {
   test('calculates yearly Earnings for single asset', () => {
-    const earnings = calculateYearlyEarningsCents({
+    const earnings = calculateYearlyEarningsForAsset({
       asset: assets[0] as Asset,
-      isXvsEnabled: true,
-      dailyXvsDistributionInterestsCents: new BigNumber('1'),
     });
-    expect(earnings?.toString()).toBe('371.01347989955426636283938');
+
+    expect(earnings.toFixed()).toMatchInlineSnapshot('"6.01347989955426636283938"');
   });
 
   test('calculates yearly Earnings for array of assets', () => {
     const earnings = calculateYearlyEarningsForAssets({
       assets: assets as Asset[],
+      isXvsEnabled: false,
+      dailyXvsDistributionInterestsCents: new BigNumber('1'),
+    });
+    expect(earnings?.toFixed()).toMatchInlineSnapshot('"-6.8460208090305522483859"');
+  });
+
+  test('calculates yearly Earnings for array of assets, including XVS distribution', () => {
+    const earnings = calculateYearlyEarningsForAssets({
+      assets: assets as Asset[],
       isXvsEnabled: true,
       dailyXvsDistributionInterestsCents: new BigNumber('1'),
     });
-    expect(earnings?.toString()).toBe('1453.1539791909694477516141');
+
+    expect(earnings?.toFixed()).toMatchInlineSnapshot('"358.1539791909694477516141"');
   });
 });

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -8,7 +8,7 @@ export { default as calculateNetApy } from './calculateNetApy';
 export { default as calculateDailyEarningsCents } from './calculateDailyEarningsCents';
 export {
   calculateYearlyEarningsForAssets,
-  calculateYearlyEarningsCents,
+  calculateYearlyEarningsForAsset,
 } from './calculateYearlyEarnings';
 export { default as calculateCollateralValue } from './calculateCollateralValue';
 export * from './generateBscScanUrl';


### PR DESCRIPTION
The yearly earnings were incorrectly calculated when including the XVS distribution: the daily XVS distribution was added to every earning associated with each asset, rather than being added to the total sum.