### PR TITLE
Fix values parameter of createProposal mutation

### DIFF
--- a/src/clients/api/mutations/createProposal/index.spec.ts
+++ b/src/clients/api/mutations/createProposal/index.spec.ts
@@ -61,7 +61,7 @@ describe('api/mutation/createProposal', () => {
     expect(createProposalMock).toHaveBeenCalledTimes(1);
     expect(createProposalMock).toHaveBeenCalledWith(
       fakeTargets,
-      [0],
+      Array(fakeSignatures.length).fill(0),
       fakeSignatures,
       fakeCallDatas,
       fakeDescription,

--- a/src/clients/api/mutations/createProposal/index.ts
+++ b/src/clients/api/mutations/createProposal/index.ts
@@ -23,7 +23,7 @@ const createProposal = async ({
   governorBravoContract: GovernorBravoDelegate;
 }): Promise<CreateProposalOutput> => {
   const resp = await governorBravoContract.methods
-    .propose(targets, [0], signatures, callDatas, description)
+    .propose(targets, Array(signatures.length).fill(0), signatures, callDatas, description)
     .send({ from: accountAddress });
   return resp;
 };


### PR DESCRIPTION
- update the `values` parameter sent through the `propose` method of the `governorBravoContract` smart contract
