### PR TITLE
Update testnet RPC provider URL

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -29,9 +29,7 @@ export const RPC_URLS: {
     'https://bsc-dataseed1.defibit.io',
     'https://bsc-dataseed.binance.org',
   ],
-  [BscChainId.TESTNET]: [
-    'https://speedy-nodes-nyc.moralis.io/6c1fe2e962cdccfe0e93dcb3/bsc/testnet',
-  ],
+  [BscChainId.TESTNET]: ['https://nd-455-325-283.p2pify.com/ebbd4659d49aea838496ce7f01531063'],
 };
 
 export const RPC_URL = sample(RPC_URLS[CHAIN_ID]) as string;


### PR DESCRIPTION
Moralis have now disabled their Speedy Nodes for free tiers, so this PR updates the RPC provider URL used on testnet to one from another free provider.