### PR TITLE
[VEN-382] Format action signature on frontend

### DIFF
--- a/src/__mocks__/api/proposals.json
+++ b/src/__mocks__/api/proposals.json
@@ -7,7 +7,7 @@
       "actions": [
         {
           "data": "0x000000000000000000000000276425aff4214570b622a3502a62ffc52848df19",
-          "signature": "_setPriceOracle(address)",
+          "signature": "_setPriceOracle",
           "target": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",
           "title": "[Unitroller](https://testnet.bscscan.com/address/0x94d1820b2D1c7c7452A163983Dc888CEC546b77D)._setPriceOracle(\"0x276425afF4214570b622A3502a62fFC52848dF19\")",
           "value": "0"

--- a/src/clients/api/queries/getProposals/__snapshots__/getProposal.spec.ts.snap
+++ b/src/clients/api/queries/getProposals/__snapshots__/getProposal.spec.ts.snap
@@ -6,7 +6,7 @@ Object {
   "actions": Array [
     Object {
       "data": "0x000000000000000000000000276425aff4214570b622a3502a62ffc52848df19",
-      "signature": "_setPriceOracle(address)",
+      "signature": "_setPriceOracle",
       "target": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",
       "title": "[Unitroller](https://testnet.bscscan.com/address/0x94d1820b2D1c7c7452A163983Dc888CEC546b77D)._setPriceOracle(\\"0x276425afF4214570b622A3502a62fFC52848dF19\\")",
       "value": "0",

--- a/src/clients/api/queries/getProposals/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getProposals/__snapshots__/index.spec.ts.snap
@@ -10,7 +10,7 @@ Object {
       "actions": Array [
         Object {
           "data": "0x000000000000000000000000276425aff4214570b622a3502a62ffc52848df19",
-          "signature": "_setPriceOracle(address)",
+          "signature": "_setPriceOracle",
           "target": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",
           "title": "[Unitroller](https://testnet.bscscan.com/address/0x94d1820b2D1c7c7452A163983Dc888CEC546b77D)._setPriceOracle(\\"0x276425afF4214570b622A3502a62fFC52848dF19\\")",
           "value": "0",
@@ -314,7 +314,7 @@ Object {
       "actions": Array [
         Object {
           "data": "0x000000000000000000000000276425aff4214570b622a3502a62ffc52848df19",
-          "signature": "_setPriceOracle(address)",
+          "signature": "_setPriceOracle",
           "target": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",
           "title": "[Unitroller](https://testnet.bscscan.com/address/0x94d1820b2D1c7c7452A163983Dc888CEC546b77D)._setPriceOracle(\\"0x276425afF4214570b622A3502a62fFC52848dF19\\")",
           "value": "0",

--- a/src/components/ReadableActionSignature/formatSignature.ts
+++ b/src/components/ReadableActionSignature/formatSignature.ts
@@ -1,0 +1,39 @@
+import { ethers } from 'ethers';
+import type { Result } from '@ethersproject/abi';
+import { FormValues } from 'pages/Vote/CreateProposalModal/proposalSchema';
+import { IProposalAction } from 'types';
+
+const formatSignature = (action: FormValues['actions'][number] | IProposalAction) => {
+  try {
+    const fragment = ethers.utils.FunctionFragment.from(action.signature || '');
+    let args: Result = [];
+
+    if (Array.isArray(action.data)) {
+      args = fragment.inputs.map((i, idx) => {
+        if (i.baseType === 'string' || i.baseType === 'address') {
+          return `"${action.data[idx]}"`;
+        }
+        return action.data[idx];
+      });
+    } else {
+      const unformattedArgs = ethers.utils.defaultAbiCoder.decode(
+        fragment.inputs.map(input => input.baseType),
+        action.data,
+      );
+      args = fragment.inputs.map((i, idx) => {
+        if (i.baseType === 'string' || i.baseType === 'address') {
+          return `"${unformattedArgs[idx]}"`;
+        }
+        return unformattedArgs[idx];
+      });
+    }
+
+    return `.${fragment.name}(${args.join(', ')})`;
+  } catch (err) {
+    console.log(err);
+  }
+
+  return '';
+};
+
+export default formatSignature;

--- a/src/components/ReadableActionSignature/getContractName.ts
+++ b/src/components/ReadableActionSignature/getContractName.ts
@@ -9,9 +9,9 @@ const checkAndFormatContractName = (
   addressJson: typeof contractAddresses | typeof tokenAddresses | typeof vBepTokensAddresses,
 ) => {
   const found = Object.entries(addressJson).find(
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    ([key, value]) => value[CHAIN_ID].toLowerCase() === target.toLowerCase(),
+    entry => entry[1][CHAIN_ID].toLowerCase() === target.toLowerCase(),
   );
+
   if (found) {
     const name = found[0];
     return `${name.charAt(0).toUpperCase()}${name.slice(1)}`;
@@ -20,6 +20,7 @@ const checkAndFormatContractName = (
 
 const getContractName = (target: string) => {
   let contractName;
+
   if (web3.utils.isAddress(target)) {
     // Check main contracts
     contractName = checkAndFormatContractName(target, contractAddresses);
@@ -27,11 +28,13 @@ const getContractName = (target: string) => {
     if (!contractName) {
       contractName = checkAndFormatContractName(target, tokenAddresses);
     }
+
     if (!contractName) {
       // check v contracts
       contractName = checkAndFormatContractName(target, vBepTokensAddresses);
     }
   }
+
   return contractName || target;
 };
 

--- a/src/components/ReadableActionSignature/index.tsx
+++ b/src/components/ReadableActionSignature/index.tsx
@@ -1,0 +1,38 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+import { Typography } from '@mui/material';
+import { IProposalAction } from 'types';
+import { generateBscScanUrl } from 'utilities';
+import { FormValues } from 'pages/Vote/CreateProposalModal/proposalSchema';
+import formatSignature from './formatSignature';
+import getContractName from './getContractName';
+import { useStyles } from './styles';
+
+interface IReadableActionSignatureProps {
+  action: FormValues['actions'][number] | IProposalAction;
+  className?: string;
+}
+
+export const ReadableActionSignature: React.FC<IReadableActionSignatureProps> = ({
+  action,
+  className,
+}) => {
+  const styles = useStyles();
+  return (
+    <Typography
+      css={styles.signature}
+      className={className}
+      key={`${action.signature}-${action.target}`}
+    >
+      <Typography
+        component="a"
+        href={generateBscScanUrl(action.target, 'address')}
+        target="_blank"
+        rel="noreferrer"
+      >
+        {getContractName(action.target)}
+      </Typography>
+      {formatSignature(action)}
+    </Typography>
+  );
+};

--- a/src/components/ReadableActionSignature/styles.ts
+++ b/src/components/ReadableActionSignature/styles.ts
@@ -1,0 +1,19 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+  return {
+    signature: css`
+      color: ${theme.palette.text.primary};
+      overflow-wrap: break-word;
+
+      > a {
+        color: ${theme.palette.interactive.success};
+        :hover {
+          color: ${theme.palette.interactive.success50};
+        }
+      }
+    `,
+  };
+};

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,5 +1,6 @@
 export * from './Accordion';
 export * from './ActiveVotingProgress';
+export * from './ReadableActionSignature';
 export * from './charts/ApyChart';
 export * from './charts/InterestRateChart';
 export * from './AuthModal';

--- a/src/pages/Proposal/Description/index.tsx
+++ b/src/pages/Proposal/Description/index.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Paper } from '@mui/material';
 import Typography from '@mui/material/Typography';
-import { MarkdownViewer } from 'components';
+import { MarkdownViewer, ReadableActionSignature } from 'components';
 import { useTranslation } from 'translation';
 import { DescriptionV1, DescriptionV2, IProposalAction } from 'types';
 import { useStyles } from './styles';
@@ -47,12 +47,13 @@ export const Description: React.FC<IDescriptionSummary> = ({ className, descript
             </ul>
           </>
         )}
+
         <Typography variant="h4" color="textSecondary" css={styles.section}>
           {t('voteProposalUi.operation')}
         </Typography>
 
-        {actions.map(({ title }) => (
-          <MarkdownViewer key={title} css={[styles.markdown, styles.actionTitle]} content={title} />
+        {actions.map(action => (
+          <ReadableActionSignature action={action} />
         ))}
       </div>
     </Paper>

--- a/src/pages/Proposal/index.spec.tsx
+++ b/src/pages/Proposal/index.spec.tsx
@@ -25,6 +25,7 @@ import TEST_IDS from './testIds';
 jest.mock('clients/api');
 jest.mock('hooks/useVote');
 
+const incorrectAction = proposals[0];
 const activeProposal = proposals[1];
 const cancelledProposal = proposals[3];
 const succeededProposal = proposals[4];
@@ -69,6 +70,11 @@ describe('pages/Proposal', () => {
   });
 
   it('renders without crashing', async () => {
+    renderComponent(<Proposal />);
+  });
+
+  it('renders without crashing on', async () => {
+    (getProposal as jest.Mock).mockImplementation(() => incorrectAction);
     renderComponent(<Proposal />);
   });
 

--- a/src/pages/Vote/CreateProposalModal/ActionAccordion/CallDataFields.tsx
+++ b/src/pages/Vote/CreateProposalModal/ActionAccordion/CallDataFields.tsx
@@ -29,10 +29,10 @@ const CallDataFields: React.FC<ICallDataFieldsProps> = ({ signature, actionIndex
 
   return (
     <FieldArray
-      name="callData"
+      name="data"
       render={() =>
         callDataTypes.map((param, idx) => {
-          const name = `actions.${actionIndex}.callData.${idx}`;
+          const name = `actions.${actionIndex}.data.${idx}`;
           return (
             <FormikTextField
               key={name}

--- a/src/pages/Vote/CreateProposalModal/ActionAccordion/index.tsx
+++ b/src/pages/Vote/CreateProposalModal/ActionAccordion/index.tsx
@@ -14,19 +14,19 @@ const ActionAccordion: React.FC = () => {
   const [expandedIdx, setExpanded] = React.useState<number | undefined>(0);
 
   const [{ value: actions }, { error: errors }, { setValue }] =
-    useField<{ address: string; signature: string; callData: string[] }[]>('actions');
+    useField<{ target: string; signature: string; data: string[] }[]>('actions');
 
   const handleBlurSignature: React.FocusEventHandler<HTMLInputElement> = () => {
     const actionsCopy = [...actions];
     if (expandedIdx !== undefined) {
       const actionCopy = actionsCopy[expandedIdx];
-      const { signature, callData } = actionCopy;
+      const { signature, data } = actionCopy;
       // When we blur the signature, clean up extra fields
-      if (callData) {
+      if (data) {
         try {
           const fragment = ethers.utils.FunctionFragment.from(signature || '');
           const numberOfInputs = fragment.inputs.length;
-          actionsCopy[expandedIdx].callData = callData.slice(0, numberOfInputs);
+          actionsCopy[expandedIdx].data = data.slice(0, numberOfInputs);
           setValue(actionsCopy);
         } catch (err) {
           // eslint-disable-next-line no-console
@@ -60,7 +60,7 @@ const ActionAccordion: React.FC = () => {
                   css={styles.accordion}
                 >
                   <FormikTextField
-                    name={`actions.${idx}.address`}
+                    name={`actions.${idx}.target`}
                     data-testid={`actions.${idx}.address`}
                     placeholder={t('vote.createProposalForm.address')}
                     maxLength={42}

--- a/src/pages/Vote/CreateProposalModal/ProposalPreview/index.tsx
+++ b/src/pages/Vote/CreateProposalModal/ProposalPreview/index.tsx
@@ -1,25 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import React from 'react';
 import { Typography } from '@mui/material';
-import { ethers } from 'ethers';
 import { useFormikContext } from 'formik';
-import { MarkdownViewer } from 'components';
-import { generateBscScanUrl } from 'utilities';
+import { ReadableActionSignature, MarkdownViewer } from 'components';
 import { useTranslation } from 'translation';
 import { FormValues } from '../proposalSchema';
 import { useStyles } from './styles';
-import getContractName from './getContractName';
-
-const formatSignature = (action: FormValues['actions'][number]) => {
-  const fragment = ethers.utils.FunctionFragment.from(action.signature || '');
-  const args = fragment.inputs.map((i, idx) => {
-    if (i.baseType === 'string') {
-      return `"${action.callData[idx]}"`;
-    }
-    return action.callData[idx];
-  });
-  return `${fragment.name}(${args.join(', ')})`;
-};
 
 const ProposalPreview: React.FC = () => {
   const styles = useStyles();
@@ -83,20 +69,7 @@ const ProposalPreview: React.FC = () => {
         </Typography>
 
         {actions.map(action => (
-          <React.Fragment key={`${action.signature}-${action.address}`}>
-            <Typography css={styles.signature}>
-              <Typography
-                component="a"
-                href={generateBscScanUrl(action.address, 'address')}
-                target="_blank"
-                rel="noreferrer"
-              >
-                {getContractName(action.address)}.
-              </Typography>
-
-              {formatSignature(action)}
-            </Typography>
-          </React.Fragment>
+          <ReadableActionSignature action={action} />
         ))}
       </div>
     </div>

--- a/src/pages/Vote/CreateProposalModal/formatProposalPayload.ts
+++ b/src/pages/Vote/CreateProposalModal/formatProposalPayload.ts
@@ -33,10 +33,10 @@ const formatProposalPayload = (data: FormValues) => {
   };
 
   data.actions.forEach(action => {
-    payload.targets.push(action.address);
+    payload.targets.push(action.target);
     payload.signatures.push(action.signature);
-    if (action.callData !== undefined) {
-      payload.callDatas.push(encodeCallData(action.signature, action.callData));
+    if (action.data !== undefined) {
+      payload.callDatas.push(encodeCallData(action.signature, action.data));
     }
   });
 

--- a/src/pages/Vote/CreateProposalModal/index.spec.tsx
+++ b/src/pages/Vote/CreateProposalModal/index.spec.tsx
@@ -150,11 +150,11 @@ describe('pages/Proposal/CreateProposalModal', () => {
       fireEvent.change(addressInput0, { target: { value: fakeAddress } });
       fireEvent.change(signatureInput0, { target: { value: fakeSignature } });
 
-      const callDataInput0 = await waitFor(() => getByTestId('actions.0.callData.0'));
-      const callDataInput1 = await waitFor(() => getByTestId('actions.0.callData.1'));
+      const dataInput0 = await waitFor(() => getByTestId('actions.0.data.0'));
+      const dataInput1 = await waitFor(() => getByTestId('actions.0.data.1'));
 
-      await fireEvent.change(callDataInput0, { target: { value: 'root' } });
-      await fireEvent.change(callDataInput1, { target: { value: 'false' } });
+      await fireEvent.change(dataInput0, { target: { value: 'root' } });
+      await fireEvent.change(dataInput1, { target: { value: 'false' } });
 
       await waitFor(() => expect(addActionButton).toBeEnabled());
       await waitFor(() => fireEvent.click(addActionButton));
@@ -197,11 +197,11 @@ describe('pages/Proposal/CreateProposalModal', () => {
       fireEvent.change(addressInput0, { target: { value: fakeAddress } });
       fireEvent.change(signatureInput0, { target: { value: fakeSignature } });
 
-      const callDataInput0 = await waitFor(() => getByTestId('actions.0.callData.0'));
-      const callDataInput1 = await waitFor(() => getByTestId('actions.0.callData.1'));
+      const dataInput0 = await waitFor(() => getByTestId('actions.0.data.0'));
+      const dataInput1 = await waitFor(() => getByTestId('actions.0.data.1'));
 
-      await fireEvent.change(callDataInput0, { target: { value: 'root' } });
-      await fireEvent.change(callDataInput1, { target: { value: 'false' } });
+      await fireEvent.change(dataInput0, { target: { value: 'root' } });
+      await fireEvent.change(dataInput1, { target: { value: 'false' } });
 
       await waitFor(() => fireEvent.click(addActionButton));
     });
@@ -256,11 +256,11 @@ describe('pages/Proposal/CreateProposalModal', () => {
       await fireEvent.change(addressInput0, { target: { value: fakeAddress } });
       await fireEvent.change(signatureInput0, { target: { value: fakeSignature } });
 
-      const callDataInput0 = await waitFor(() => getByTestId('actions.0.callData.0'));
-      const callDataInput1 = await waitFor(() => getByTestId('actions.0.callData.1'));
+      const dataInput0 = await waitFor(() => getByTestId('actions.0.data.0'));
+      const dataInput1 = await waitFor(() => getByTestId('actions.0.data.1'));
 
-      await fireEvent.change(callDataInput0, { target: { value: 'root' } });
-      await fireEvent.change(callDataInput1, { target: { value: 'false' } });
+      await fireEvent.change(dataInput0, { target: { value: 'root' } });
+      await fireEvent.change(dataInput1, { target: { value: 'false' } });
     });
 
     await waitFor(() => expect(addActionButton).toBeEnabled()); // failing

--- a/src/pages/Vote/CreateProposalModal/index.tsx
+++ b/src/pages/Vote/CreateProposalModal/index.tsx
@@ -140,7 +140,7 @@ export const CreateProposal: React.FC<ICreateProposal> = ({
     >
       <Formik
         initialValues={{
-          actions: [{ address: '', signature: '', callData: [] }],
+          actions: [{ target: '', signature: '', data: [] }],
           description: '',
           forDescription: '',
           againstDescription: '',

--- a/src/pages/Vote/CreateProposalModal/proposalSchema.ts
+++ b/src/pages/Vote/CreateProposalModal/proposalSchema.ts
@@ -15,7 +15,7 @@ const proposalSchema = yup.object({
     .array()
     .of(
       yup.object({
-        address: yup
+        target: yup
           .string()
           .required()
           .test('isAddress', ErrorCode.ACTION_ADDRESS_NOT_VALID, value =>
@@ -30,7 +30,7 @@ const proposalSchema = yup.object({
           )
           .required(),
         // @TODO add specific validation and errors for specific types
-        callData: yup
+        data: yup
           .array()
           .of(
             yup.string().test({
@@ -39,14 +39,14 @@ const proposalSchema = yup.object({
               test(value) {
                 let valid = true;
                 try {
-                  const callDataTypes =
+                  const dataTypes =
                     // @ts-expect-error The yup type doesn't show this value exists but it does @TODO extend type
                     parseFunctionSignature(this.options.from[0].value.signature)?.inputs.map(
                       input => input.type,
                     ) || [];
                   encodeParameters(
                     // @ts-expect-error The yup type doesn't show this value exists but it does @TODO extend type
-                    [callDataTypes[this.options.index]],
+                    [dataTypes[this.options.index]],
                     [formatIfArray(value || '')],
                   );
                 } catch (error) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -82,7 +82,6 @@ export interface IProposalAction {
   data: string;
   signature: string;
   target: string;
-  title: string;
   value: string;
 }
 


### PR DESCRIPTION
## Jira ticket(s)

VEN-382

## Changes

- Renames create proposal form field so action shape resembles the shape returned from the backend
- Removes reliance on returned formatted title and formats the action signature on the frontend. This removes the need to keep contract addresses synced on the frontend and backend.
