### PR TITLE
Set collectCoverageFrom in Jest config

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,6 +171,10 @@
     "moduleNameMapper": {
       "^.+\\.css$": "<rootDir>/src/__mocks__/CSSStub.js"
     },
+    "collectCoverageFrom": [
+      "<rootDir>/src/**/*.{ts,tsx}",
+      "!<rootDir>/src/**/*.stories.tsx"
+    ],
     "resetMocks": false,
     "clearMocks": true
   }


### PR DESCRIPTION
## Jira ticket(s)

N/A

## Changes

- set `collectCoverageFrom` in Jest config so that stories are ignored
