### PR TITLE
Rollback to previous testnet provider URL

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -30,9 +30,7 @@ export const RPC_URLS: {
     'https://bsc-dataseed.binance.org',
   ],
   [BscChainId.TESTNET]: [
-    'https://data-seed-prebsc-1-s1.binance.org:8545/',
-    'https://data-seed-prebsc-2-s1.binance.org:8545/',
-    'https://data-seed-prebsc-1-s2.binance.org:8545/',
+    'https://speedy-nodes-nyc.moralis.io/6c1fe2e962cdccfe0e93dcb3/bsc/testnet',
   ],
 };
 


### PR DESCRIPTION
## Jira ticket(s)

N/A

## Changes

- use previous provider URL, now that it seems to have been fixed by Moralis
