### PR TITLE
Copy files necessary to build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 COPY package.json ./
 COPY yarn.lock ./
+COPY src/constants/contracts/abis ./src/constants/contracts/abis
+COPY patches ./patches
 
 RUN yarn
 


### PR DESCRIPTION
The last update of the Docker file has broke the pipelines in Jenkins because the contract ABIs and the patches no longer get copied before starting the installation process, making the post install operations fail.