### PR TITLE
[VEN-498] Start updating Market Details page

### DIFF
--- a/src/components/CellGroup/index.tsx
+++ b/src/components/CellGroup/index.tsx
@@ -12,14 +12,14 @@ export interface Cell {
   color?: string;
 }
 
-export interface NumberCellGroupProps {
+export interface CellGroupProps {
   cells: Cell[];
   smallValues?: boolean;
   title?: string;
   className?: string;
 }
 
-export const CellGroup: React.FC<NumberCellGroupProps> = ({
+export const CellGroup: React.FC<CellGroupProps> = ({
   cells,
   title,
   smallValues = false,

--- a/src/components/CellGroup/styles.ts
+++ b/src/components/CellGroup/styles.ts
@@ -5,7 +5,7 @@ export const useStyles = () => {
   const theme = useTheme();
   return {
     container: css`
-      ${theme.breakpoints.down('xxl')} {
+      ${theme.breakpoints.down('xl')} {
         padding: 0;
         background-color: transparent;
       }
@@ -17,7 +17,7 @@ export const useStyles = () => {
       display: flex;
       flex-wrap: wrap;
 
-      ${theme.breakpoints.down('xxl')} {
+      ${theme.breakpoints.down('xl')} {
         display: grid;
         grid-template-columns: 1fr 1fr;
         grid-gap: ${theme.spacing(2)};
@@ -43,7 +43,7 @@ export const useStyles = () => {
         border-right: 1px solid ${theme.palette.interactive.delimiter};
       }
 
-      ${theme.breakpoints.down('xxl')} {
+      ${theme.breakpoints.down('xl')} {
         border-radius: ${theme.spacing(4)};
         padding: ${theme.spacing(4)};
         background-color: ${theme.palette.background.paper};
@@ -69,7 +69,7 @@ export const useStyles = () => {
     label: css`
       color: ${theme.palette.text.secondary};
 
-      ${theme.breakpoints.down('xxl')} {
+      ${theme.breakpoints.down('xl')} {
         font-size: ${theme.typography.small1.fontSize};
       }
     `,

--- a/src/components/Layout/styles.ts
+++ b/src/components/Layout/styles.ts
@@ -13,18 +13,5 @@ export const useStyles = () => {
         flex-direction: column;
       }
     `,
-    banner: css`
-      margin: ${theme.spacing(4, 10, 0)};
-      ${theme.breakpoints.down('lg')} {
-        margin: ${theme.spacing(6, 6, 0)};
-      }
-      ${theme.breakpoints.down('md')} {
-        margin: ${theme.spacing(4, 4, 0)};
-      }
-    `,
-    bannerLink: css`
-      color: ${theme.palette.text.primary};
-      text-decoration: underline;
-    `,
   };
 };

--- a/src/pages/Market/index.tsx
+++ b/src/pages/Market/index.tsx
@@ -1,5 +1,68 @@
-import React from 'react';
+import { Cell, CellGroup } from 'components';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'translation';
+import { Asset } from 'types';
+import { formatCentsToReadableValue } from 'utilities';
 
-const Market: React.FC = () => <>Market</>;
+import { assetData } from '__mocks__/models/asset';
+
+export interface MarketUiProps {
+  assets: Asset[];
+  totalSupplyCents: number;
+  totalBorrowCents: number;
+}
+
+export const MarketUi: React.FC<MarketUiProps> = ({
+  assets,
+  totalSupplyCents,
+  totalBorrowCents,
+}) => {
+  const { t } = useTranslation();
+
+  const cells: Cell[] = useMemo(
+    () => [
+      {
+        label: t('market.header.totalSupplyLabel'),
+        value: formatCentsToReadableValue({
+          value: totalSupplyCents,
+        }),
+      },
+      {
+        label: t('market.header.totalBorrowLabel'),
+        value: formatCentsToReadableValue({
+          value: totalBorrowCents,
+        }),
+      },
+      {
+        label: t('market.header.availableLiquidityLabel'),
+        value: formatCentsToReadableValue({
+          value: totalSupplyCents - totalBorrowCents,
+        }),
+      },
+      {
+        label: t('market.header.assetsLabel'),
+        value: assets.length,
+      },
+    ],
+    [totalSupplyCents, totalBorrowCents, assets.length],
+  );
+
+  return <CellGroup cells={cells} />;
+};
+
+const Market: React.FC = () => {
+  // TODO: fetch actual values (see https://jira.toolsfdg.net/browse/VEN-546)
+  const assets = assetData;
+  const totalSupplyCents = 1000000000;
+  const totalBorrowCents = 100000000;
+
+  return (
+    <MarketUi
+      assets={assets}
+      totalSupplyCents={totalSupplyCents}
+      totalBorrowCents={totalBorrowCents}
+    />
+  );
+};
 
 export default Market;

--- a/src/pages/Market/index.tsx
+++ b/src/pages/Market/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
-import { Cell, CellGroup } from 'components';
+import { Cell, CellGroup, Icon } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Asset } from 'types';
@@ -12,6 +12,7 @@ import { useStyles } from './styles';
 
 export interface MarketUiProps {
   assets: Asset[];
+  isIsolatedLendingMarket: boolean;
   totalSupplyCents: number;
   totalBorrowCents: number;
   description: string;
@@ -19,12 +20,13 @@ export interface MarketUiProps {
 
 export const MarketUi: React.FC<MarketUiProps> = ({
   assets,
+  isIsolatedLendingMarket,
   totalSupplyCents,
   totalBorrowCents,
   description,
 }) => {
   const styles = useStyles();
-  const { t } = useTranslation();
+  const { t, Trans } = useTranslation();
 
   const cells: Cell[] = useMemo(
     () => [
@@ -55,19 +57,48 @@ export const MarketUi: React.FC<MarketUiProps> = ({
   );
 
   return (
-    <div css={styles.header}>
-      <Typography variant="small2" component="div" css={styles.headerDescription}>
-        {description}
-      </Typography>
+    <>
+      <div css={styles.header}>
+        <Typography variant="small2" component="div" css={styles.headerDescription}>
+          {description}
+        </Typography>
 
-      <CellGroup cells={cells} />
-    </div>
+        <CellGroup cells={cells} />
+      </div>
+
+      {isIsolatedLendingMarket && (
+        <div css={styles.banner}>
+          <div css={styles.bannerContent}>
+            <Icon name="attention" css={styles.bannerIcon} />
+
+            <Typography variant="small2" css={styles.bannerText}>
+              <Trans
+                i18nKey="market.bannerText"
+                components={{
+                  Link: (
+                    <Typography
+                      variant="small2"
+                      component="a"
+                      // TODO: add href
+                      href="TBD"
+                      target="_blank"
+                      rel="noreferrer"
+                    />
+                  ),
+                }}
+              />
+            </Typography>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 
 const Market: React.FC = () => {
   // TODO: fetch actual values (see https://jira.toolsfdg.net/browse/VEN-546)
   const assets = assetData;
+  const isIsolatedLendingMarket = true;
   const totalSupplyCents = 1000000000;
   const totalBorrowCents = 100000000;
   const description =
@@ -76,6 +107,7 @@ const Market: React.FC = () => {
   return (
     <MarketUi
       assets={assets}
+      isIsolatedLendingMarket={isIsolatedLendingMarket}
       totalSupplyCents={totalSupplyCents}
       totalBorrowCents={totalBorrowCents}
       description={description}

--- a/src/pages/Market/index.tsx
+++ b/src/pages/Market/index.tsx
@@ -1,3 +1,5 @@
+/** @jsxImportSource @emotion/react */
+import { Typography } from '@mui/material';
 import { Cell, CellGroup } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
@@ -6,17 +8,22 @@ import { formatCentsToReadableValue } from 'utilities';
 
 import { assetData } from '__mocks__/models/asset';
 
+import { useStyles } from './styles';
+
 export interface MarketUiProps {
   assets: Asset[];
   totalSupplyCents: number;
   totalBorrowCents: number;
+  description: string;
 }
 
 export const MarketUi: React.FC<MarketUiProps> = ({
   assets,
   totalSupplyCents,
   totalBorrowCents,
+  description,
 }) => {
+  const styles = useStyles();
   const { t } = useTranslation();
 
   const cells: Cell[] = useMemo(
@@ -47,7 +54,15 @@ export const MarketUi: React.FC<MarketUiProps> = ({
     [totalSupplyCents, totalBorrowCents, assets.length],
   );
 
-  return <CellGroup cells={cells} />;
+  return (
+    <div css={styles.header}>
+      <Typography variant="small2" component="div" css={styles.headerDescription}>
+        {description}
+      </Typography>
+
+      <CellGroup cells={cells} />
+    </div>
+  );
 };
 
 const Market: React.FC = () => {
@@ -55,12 +70,15 @@ const Market: React.FC = () => {
   const assets = assetData;
   const totalSupplyCents = 1000000000;
   const totalBorrowCents = 100000000;
+  const description =
+    'The Metaverse pool offers increased LTV to allow  a leveraged SOL position up to 10x. Higher leverage comes at the cost of increased liquidation risk so proceed with caution.';
 
   return (
     <MarketUi
       assets={assets}
       totalSupplyCents={totalSupplyCents}
       totalBorrowCents={totalBorrowCents}
+      description={description}
     />
   );
 };

--- a/src/pages/Market/styles.ts
+++ b/src/pages/Market/styles.ts
@@ -1,5 +1,5 @@
 import { css } from '@emotion/react';
-import { useTheme } from '@mui/material';
+import { alpha, useTheme } from '@mui/material';
 
 export const useStyles = () => {
   const theme = useTheme();
@@ -24,6 +24,43 @@ export const useStyles = () => {
         margin-bottom: ${theme.spacing(6)};
         display: block;
       }
+    `,
+    banner: css`
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: ${theme.spacing(6)};
+      border-radius: ${theme.shape.borderRadius.small}px;
+      border: 1px solid ${theme.palette.interactive.warning};
+      background-color: ${alpha(theme.palette.interactive.warning as string, 0.1)};
+      margin-bottom: ${theme.spacing(8)};
+
+      ${theme.breakpoints.down('xxl')} {
+        margin-bottom: ${theme.spacing(6)};
+      }
+    `,
+    bannerContent: css`
+      display: flex;
+      align-items: center;
+      margin: 0 auto;
+    `,
+    bannerText: css`
+      color: ${theme.palette.text.primary};
+
+      a {
+        color: ${theme.palette.interactive.primary};
+      }
+
+      a:hover {
+        text-decoration: underline;
+      }
+    `,
+    bannerIcon: css`
+      flex-shrink: 0;
+      color: ${theme.palette.interactive.warning};
+      margin-right: ${theme.spacing(2)};
+      width: ${theme.spacing(6)};
+      height: ${theme.spacing(6)};
     `,
   };
 };

--- a/src/pages/Market/styles.ts
+++ b/src/pages/Market/styles.ts
@@ -1,0 +1,29 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  return {
+    header: css`
+      margin-bottom: ${theme.spacing(8)};
+      display: flex;
+      align-items: center;
+
+      ${theme.breakpoints.down('xxl')} {
+        margin-bottom: ${theme.spacing(6)};
+        display: block;
+      }
+    `,
+    headerDescription: css`
+      margin-right: ${theme.spacing(6)};
+      color: ${theme.palette.text.primary};
+      flex: 1;
+
+      ${theme.breakpoints.down('xxl')} {
+        margin-bottom: ${theme.spacing(6)};
+        display: block;
+      }
+    `,
+  };
+};

--- a/src/pages/Markets/Header/index.tsx
+++ b/src/pages/Markets/Header/index.tsx
@@ -44,7 +44,7 @@ export const HeaderUi: React.FC<HeaderProps> = ({
     },
   ];
 
-  return <CellGroup css={styles.cellGroup} cells={cells} />;
+  return <CellGroup css={styles.cellGroup} cells={cells} smallValues />;
 };
 
 const Header = () => {

--- a/src/theme/MuiThemeProvider/muiTheme.ts
+++ b/src/theme/MuiThemeProvider/muiTheme.ts
@@ -95,7 +95,6 @@ export const SHAPE = {
     xxLarge: SPACING * 10,
   },
   footerHeight: '56px',
-  bannerHeight: '56px',
   drawerWidthDesktop: '224px',
   drawerWidthTablet: '80px',
 };

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -16,6 +16,52 @@
       "totalSupply": "Total supply"
     }
   },
+  "asset": {
+    "borrowInfo": {
+      "stats": {
+        "apy": "APY",
+        "distributionApy": "Distribution APY",
+        "totalBorrow": "Total borrow"
+      },
+      "title": "Borrow info"
+    },
+    "interestRateModel": {
+      "title": "Interest Rate Model"
+    },
+    "legends": {
+      "borrowApy": "Borrow APY",
+      "supplyApy": "Supply APY",
+      "utilizationRate": "Utilization rate"
+    },
+    "marketInfo": {
+      "stats": {
+        "borrowCapLabel": "Borrow cap",
+        "borrowerCountLabel": "# of borrowers",
+        "collateralFactorLabel": "Collateral factor",
+        "dailyBorrowingInterestsLabel": "Daily borrowing interests",
+        "dailyDistributionXvs": "Daily XVS distributed",
+        "dailySupplyingInterestsLabel": "Daily supplying interests",
+        "exchangeRateLabel": "Exchange rate",
+        "exchangeRateValue": "1 {{tokenSymbol}}={{rate}} {{vTokenSymbol}}",
+        "marketLiquidityLabel": "Market liquidity",
+        "mintedTokensLabel": "{{vTokenSymbol}} minted",
+        "priceLabel": "Price",
+        "reserveFactorLabel": "Reserve factor",
+        "reserveTokensLabel": "Reserves",
+        "supplierCountLabel": "# of suppliers",
+        "unlimitedBorrowCap": "Uncapped"
+      },
+      "title": "Market info"
+    },
+    "supplyInfo": {
+      "stats": {
+        "apy": "APY",
+        "distributionApy": "Distribution APY",
+        "totalSupply": "Total supply"
+      },
+      "title": "Supply info"
+    }
+  },
   "authModal": {
     "accountDetails": {
       "logOutButtonLabel": "Log out"
@@ -226,55 +272,15 @@
       "totalBorrow": "Total borrow",
       "totalSupply": "Total supply"
     },
+    "header": {
+      "assetsLabel": "Assets",
+      "availableLiquidityLabel": "Available Liquidity",
+      "totalBorrowLabel": "Total Borrow",
+      "totalSupplyLabel": "Total Supply"
+    },
     "totalBorrow": "Total Borrow",
     "totalSupply": "Total Supply",
     "totalTreasury": "Total Treasury"
-  },
-  "asset": {
-    "borrowInfo": {
-      "stats": {
-        "apy": "APY",
-        "distributionApy": "Distribution APY",
-        "totalBorrow": "Total borrow"
-      },
-      "title": "Borrow info"
-    },
-    "interestRateModel": {
-      "title": "Interest Rate Model"
-    },
-    "legends": {
-      "borrowApy": "Borrow APY",
-      "supplyApy": "Supply APY",
-      "utilizationRate": "Utilization rate"
-    },
-    "marketInfo": {
-      "stats": {
-        "borrowCapLabel": "Borrow cap",
-        "borrowerCountLabel": "# of borrowers",
-        "collateralFactorLabel": "Collateral factor",
-        "dailyBorrowingInterestsLabel": "Daily borrowing interests",
-        "dailyDistributionXvs": "Daily XVS distributed",
-        "dailySupplyingInterestsLabel": "Daily supplying interests",
-        "exchangeRateLabel": "Exchange rate",
-        "exchangeRateValue": "1 {{tokenSymbol}}={{rate}} {{vTokenSymbol}}",
-        "marketLiquidityLabel": "Market liquidity",
-        "mintedTokensLabel": "{{vTokenSymbol}} minted",
-        "priceLabel": "Price",
-        "reserveFactorLabel": "Reserve factor",
-        "reserveTokensLabel": "Reserves",
-        "supplierCountLabel": "# of suppliers",
-        "unlimitedBorrowCap": "Uncapped"
-      },
-      "title": "Market info"
-    },
-    "supplyInfo": {
-      "stats": {
-        "apy": "APY",
-        "distributionApy": "Distribution APY",
-        "totalSupply": "Total supply"
-      },
-      "title": "Supply info"
-    }
   },
   "markets": {
     "collateralConfirmModal": {

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -264,6 +264,7 @@
   },
   "market": {
     "availableLiquidity": "Available Liquidity",
+    "bannerText": "You are currently looking at an isolated lending market. Supplying tokens to an isolated lending market will increase your borrow limit for this market only, effectively enabling you to borrow tokens from this market only. See <Link>our FAQ</Link> to learn more.",
     "columns": {
       "assets": "Assets",
       "liquidity": "Liquidity",

--- a/src/types/mui.d.ts
+++ b/src/types/mui.d.ts
@@ -53,7 +53,6 @@ declare module '@mui/material/styles' {
       xxLarge: number;
     };
     footerHeight: string;
-    bannerHeight: string;
     drawerWidthDesktop: string;
     drawerWidthTablet: string;
   }


### PR DESCRIPTION
## Jira ticket(s)

VEN-498

## Changes

- rename `NumberCellGroupProps` type to `CellGroupProps`
- add header to Market Details page
Note that the supply and borrow market tables will be added through another PR (I first need to work on https://jira.toolsfdg.net/browse/VEN-571)
