### PR TITLE
[VEN-393] Use 8 decimals to display token values + improve responsiveness of LabeledInlineContent

### DIFF
--- a/src/components/LabeledInlineContent/index.tsx
+++ b/src/components/LabeledInlineContent/index.tsx
@@ -33,7 +33,7 @@ export const LabeledInlineContent = ({
 
       <Typography
         component="div"
-        css={[styles.column, styles.getContent({ invertTextColors })]}
+        css={[styles.column, styles.getContent({ invertTextColors, hasIcon: !!iconName })]}
         variant="body1"
       >
         {children}

--- a/src/components/LabeledInlineContent/styles.ts
+++ b/src/components/LabeledInlineContent/styles.ts
@@ -25,7 +25,6 @@ export const useStyles = () => {
         }
       }
     `,
-    iconColumn: css``,
     icon: css`
       width: ${theme.shape.iconSize.large}px;
       height: ${theme.shape.iconSize.large}px;

--- a/src/components/LabeledInlineContent/styles.ts
+++ b/src/components/LabeledInlineContent/styles.ts
@@ -20,7 +20,7 @@ export const useStyles = () => {
       align-items: center;
 
       ${theme.breakpoints.down('sm')} {
-        :first-of-type {
+        &:first-of-type {
           margin-bottom: ${theme.spacing(1)};
         }
       }

--- a/src/components/LabeledInlineContent/styles.ts
+++ b/src/components/LabeledInlineContent/styles.ts
@@ -10,11 +10,22 @@ export const useStyles = () => {
       align-items: center;
       justify-content: space-between;
       width: 100%;
+
+      ${theme.breakpoints.down('sm')} {
+        display: block;
+      }
     `,
     column: css`
       display: flex;
       align-items: center;
+
+      ${theme.breakpoints.down('sm')} {
+        :first-of-type {
+          margin-bottom: ${theme.spacing(1)};
+        }
+      }
     `,
+    iconColumn: css``,
     icon: css`
       width: ${theme.shape.iconSize.large}px;
       height: ${theme.shape.iconSize.large}px;
@@ -24,8 +35,19 @@ export const useStyles = () => {
     getLabel: ({ invertTextColors }: { invertTextColors: boolean }) => css`
       color: ${invertTextColors ? theme.palette.text.primary : theme.palette.text.secondary};
     `,
-    getContent: ({ invertTextColors }: { invertTextColors: boolean }) => css`
+    getContent: ({
+      invertTextColors,
+      hasIcon,
+    }: {
+      invertTextColors: boolean;
+      hasIcon: boolean;
+    }) => css`
       color: ${invertTextColors ? theme.palette.text.secondary : theme.palette.text.primary};
+
+      ${hasIcon &&
+      css`
+        margin-left: ${theme.spacing(7)};
+      `}
     `,
   };
 };

--- a/src/components/SuccessfulTransactionModal/styles.ts
+++ b/src/components/SuccessfulTransactionModal/styles.ts
@@ -26,13 +26,21 @@ export const useStyles = () => {
       display: flex;
       align-items: center;
       margin-bottom: ${theme.spacing(10)};
+
+      ${theme.breakpoints.down('sm')} {
+        display: block;
+      }
     `,
     amountContainer: css`
       display: flex;
       align-items: center;
+      margin-left: ${theme.spacing(2)};
+
+      ${theme.breakpoints.down('sm')} {
+        margin-left: 0;
+      }
     `,
     amountTokenIcon: css`
-      margin-left: ${theme.spacing(2)};
       margin-right: ${theme.spacing(1)};
     `,
   };

--- a/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/AccountData/index.tsx
@@ -167,7 +167,7 @@ const AccountData: React.FC<IAccountDataProps> = ({
 
       <LabeledInlineContent
         label={t('borrowRepayModal.borrow.dailyEarnings')}
-        css={styles.bottomRow}
+        css={styles.getRow({ isLast: true })}
       >
         <ValueUpdate
           original={dailyEarningsCents?.toNumber()}

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -24,6 +24,7 @@ import {
   calculateYearlyEarningsForAssets,
   calculateDailyEarningsCents,
   calculateCollateralValue,
+  getToken,
 } from 'utilities';
 import { useDailyXvsWei } from 'hooks/useDailyXvsWei';
 import { useStyles } from '../styles';
@@ -64,6 +65,9 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
   const styles = useStyles();
   const { t, Trans } = useTranslation();
   const { id: assetId } = asset;
+
+  const token = getToken(assetId);
+
   const amount = new BigNumber(amountValue || 0);
   const validAmount = amount && !amount.isZero() && !amount.isNaN();
 
@@ -201,7 +205,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
         <ValueUpdate original={dailyEarningsCents} update={hypotheticalDailyEarningCents} />
       </LabeledInlineContent>
       <LabeledInlineContent
-        label={t('supplyWithdraw.supplyBalance')}
+        label={t('supplyWithdraw.supplyBalance', { tokenSymbol: token.symbol })}
         css={styles.getRow({ isLast: true })}
         className="info-row"
       >
@@ -213,6 +217,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
               value,
               tokenId: asset.id,
               minimizeDecimals: true,
+              addSymbol: false,
             })
           }
         />

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/SupplyWithdrawForm.tsx
@@ -202,7 +202,7 @@ export const SupplyWithdrawContent: React.FC<ISupplyWithdrawFormUiProps> = ({
       </LabeledInlineContent>
       <LabeledInlineContent
         label={t('supplyWithdraw.supplyBalance')}
-        css={styles.bottomRow}
+        css={styles.getRow({ isLast: true })}
         className="info-row"
       >
         <ValueUpdate

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.spec.tsx
@@ -150,7 +150,7 @@ describe('pages/Dashboard/SupplyWithdrawUi', () => {
         },
       );
 
-      await waitFor(() => getByText(`1,000 ${fakeAsset.symbol.toUpperCase()}`));
+      await waitFor(() => getByText('1,000'));
     });
 
     it('disables submit button if an amount entered in input is higher than token wallet balance', async () => {

--- a/src/pages/Dashboard/Modals/styles.ts
+++ b/src/pages/Dashboard/Modals/styles.ts
@@ -35,15 +35,8 @@ export const useStyles = () => {
         margin-bottom: ${theme.spacing(isLast ? 6 : 3)};
 
         span {
-          font-size: 0.875rem;
+          font-size: ${theme.typography.small1.fontSize};
         }
-      }
-    `,
-    bottomRow: css`
-      margin-bottom: ${theme.spacing(12)};
-
-      ${theme.breakpoints.down('md')} {
-        margin-bottom: ${theme.spacing(8)};
       }
     `,
   };

--- a/src/pages/MarketDetails/__snapshots__/index.spec.tsx.snap
+++ b/src/pages/MarketDetails/__snapshots__/index.spec.tsx.snap
@@ -6,4 +6,4 @@ exports[`pages/MarketDetails fetches market details and displays them correctly 
 
 exports[`pages/MarketDetails fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`pages/MarketDetails fetches market details and displays them correctly 4`] = `"Market infoPrice$399.24Market liquidity$4,198,428.82# of suppliers144# of borrowers6Borrow capUncappedInterest paid/day$9,981.00Reserves0 AAVEReserve factor0%Collateral factor55%vAAVE minted52,965,104,736,226.06Exchange rate1 AAVE=4997145456.364805 vAAVE"`;
+exports[`pages/MarketDetails fetches market details and displays them correctly 4`] = `"Market infoPrice$399.24Market liquidity$4,198,428.82# of suppliers144# of borrowers6Borrow capUncappedInterest paid/day$9,981.00Reserves0 AAVEReserve factor0%Collateral factor55%vAAVE minted52,965,104,736,226.0635259Exchange rate1 AAVE=4997145456.364805 vAAVE"`;

--- a/src/pages/Proposal/VoteSummary/index.tsx
+++ b/src/pages/Proposal/VoteSummary/index.tsx
@@ -8,14 +8,7 @@ import Path from 'constants/path';
 import { convertWeiToTokens } from 'utilities';
 import { useTranslation } from 'translation';
 import { XVS_TOKEN_ID } from 'constants/xvs';
-import {
-  Button,
-  Icon,
-  LabeledInlineContent,
-  EllipseAddress,
-  Tooltip,
-  LabeledProgressBar,
-} from 'components';
+import { Button, Icon, EllipseAddress, Tooltip, LabeledProgressBar } from 'components';
 import { IVoter } from 'types';
 import { useStyles } from './styles';
 
@@ -79,9 +72,10 @@ const VoteSummary = ({
         </Button>
       </div>
 
-      <LabeledInlineContent label={t('voteSummary.addresses', { count: voters.length })}>
+      <div css={styles.votesHeader}>
+        <Typography>{t('voteSummary.addresses', { count: voters.length })}</Typography>
         <Typography>{t('voteSummary.votes')}</Typography>
-      </LabeledInlineContent>
+      </div>
 
       <ul css={styles.votesWrapper}>
         {voters.map(({ address, voteWeightWei, reason }) => (

--- a/src/pages/Proposal/VoteSummary/styles.ts
+++ b/src/pages/Proposal/VoteSummary/styles.ts
@@ -48,6 +48,10 @@ export const useStyles = () => {
         margin-bottom: 0;
       }
     `,
+    votesHeader: css`
+      display: flex;
+      justify-content: space-between;
+    `,
     votesWrapper: css`
       margin: 0;
       padding-left: 0;

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -368,7 +368,7 @@
     },
     "supply": "Supply",
     "supplyApy": "Supply APY",
-    "supplyBalance": "Supply Balance",
+    "supplyBalance": "Supply Balance ({{ tokenSymbol }})",
     "walletBalance": "Wallet balance: <White>{{amount}}</White>",
     "withdraw": "Withdraw",
     "withdrawableAmount": "Withdrawable amount: <White>{{amount}}</White>"

--- a/src/utilities/formatTokensToReadableValue.spec.ts
+++ b/src/utilities/formatTokensToReadableValue.spec.ts
@@ -10,22 +10,13 @@ describe('utilities/formatTokensToReadableValue', () => {
     expect(value).toBe('100,000.12333334 BUSD');
   });
 
-  test('formats shorthand value correctly great than 1', () => {
+  test('formats shorthand value correctly', () => {
     const value = formatTokensToReadableValue({
-      value: new BigNumber(1000.1234),
-      tokenId: 'eth',
-      minimizeDecimals: true,
-    });
-    expect(value).toBe('1,000.12 ETH');
-  });
-
-  test('formats shorthand value correctly less than 1', () => {
-    const value = formatTokensToReadableValue({
-      value: new BigNumber(0.1234),
+      value: new BigNumber(0.1234567899999),
       tokenId: 'ada',
       minimizeDecimals: true,
     });
-    expect(value).toBe('0.1234 ADA');
+    expect(value).toBe('0.12345679 ADA');
   });
 
   test('removes trailing zeros', () => {

--- a/src/utilities/formatTokensToReadableValue.ts
+++ b/src/utilities/formatTokensToReadableValue.ts
@@ -23,9 +23,7 @@ export const formatTokensToReadableValue = ({
 
   let decimalPlaces;
   if (minimizeDecimals) {
-    // If value is greater than 1, use 2 decimal places, otherwise use 8
-    // see (https://app.clickup.com/24381231/v/dc/q81tf-9288/q81tf-1128)
-    decimalPlaces = value.gt(1) ? 2 : 8;
+    decimalPlaces = 8;
   } else {
     const token = getToken(tokenId);
     decimalPlaces = token.decimals;


### PR DESCRIPTION
## Jira ticket(s)

VEN-393

## Changes

- always use 8 decimals at minimum to display token values
- display columns of `LabeledInlineContent` as rows on mobile to gain horizontal space
- update how supply balance is displayed on Supply form so it takes less horizontal space (token symbol is now displayed in the header rather than next to each token value)