### PR TITLE
Prevent wallet logo from expending in auth modal

### DIFF
--- a/src/components/AuthModal/AccountDetails/styles.ts
+++ b/src/components/AuthModal/AccountDetails/styles.ts
@@ -25,6 +25,7 @@ export const useStyles = () => {
     `,
     walletLogo: css`
       width: ${theme.spacing(12)};
+      height: auto;
       margin-right: ${theme.spacing(4)};
       flex-shrink: 0;
 


### PR DESCRIPTION
## Changes

- add CSS rule to prevent SVG icon of wallet logo in auth modal from taking all the vertical space available (bug observed with InfinityWallet' logo icon)
