### PR TITLE
Add max length to vote reason

### DIFF
--- a/src/pages/Proposal/VoteModal/index.tsx
+++ b/src/pages/Proposal/VoteModal/index.tsx
@@ -88,6 +88,7 @@ const VoteModal: React.FC<VoteModalProps> = ({
               name="reason"
               id="reason"
               placeholder={t('vote.addComment')}
+              maxLength={256}
               css={styles.comment}
             />
             <FormikSubmitButton


### PR DESCRIPTION
- add `maxLength` property to vote reason input so users can't enter a reason message that's longer than the maximum length supported by the database (256 characters)
