### PR TITLE
Remove homepage attribute from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "venus",
-  "homepage": ".",
   "version": "1.1.3",
   "private": true,
   "engines": {


### PR DESCRIPTION
## Changes

- remove homepage attribute from `package.json` to fix an issue with nested links not loading properly when being opened directly