### PR TITLE
[VEN-493] Create CellGroup and InfoIcon components

### DIFF
--- a/src/components/CellGroup/index.stories.tsx
+++ b/src/components/CellGroup/index.stories.tsx
@@ -1,0 +1,40 @@
+import { ComponentMeta } from '@storybook/react';
+import React from 'react';
+
+import { withCenterStory, withRouter } from 'stories/decorators';
+
+import { Cell, CellGroup } from '.';
+
+export default {
+  title: 'Components/CellGroup',
+  component: CellGroup,
+  decorators: [withRouter, withCenterStory({ width: '100%' })],
+  parameters: {
+    backgrounds: {
+      default: 'Primary',
+    },
+  },
+} as ComponentMeta<typeof CellGroup>;
+
+const cells: Cell[] = [
+  {
+    label: 'Total supply',
+    value: '$1,000,000',
+  },
+  {
+    label: 'Total borrow',
+    value: '$1,000',
+  },
+  {
+    label: 'Available Liquidity',
+    value: '$999,000',
+  },
+  {
+    label: 'Total treasury',
+    value: '$1,000',
+  },
+];
+
+export const Default = () => <CellGroup cells={cells} />;
+
+export const WithTitle = () => <CellGroup cells={cells} title="Summary" />;

--- a/src/components/CellGroup/index.stories.tsx
+++ b/src/components/CellGroup/index.stories.tsx
@@ -20,10 +20,12 @@ const cells: Cell[] = [
   {
     label: 'Total supply',
     value: '$1,000,000',
+    tooltip: 'This is a fake tooltip',
   },
   {
     label: 'Total borrow',
     value: '$1,000',
+    color: 'green',
   },
   {
     label: 'Available Liquidity',
@@ -38,3 +40,5 @@ const cells: Cell[] = [
 export const Default = () => <CellGroup cells={cells} />;
 
 export const WithTitle = () => <CellGroup cells={cells} title="Summary" />;
+
+export const WithSmallValues = () => <CellGroup cells={cells} smallValues />;

--- a/src/components/CellGroup/index.tsx
+++ b/src/components/CellGroup/index.tsx
@@ -1,0 +1,42 @@
+/** @jsxImportSource @emotion/react */
+import { Paper, Typography } from '@mui/material';
+import React from 'react';
+
+import { useStyles } from './styles';
+
+export interface Cell {
+  label: string;
+  value: string | number;
+  color?: string;
+}
+
+export interface NumberCellGroupProps {
+  cells: Cell[];
+  title?: string;
+}
+
+export const CellGroup: React.FC<NumberCellGroupProps> = ({ cells, title }) => {
+  const styles = useStyles();
+
+  return (
+    <Paper css={styles.container}>
+      {!!title && <h4 css={styles.title}>{title}</h4>}
+
+      <div css={styles.cellContainer}>
+        {cells.map(({ label, value }) => (
+          <div css={styles.cell}>
+            <Typography variant="body2" css={styles.label} component="div">
+              {label}
+            </Typography>
+
+            <Typography variant="h3" css={styles.value}>
+              {value}
+            </Typography>
+          </div>
+        ))}
+      </div>
+    </Paper>
+  );
+};
+
+export default CellGroup;

--- a/src/components/CellGroup/index.tsx
+++ b/src/components/CellGroup/index.tsx
@@ -12,6 +12,7 @@ export interface Cell {
 
 export interface NumberCellGroupProps {
   cells: Cell[];
+  tooltip?: string;
   title?: string;
 }
 

--- a/src/components/CellGroup/index.tsx
+++ b/src/components/CellGroup/index.tsx
@@ -2,35 +2,47 @@
 import { Paper, Typography } from '@mui/material';
 import React from 'react';
 
+import { InfoIcon } from '../InfoIcon';
 import { useStyles } from './styles';
 
 export interface Cell {
   label: string;
   value: string | number;
+  tooltip?: string;
   color?: string;
 }
 
 export interface NumberCellGroupProps {
   cells: Cell[];
-  tooltip?: string;
+  smallValues?: boolean;
   title?: string;
+  className?: string;
 }
 
-export const CellGroup: React.FC<NumberCellGroupProps> = ({ cells, title }) => {
+export const CellGroup: React.FC<NumberCellGroupProps> = ({
+  cells,
+  title,
+  smallValues = false,
+  className,
+}) => {
   const styles = useStyles();
 
   return (
-    <Paper css={styles.container}>
+    <Paper css={styles.container} className={className}>
       {!!title && <h4 css={styles.title}>{title}</h4>}
 
       <div css={styles.cellContainer}>
-        {cells.map(({ label, value }) => (
+        {cells.map(({ label, value, tooltip, color }) => (
           <div css={styles.cell}>
-            <Typography variant="body2" css={styles.label} component="div">
-              {label}
-            </Typography>
+            <div css={styles.labelContainer}>
+              <Typography variant="body2" css={styles.label}>
+                {label}
+              </Typography>
 
-            <Typography variant="h3" css={styles.value}>
+              {!!tooltip && <InfoIcon tooltip={tooltip} css={styles.labelInfoIcon} />}
+            </div>
+
+            <Typography variant={smallValues ? 'h4' : 'h3'} css={styles.getValue({ color })}>
               {value}
             </Typography>
           </div>

--- a/src/components/CellGroup/styles.ts
+++ b/src/components/CellGroup/styles.ts
@@ -5,7 +5,7 @@ export const useStyles = () => {
   const theme = useTheme();
   return {
     container: css`
-      ${theme.breakpoints.down('lg')} {
+      ${theme.breakpoints.down('xxl')} {
         padding: 0;
         background-color: transparent;
       }
@@ -17,10 +17,14 @@ export const useStyles = () => {
       display: flex;
       flex-wrap: wrap;
 
-      ${theme.breakpoints.down('lg')} {
+      ${theme.breakpoints.down('xxl')} {
         display: grid;
         grid-template-columns: 1fr 1fr;
         grid-gap: ${theme.spacing(2)};
+      }
+
+      ${theme.breakpoints.down('md')} {
+        grid-template-columns: 1fr;
       }
     `,
     cell: css`
@@ -39,7 +43,7 @@ export const useStyles = () => {
         border-right: 1px solid ${theme.palette.interactive.delimiter};
       }
 
-      ${theme.breakpoints.down('lg')} {
+      ${theme.breakpoints.down('xxl')} {
         border-radius: ${theme.spacing(4)};
         padding: ${theme.spacing(4)};
         background-color: ${theme.palette.background.paper};
@@ -57,21 +61,23 @@ export const useStyles = () => {
         }
       }
     `,
+    labelContainer: css`
+      display: flex;
+      align-items: center;
+      margin-bottom: ${theme.spacing(1)};
+    `,
     label: css`
       color: ${theme.palette.text.secondary};
-      margin-bottom: ${theme.spacing(1)};
 
-      ${theme.breakpoints.down('xl')} {
+      ${theme.breakpoints.down('xxl')} {
         font-size: ${theme.typography.small1.fontSize};
       }
     `,
-    value: css`
-      ${theme.breakpoints.down('xl')} {
-        font-size: ${theme.typography.body2.fontSize};
-        font-weight: ${theme.typography.body2.fontWeight};
-        letter-spacing: ${theme.typography.body2.letterSpacing};
-        color: ${theme.palette.text.primary};
-      }
+    labelInfoIcon: css`
+      margin-left: ${theme.spacing(2)};
+    `,
+    getValue: ({ color }: { color?: string }) => css`
+      color: ${color || theme.palette.text.primary};
     `,
   };
 };

--- a/src/components/CellGroup/styles.ts
+++ b/src/components/CellGroup/styles.ts
@@ -1,0 +1,77 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+  return {
+    container: css`
+      ${theme.breakpoints.down('lg')} {
+        padding: 0;
+        background-color: transparent;
+      }
+    `,
+    title: css`
+      margin-bottom: ${theme.spacing(4)};
+    `,
+    cellContainer: css`
+      display: flex;
+      flex-wrap: wrap;
+
+      ${theme.breakpoints.down('lg')} {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        grid-gap: ${theme.spacing(2)};
+      }
+    `,
+    cell: css`
+      flex-direction: column;
+      padding: 0 ${theme.spacing(10)};
+
+      :first-of-type {
+        padding-left: 0;
+      }
+
+      :last-of-type {
+        padding-right: 0;
+      }
+
+      :not(:last-of-type) {
+        border-right: 1px solid ${theme.palette.interactive.delimiter};
+      }
+
+      ${theme.breakpoints.down('lg')} {
+        border-radius: ${theme.spacing(4)};
+        padding: ${theme.spacing(4)};
+        background-color: ${theme.palette.background.paper};
+
+        :first-of-type {
+          padding-left: ${theme.spacing(4)};
+        }
+
+        :last-of-type {
+          padding-right: ${theme.spacing(4)};
+        }
+
+        :not(:last-of-type) {
+          border-right: 0;
+        }
+      }
+    `,
+    label: css`
+      color: ${theme.palette.text.secondary};
+      margin-bottom: ${theme.spacing(1)};
+
+      ${theme.breakpoints.down('xl')} {
+        font-size: ${theme.typography.small1.fontSize};
+      }
+    `,
+    value: css`
+      ${theme.breakpoints.down('xl')} {
+        font-size: ${theme.typography.body2.fontSize};
+        font-weight: ${theme.typography.body2.fontWeight};
+        letter-spacing: ${theme.typography.body2.letterSpacing};
+        color: ${theme.palette.text.primary};
+      }
+    `,
+  };
+};

--- a/src/components/InfoIcon/index.stories.tsx
+++ b/src/components/InfoIcon/index.stories.tsx
@@ -1,0 +1,14 @@
+import { ComponentMeta } from '@storybook/react';
+import React from 'react';
+
+import { withCenterStory } from 'stories/decorators';
+
+import { InfoIcon } from '.';
+
+export default {
+  title: 'Components/InfoIcon',
+  component: InfoIcon,
+  decorators: [withCenterStory({ width: 100 })],
+} as ComponentMeta<typeof InfoIcon>;
+
+export const Default = () => <InfoIcon tooltip="This is fake tooltip" />;

--- a/src/components/InfoIcon/index.stories.tsx
+++ b/src/components/InfoIcon/index.stories.tsx
@@ -11,4 +11,4 @@ export default {
   decorators: [withCenterStory({ width: 100 })],
 } as ComponentMeta<typeof InfoIcon>;
 
-export const Default = () => <InfoIcon tooltip="This is fake tooltip" />;
+export const Default = () => <InfoIcon tooltip="This is a fake tooltip" />;

--- a/src/components/InfoIcon/index.tsx
+++ b/src/components/InfoIcon/index.tsx
@@ -1,0 +1,21 @@
+/** @jsxImportSource @emotion/react */
+import React from 'react';
+
+import { Icon } from '../Icon';
+import { Tooltip } from '../Tooltip';
+import { useStyles } from './styles';
+
+export interface InfoIconProps {
+  tooltip: string;
+  className?: string;
+}
+
+export const InfoIcon = ({ tooltip, className }: InfoIconProps) => {
+  const styles = useStyles();
+
+  return (
+    <Tooltip css={styles.container} className={className} title={tooltip}>
+      <Icon css={styles.icon} name="info" />
+    </Tooltip>
+  );
+};

--- a/src/components/InfoIcon/styles.ts
+++ b/src/components/InfoIcon/styles.ts
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 
 export const useStyles = () => ({
   container: css`
-    display: flex;
+    display: inline-flex;
   `,
   icon: css`
     cursor: help;

--- a/src/components/InfoIcon/styles.ts
+++ b/src/components/InfoIcon/styles.ts
@@ -1,0 +1,10 @@
+import { css } from '@emotion/react';
+
+export const useStyles = () => ({
+  container: css`
+    display: flex;
+  `,
+  icon: css`
+    cursor: help;
+  `,
+});

--- a/src/components/ProgressBar/AccountHealth/index.tsx
+++ b/src/components/ProgressBar/AccountHealth/index.tsx
@@ -9,8 +9,7 @@ import {
 
 import PLACEHOLDER_KEY from 'constants/placeholderKey';
 
-import { Icon } from '../../Icon';
-import { Tooltip } from '../../Tooltip';
+import { InfoIcon } from '../../InfoIcon';
 import { LabeledProgressBar } from '../LabeledProgressBar';
 import { useStyles } from './styles';
 
@@ -82,9 +81,7 @@ export const AccountHealth: React.FC<AccountHealthProps> = ({
             {variant === 'borrowBalance'
               ? readableBorrowBalance
               : readableBorrowLimitUsedPercentage}
-            <Tooltip css={styles.tooltip} title={t('myAccount.includingMintedVai')}>
-              <Icon css={styles.infoIcon} name="info" />
-            </Tooltip>
+            <InfoIcon css={styles.tooltip} tooltip={t('myAccount.includingMintedVai')} />
           </span>
         }
         greyRightText={

--- a/src/components/ProgressBar/AccountHealth/styles.ts
+++ b/src/components/ProgressBar/AccountHealth/styles.ts
@@ -9,12 +9,7 @@ export const useStyles = () => {
       align-items: center;
     `,
     tooltip: css`
-      align-items: center;
-      display: inline-flex;
       margin-left: ${theme.spacing(2)};
-    `,
-    infoIcon: css`
-      cursor: help;
     `,
   };
 };

--- a/src/components/Select/styles.ts
+++ b/src/components/Select/styles.ts
@@ -9,7 +9,7 @@ export const useStyles = () => {
 
   return {
     container: css`
-      display: flex;
+      display: inline-flex;
       align-items: center;
     `,
     label: css`

--- a/src/components/Select/styles.ts
+++ b/src/components/Select/styles.ts
@@ -9,7 +9,7 @@ export const useStyles = () => {
 
   return {
     container: css`
-      display: inline-flex;
+      display: flex;
       align-items: center;
     `,
     label: css`

--- a/src/components/Toggle/index.tsx
+++ b/src/components/Toggle/index.tsx
@@ -4,8 +4,7 @@ import Switch from '@mui/material/Switch';
 import { SwitchBaseProps } from '@mui/material/internal/SwitchBase';
 import React from 'react';
 
-import { Icon } from '../Icon';
-import { Tooltip } from '../Tooltip';
+import { InfoIcon } from '../InfoIcon';
 import { useStyles } from './styles';
 
 export interface ToggleProps {
@@ -32,11 +31,7 @@ export const Toggle = ({
 
   return (
     <div css={styles.container} className={className}>
-      {!!tooltip && (
-        <Tooltip css={styles.tooltip} title={tooltip}>
-          <Icon css={styles.infoIcon} name="info" />
-        </Tooltip>
-      )}
+      {!!tooltip && <InfoIcon css={styles.infoIcon} tooltip={tooltip} />}
 
       {!!label && (
         <Typography color="text.primary" variant="small1" component="span" css={styles.label}>

--- a/src/components/Toggle/styles.ts
+++ b/src/components/Toggle/styles.ts
@@ -13,12 +13,8 @@ export const useStyles = () => {
     label: css`
       margin-right: ${theme.spacing(2)};
     `,
-    tooltip: css`
-      margin-right: ${theme.spacing(2)};
-      display: flex;
-    `,
     infoIcon: css`
-      cursor: help;
+      margin-right: ${theme.spacing(2)};
     `,
     getSwitch: ({ isLight }: { isLight: boolean }) => css`
       flex-shrink: 0;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -42,3 +42,5 @@ export * from './TokenTextField';
 export * from './Tooltip';
 export * from './ValueUpdate';
 export * from './Markdown';
+export * from './InfoIcon';
+export * from './CellGroup';

--- a/src/pages/Market/Header/index.tsx
+++ b/src/pages/Market/Header/index.tsx
@@ -1,13 +1,13 @@
 /** @jsxImportSource @emotion/react */
-import { Paper, Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
+import { Cell, CellGroup } from 'components';
 import React from 'react';
 import { useTranslation } from 'translation';
 import { formatCentsToReadableValue } from 'utilities';
 
 import { useGetTreasuryTotals } from 'clients/api';
 
-import { useStyles } from '../styles';
+import { useStyles } from './styles';
 
 interface HeaderProps {
   totalSupplyCents: BigNumber;
@@ -24,44 +24,27 @@ export const HeaderUi: React.FC<HeaderProps> = ({
 }) => {
   const { t } = useTranslation();
   const styles = useStyles();
-  return (
-    <Paper css={styles.headerRoot}>
-      <div css={styles.row}>
-        <Paper css={styles.box}>
-          <Typography variant="small1" css={styles.title}>
-            {t('market.totalSupply')}
-          </Typography>
-          <Typography variant="h3" css={styles.value}>
-            {formatCentsToReadableValue({ value: totalSupplyCents })}
-          </Typography>
-        </Paper>
-        <Paper css={styles.box}>
-          <Typography variant="small1" css={styles.title}>
-            {t('market.totalBorrow')}
-          </Typography>
-          <Typography variant="h3" css={styles.value}>
-            {formatCentsToReadableValue({ value: totalBorrowCents })}
-          </Typography>
-        </Paper>
-        <Paper css={styles.box}>
-          <Typography variant="small1" css={styles.title}>
-            {t('market.availableLiquidity')}
-          </Typography>
-          <Typography variant="h3" css={styles.value}>
-            {formatCentsToReadableValue({ value: availableLiquidityCents })}
-          </Typography>
-        </Paper>
-        <Paper css={styles.box}>
-          <Typography variant="small1" css={styles.title}>
-            {t('market.totalTreasury')}
-          </Typography>
-          <Typography variant="h3" css={styles.value}>
-            {formatCentsToReadableValue({ value: totalTreasuryCents })}
-          </Typography>
-        </Paper>
-      </div>
-    </Paper>
-  );
+
+  const cells: Cell[] = [
+    {
+      label: t('market.totalSupply'),
+      value: formatCentsToReadableValue({ value: totalSupplyCents }),
+    },
+    {
+      label: t('market.totalBorrow'),
+      value: formatCentsToReadableValue({ value: totalBorrowCents }),
+    },
+    {
+      label: t('market.availableLiquidity'),
+      value: formatCentsToReadableValue({ value: availableLiquidityCents }),
+    },
+    {
+      label: t('market.totalTreasury'),
+      value: formatCentsToReadableValue({ value: totalTreasuryCents }),
+    },
+  ];
+
+  return <CellGroup css={styles.cellGroup} cells={cells} />;
 };
 
 const Header = () => {

--- a/src/pages/Market/Header/styles.ts
+++ b/src/pages/Market/Header/styles.ts
@@ -1,0 +1,16 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  return {
+    cellGroup: css`
+      margin-bottom: ${theme.spacing(8)};
+
+      ${theme.breakpoints.down('xxl')} {
+        margin-bottom: ${theme.spacing(6)};
+      }
+    `,
+  };
+};

--- a/src/pages/Market/styles.ts
+++ b/src/pages/Market/styles.ts
@@ -3,17 +3,8 @@ import { useTheme } from '@mui/material';
 
 export const useStyles = () => {
   const theme = useTheme();
-  return {
-    headerRoot: css`
-      margin-bottom: ${theme.spacing(8)};
-      padding: ${theme.spacing(4)} 0 ${theme.spacing(4)} ${theme.spacing(6)};
 
-      ${theme.breakpoints.down('xxl')} {
-        padding: 0;
-        background-color: transparent;
-        margin-bottom: ${theme.spacing(6)};
-      }
-    `,
+  return {
     row: css`
       display: flex;
       flex-wrap: wrap;

--- a/src/pages/Vote/Governance/index.tsx
+++ b/src/pages/Vote/Governance/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
-import { Icon, Pagination, Spinner, TextButton, Tooltip } from 'components';
+import { InfoIcon, Pagination, Spinner, TextButton } from 'components';
 import React, { useState } from 'react';
 import { useTranslation } from 'translation';
 import { Proposal } from 'types';
@@ -62,9 +62,7 @@ export const GovernanceUi: React.FC<GovernanceUiProps> = ({
             {t('vote.createProposalPlus')}
           </TextButton>
 
-          <Tooltip title={t('vote.requiredVotingPower')} css={styles.infoIconWrapper}>
-            <Icon name="info" css={styles.infoIcon} />
-          </Tooltip>
+          <InfoIcon tooltip={t('vote.requiredVotingPower')} css={styles.infoIconWrapper} />
         </div>
       </div>
 

--- a/src/pages/Vote/Governance/styles.ts
+++ b/src/pages/Vote/Governance/styles.ts
@@ -34,12 +34,9 @@ export const useStyles = () => {
       align-items: flex-end;
     `,
     infoIconWrapper: css`
-      display: flex;
       align-self: center;
     `,
-    infoIcon: css`
-      cursor: help;
-    `,
+
     pagination: css`
       justify-content: flex-start;
     `,

--- a/src/pages/Vote/VotingWallet/index.tsx
+++ b/src/pages/Vote/VotingWallet/index.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { Paper, Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
-import { Delimiter, Icon, LinkButton, PrimaryButton, Tooltip } from 'components';
+import { Delimiter, Icon, InfoIcon, LinkButton, PrimaryButton } from 'components';
 import React, { useContext, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'translation';
@@ -101,12 +101,10 @@ export const VotingWalletUi: React.FC<VotingWalletUiProps> = ({
             </Typography>
 
             {previouslyDelegated && (
-              <Tooltip
-                title={t('vote.youDelegatedTo', { delegate })}
+              <InfoIcon
+                tooltip={t('vote.youDelegatedTo', { delegate })}
                 css={[styles.infoIcon, styles.subtitle]}
-              >
-                <Icon name="info" />
-              </Tooltip>
+              />
             )}
           </div>
 

--- a/src/pages/Vote/VotingWallet/styles.ts
+++ b/src/pages/Vote/VotingWallet/styles.ts
@@ -74,10 +74,10 @@ export const useStyles = () => {
       }
     `,
     subtitle: css`
-      margin-bottom: ${theme.spacing(1)};
       ${theme.breakpoints.down('md')} {
         font-size: ${theme.typography.small1.fontSize};
       }
+
       ${theme.breakpoints.down('sm')} {
         font-size: ${theme.typography.body1.fontSize};
       }
@@ -121,13 +121,13 @@ export const useStyles = () => {
       }
     `,
     infoIcon: css`
-      display: flex;
       align-self: center;
     `,
     totalLockedTitle: css`
       display: flex;
       flex-direction: row;
       align-items: flex-end;
+      margin-bottom: ${theme.spacing(1)};
     `,
   };
 };


### PR DESCRIPTION
## Jira ticket(s)

VEN-493

## Changes

- create `CellGroup` component
<img width="1510" alt="Screen Shot 2022-08-18 at 14 43 44" src="https://user-images.githubusercontent.com/44675210/185410096-819c24db-e76b-4d67-9d8b-2523103555c2.png">
- implement `CellGroup` component to Markets page
- create `InfoIcon` component 
<img width="210" alt="Screen Shot 2022-08-18 at 14 45 08" src="https://user-images.githubusercontent.com/44675210/185410376-ea6fdf5f-4a9a-4646-aee2-80ae6e8932ec.png">
- implement `InfoIcon` component to relevant pages
