### PR TITLE
[VEN-298] No collateralized supplied tokens warning

### DIFF
--- a/src/__mocks__/models/asset.ts
+++ b/src/__mocks__/models/asset.ts
@@ -24,7 +24,7 @@ export const assetData: Asset[] = [
     walletBalance: new BigNumber('100'),
     supplyBalance: new BigNumber('90'),
     borrowBalance: new BigNumber('0'),
-    collateral: false,
+    collateral: true,
     percentOfLimit: '0',
     treasuryTotalBorrowsCents: new BigNumber('70925716.2839193373613181'),
     treasuryTotalSupplyCents: new BigNumber('278311516.880071415163614'),

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -44,6 +44,7 @@
         "title": "To borrow {{symbol}} to the Venus Protocol, you need to enable it first"
       },
       "highAmountWarning": "You entered a high amount, which puts you at risk of liquidation",
+      "noCollateralizedSuppliedAssetWarning": "You need to supply tokens and enable them as collateral before you can borrow {{tokenSymbol}} from the Venus protocol",
       "rightMaxButtonLabel": "{{limitPercentage}}% LIMIT",
       "submitButton": "Borrow",
       "submitButtonDisabled": "Enter a valid amount to borrow",


### PR DESCRIPTION
…lied tokens

## Jira ticket(s)

VEN-298

## Changes

- display warning message on borrow modal when user has no supplied and collateralized tokens
<img width="595" alt="Screen Shot 2022-07-04 at 12 34 20" src="https://user-images.githubusercontent.com/44675210/177146940-d4095c3f-89d6-4307-9d33-4923dbbc1ccd.png">

