### PR TITLE
Fix issue with collateral switch not displaying on supplied assets table

### DIFF
--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -83,7 +83,7 @@ export const SuppliedTable: React.FC<SuppliedTableUiProps> = ({
     {
       key: 'collateral',
       render: () =>
-        asset.collateralFactor.toNumber() ? (
+        asset.collateralFactor.toNumber() || asset.collateral ? (
           <Toggle onChange={() => collateralOnChange(asset)} value={asset.collateral} />
         ) : (
           PLACEHOLDER_KEY


### PR DESCRIPTION
When an asset does not have a collateral factor, its collateral switch is currently hidden from the supplied asset table. This PR fixes this issue, so that tokens that previously had a collateral factor and were enabled as collateral can still be disabled if their collateral factor is updated to 0 (which is currently the case for LUNA and UST).