### PR TITLE
[VEN-688] Unify how timestamp is displayed on proposal item

### DIFF
--- a/src/components/ProposalCard/index.tsx
+++ b/src/components/ProposalCard/index.tsx
@@ -2,11 +2,13 @@
 import Grid from '@mui/material/Grid';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
-import { VoteSupport } from 'types';
+import { useTranslation } from 'translation';
+import { ProposalState, VoteSupport } from 'types';
 
 import { Chip } from '../Chip';
+import { Countdown } from '../Countdown';
 import { useStyles } from './styles';
 
 interface ProposalCardProps {
@@ -18,7 +20,11 @@ interface ProposalCardProps {
   headerRightItem?: React.ReactElement;
   headerLeftItem?: React.ReactElement;
   contentRightItem: React.ReactElement;
-  footer?: React.ReactElement;
+  proposalState: ProposalState;
+  endDate?: Date;
+  cancelDate?: Date;
+  queuedDate?: Date;
+  executedDate?: Date;
 }
 
 export const ProposalCard: React.FC<ProposalCardProps> = ({
@@ -29,10 +35,70 @@ export const ProposalCard: React.FC<ProposalCardProps> = ({
   headerRightItem,
   headerLeftItem,
   contentRightItem,
-  footer,
+  proposalState,
+  endDate,
+  cancelDate,
+  queuedDate,
+  executedDate,
   ...containerProps
 }) => {
   const styles = useStyles();
+  const { Trans } = useTranslation();
+
+  const footerDom = useMemo(() => {
+    // Translation key: do not remove this comment
+    // t('proposalCard.activeUntilDate')
+    let i18nKey = 'proposalCard.activeUntilDate';
+    let date = endDate;
+
+    if (proposalState === 'Canceled') {
+      // Translation key: do not remove this comment
+      // t('proposalCard.canceled')
+      i18nKey = 'proposalCard.canceled';
+      date = cancelDate;
+    } else if (proposalState === 'Defeated') {
+      // Translation key: do not remove this comment
+      // t('proposalCard.defeated')
+      i18nKey = 'proposalCard.defeated';
+    } else if (proposalState === 'Succeeded') {
+      // Translation key: do not remove this comment
+      // t('proposalCard.succeeded')
+      i18nKey = 'proposalCard.succeeded';
+    } else if (proposalState === 'Queued') {
+      // Translation key: do not remove this comment
+      // t('proposalCard.queued')
+      i18nKey = 'proposalCard.queued';
+      date = queuedDate;
+    } else if (proposalState === 'Executed') {
+      // Translation key: do not remove this comment
+      // t('proposalCard.executed')
+      i18nKey = 'proposalCard.executed';
+      date = executedDate;
+    } else if (proposalState === 'Expired') {
+      // Translation key: do not remove this comment
+      // t('proposalCard.expired')
+      i18nKey = 'proposalCard.expired';
+    }
+
+    return (
+      <div css={styles.timestamp}>
+        {proposalState !== 'Pending' && endDate && (
+          <Typography variant="small2">
+            <Trans
+              i18nKey={i18nKey}
+              components={{
+                Date: <Typography variant="small2" color="textPrimary" />,
+              }}
+              values={{ date }}
+            />
+          </Typography>
+        )}
+
+        {proposalState === 'Active' && endDate && <Countdown date={endDate} />}
+      </div>
+    );
+  }, [proposalState, endDate, cancelDate]);
+
   return (
     <Paper
       className={className}
@@ -59,7 +125,7 @@ export const ProposalCard: React.FC<ProposalCardProps> = ({
             {title}
           </Typography>
 
-          {footer}
+          {footerDom}
         </Grid>
         <Grid css={[styles.gridItem, styles.gridItemRight]} item xs={12} sm={4}>
           {contentRightItem}

--- a/src/components/ProposalCard/styles.ts
+++ b/src/components/ProposalCard/styles.ts
@@ -56,5 +56,9 @@ export const useStyles = () => {
         padding-bottom: ${theme.spacing(10)};
       }
     `,
+    timestamp: css`
+      display: flex;
+      justify-content: space-between;
+    `,
   };
 };

--- a/src/pages/Vote/CreateProposalModal/ProposalPreview/index.tsx
+++ b/src/pages/Vote/CreateProposalModal/ProposalPreview/index.tsx
@@ -70,7 +70,10 @@ const ProposalPreview: React.FC = () => {
         </Typography>
 
         {actions.map(action => (
-          <ReadableActionSignature action={action} />
+          <ReadableActionSignature
+            key={`proposal-preview-readable-action-signature-${action.signature}-${action.target}`}
+            action={action}
+          />
         ))}
       </div>
     </div>

--- a/src/pages/Vote/Governance/index.tsx
+++ b/src/pages/Vote/Governance/index.tsx
@@ -75,6 +75,7 @@ export const GovernanceUi: React.FC<GovernanceUiProps> = ({
             description,
             state,
             endDate,
+            cancelDate,
             forVotesWei,
             abstainedVotesWei,
             againstVotesWei,
@@ -86,6 +87,7 @@ export const GovernanceUi: React.FC<GovernanceUiProps> = ({
               proposalTitle={description.title}
               proposalState={state}
               endDate={endDate}
+              cancelDate={cancelDate}
               forVotesWei={forVotesWei}
               againstVotesWei={againstVotesWei}
               abstainedVotesWei={abstainedVotesWei}

--- a/src/pages/Vote/GovernanceProposal/index.stories.tsx
+++ b/src/pages/Vote/GovernanceProposal/index.stories.tsx
@@ -23,6 +23,7 @@ export const Active = () => (
     forVotesWei={new BigNumber('500000000000000000')}
     againstVotesWei={new BigNumber('2000000000000000000')}
     abstainedVotesWei={new BigNumber('0')}
+    cancelDate={undefined}
     endDate={new Date(Date.now() + 3650000)}
   />
 );
@@ -31,6 +32,7 @@ export const Queued = () => (
     proposalId={58}
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon with very very very very very very very very very very very very very very very very long text example"
     proposalState="Queued"
+    cancelDate={undefined}
     endDate={new Date()}
   />
 );
@@ -39,6 +41,7 @@ export const Pending = () => (
     proposalId={58}
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Pending"
+    cancelDate={undefined}
     endDate={new Date()}
   />
 );
@@ -47,6 +50,7 @@ export const Executed = () => (
     proposalId={58}
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Executed"
+    cancelDate={undefined}
     endDate={new Date()}
   />
 );
@@ -55,7 +59,8 @@ export const Cancelled = () => (
     proposalId={58}
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Canceled"
-    endDate={new Date(Date.now())}
+    cancelDate={new Date(Date.now())}
+    endDate={undefined}
   />
 );
 
@@ -64,6 +69,7 @@ export const Defeated = () => (
     proposalId={58}
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Defeated"
+    cancelDate={undefined}
     endDate={new Date(Date.now())}
   />
 );
@@ -73,6 +79,7 @@ export const Succeeded = () => (
     proposalId={58}
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Succeeded"
+    cancelDate={undefined}
     endDate={new Date(Date.now())}
   />
 );
@@ -82,6 +89,7 @@ export const Expired = () => (
     proposalId={58}
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Expired"
+    cancelDate={undefined}
     endDate={new Date(Date.now())}
   />
 );

--- a/src/pages/Vote/GovernanceProposal/index.tsx
+++ b/src/pages/Vote/GovernanceProposal/index.tsx
@@ -2,14 +2,7 @@
 import { SerializedStyles } from '@emotion/react';
 import Typography from '@mui/material/Typography';
 import { BigNumber } from 'bignumber.js';
-import {
-  ActiveChip,
-  ActiveVotingProgress,
-  Countdown,
-  Icon,
-  IconName,
-  ProposalCard,
-} from 'components';
+import { ActiveChip, ActiveVotingProgress, Icon, IconName, ProposalCard } from 'components';
 import React, { useContext, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { ProposalState, VoteSupport } from 'types';
@@ -101,7 +94,10 @@ interface GovernanceProposalProps {
   proposalId: number;
   proposalTitle: string;
   proposalState: ProposalState;
-  endDate: Date | undefined;
+  endDate?: Date;
+  cancelDate?: Date;
+  queuedDate?: Date;
+  executedDate?: Date;
   userVoteStatus?: VoteSupport;
   forVotesWei?: BigNumber;
   againstVotesWei?: BigNumber;
@@ -114,13 +110,15 @@ const GovernanceProposalUi: React.FC<GovernanceProposalProps> = ({
   proposalTitle,
   proposalState,
   endDate,
+  cancelDate,
+  queuedDate,
+  executedDate,
   userVoteStatus,
   forVotesWei,
   againstVotesWei,
   abstainedVotesWei,
 }) => {
-  const styles = useStyles();
-  const { t, Trans } = useTranslation();
+  const { t } = useTranslation();
 
   const voteStatusText = useMemo(() => {
     switch (userVoteStatus) {
@@ -165,26 +163,12 @@ const GovernanceProposalUi: React.FC<GovernanceProposalProps> = ({
           <StatusCard state={proposalState} />
         )
       }
-      footer={
-        endDate && proposalState === 'Active' ? (
-          <div css={styles.timestamp}>
-            <Typography variant="small2">
-              <Trans
-                i18nKey="voteProposalUi.activeUntilDate"
-                components={{
-                  Date: <Typography variant="small2" color="textPrimary" />,
-                }}
-                values={{
-                  date: endDate,
-                }}
-              />
-            </Typography>
-
-            <Countdown date={endDate} />
-          </div>
-        ) : undefined
-      }
       data-testid={TEST_IDS.governanceProposal(proposalId.toString())}
+      proposalState={proposalState}
+      endDate={endDate}
+      cancelDate={cancelDate}
+      queuedDate={queuedDate}
+      executedDate={executedDate}
     />
   );
 };

--- a/src/pages/Vote/GovernanceProposal/styles.ts
+++ b/src/pages/Vote/GovernanceProposal/styles.ts
@@ -55,9 +55,5 @@ export const useStyles = () => {
       border-radius: 50%;
       stroke-width: ${theme.spacing(0.5)};
     `,
-    timestamp: css`
-      display: flex;
-      justify-content: space-between;
-    `,
   };
 };

--- a/src/pages/VoterDetails/History/VoterProposal/index.stories.tsx
+++ b/src/pages/VoterDetails/History/VoterProposal/index.stories.tsx
@@ -24,7 +24,6 @@ export const Active = () => (
     againstVotesWei={new BigNumber('2000000000000000000')}
     abstainedVotesWei={new BigNumber('0')}
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}
@@ -36,7 +35,6 @@ export const Queued = () => (
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon with very very very very very very very very very very very very very very very very long text example"
     proposalState="Queued"
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}
@@ -48,7 +46,6 @@ export const Pending = () => (
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Pending"
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}
@@ -60,7 +57,6 @@ export const Executed = () => (
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Executed"
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}
@@ -72,7 +68,6 @@ export const Cancelled = () => (
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Canceled"
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}
@@ -85,7 +80,6 @@ export const Defeated = () => (
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Defeated"
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}
@@ -98,7 +92,6 @@ export const Succeeded = () => (
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Succeeded"
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}
@@ -111,7 +104,6 @@ export const Expired = () => (
     proposalTitle="Buy back and burn and Tokenomic contribution finished soon"
     proposalState="Expired"
     endDate={new Date(1678859525000)}
-    createdDate={new Date(1678859525000)}
     cancelDate={undefined}
     queuedDate={new Date(1678899525000)}
     executedDate={new Date(1698859525000)}

--- a/src/pages/VoterDetails/History/VoterProposal/index.tsx
+++ b/src/pages/VoterDetails/History/VoterProposal/index.tsx
@@ -27,7 +27,6 @@ interface VoterProposalProps {
   againstVotesWei?: BigNumber;
   abstainedVotesWei?: BigNumber;
   endDate: Date | undefined;
-  createdDate: Date | undefined;
   cancelDate: Date | undefined;
   queuedDate: Date | undefined;
   executedDate: Date | undefined;
@@ -42,14 +41,14 @@ const VoterProposal: React.FC<VoterProposalProps> = ({
   forVotesWei,
   againstVotesWei,
   abstainedVotesWei,
-  createdDate,
   cancelDate,
   queuedDate,
   endDate,
   executedDate,
 }) => {
   const styles = useStyles();
-  const { t, Trans } = useTranslation();
+  const { t } = useTranslation();
+
   const voteChipText = useMemo(() => {
     switch (userVoteStatus) {
       case 'FOR':
@@ -69,100 +68,22 @@ const VoterProposal: React.FC<VoterProposalProps> = ({
     abstainedVotesWei || 0,
   ]);
 
-  const [stateChip, stateTimestamp] = useMemo(() => {
+  const stateChip = useMemo(() => {
     switch (proposalState) {
       case 'Active':
-        return [
-          <ActiveChip text={t('voteProposalUi.proposalState.active')} />,
-          createdDate && (
-            <Trans
-              i18nKey="voteProposalUi.proposalState.activeTimestamp"
-              components={{
-                Span: <Typography variant="small2" color="textPrimary" component="span" />,
-              }}
-              values={{
-                date: createdDate,
-              }}
-            />
-          ),
-        ];
+        return <ActiveChip text={t('voteProposalUi.proposalState.active')} />;
       case 'Canceled':
-        return [
-          <InactiveChip text={t('voteProposalUi.proposalState.canceled')} />,
-          cancelDate && (
-            <Trans
-              i18nKey="voteProposalUi.proposalState.canceledTimestamp"
-              components={{
-                Span: <Typography variant="small2" color="textPrimary" component="span" />,
-              }}
-              values={{
-                date: cancelDate,
-              }}
-            />
-          ),
-        ];
+        return <InactiveChip text={t('voteProposalUi.proposalState.canceled')} />;
       case 'Succeeded':
-        return [
-          <ActiveChip text={t('voteProposalUi.proposalState.passed')} />,
-          endDate && (
-            <Trans
-              i18nKey="voteProposalUi.proposalState.succeededTimestamp"
-              components={{
-                Span: <Typography variant="small2" color="textPrimary" component="span" />,
-              }}
-              values={{
-                date: endDate,
-              }}
-            />
-          ),
-        ];
+        return <ActiveChip text={t('voteProposalUi.proposalState.passed')} />;
       case 'Queued':
-        return [
-          <InactiveChip text={t('voteProposalUi.proposalState.queued')} />,
-          queuedDate && (
-            <Trans
-              i18nKey="voteProposalUi.proposalState.queuedTimestamp"
-              components={{
-                Span: <Typography variant="small2" color="textPrimary" component="span" />,
-              }}
-              values={{
-                date: queuedDate,
-              }}
-            />
-          ),
-        ];
+        return <InactiveChip text={t('voteProposalUi.proposalState.queued')} />;
       case 'Defeated':
-        return [
-          <ErrorChip text={t('voteProposalUi.proposalState.defeated')} />,
-          endDate && (
-            <Trans
-              i18nKey="voteProposalUi.proposalState.defeatedTimestamp"
-              components={{
-                Span: <Typography variant="small2" color="textPrimary" component="span" />,
-              }}
-              values={{
-                date: endDate,
-              }}
-            />
-          ),
-        ];
+        return <ErrorChip text={t('voteProposalUi.proposalState.defeated')} />;
       case 'Executed':
-        return [
-          <BlueChip text={t('voteProposalUi.proposalState.executed')} />,
-          executedDate && (
-            <Trans
-              i18nKey="voteProposalUi.proposalState.executedTimestamp"
-              components={{
-                Span: <Typography variant="small2" color="textPrimary" component="span" />,
-              }}
-              values={{
-                date: executedDate,
-              }}
-            />
-          ),
-        ];
+        return <BlueChip text={t('voteProposalUi.proposalState.executed')} />;
       default:
-        return [];
+        return undefined;
     }
   }, [proposalState]);
 
@@ -175,11 +96,6 @@ const VoterProposal: React.FC<VoterProposalProps> = ({
       headerLeftItem={stateChip}
       headerRightItem={voteChipText}
       title={proposalTitle}
-      footer={
-        <Typography variant="small2" component="span">
-          {stateTimestamp}
-        </Typography>
-      }
       contentRightItem={
         <ActiveVotingProgress
           votedForWei={forVotesWei}
@@ -188,6 +104,11 @@ const VoterProposal: React.FC<VoterProposalProps> = ({
           votedTotalWei={votedTotalWei}
         />
       }
+      proposalState={proposalState}
+      endDate={endDate}
+      cancelDate={cancelDate}
+      queuedDate={queuedDate}
+      executedDate={executedDate}
     />
   );
 };

--- a/src/pages/VoterDetails/History/index.tsx
+++ b/src/pages/VoterDetails/History/index.tsx
@@ -41,7 +41,6 @@ export const History: React.FC<HistoryProps> = ({
             forVotesWei,
             abstainedVotesWei,
             againstVotesWei,
-            createdDate,
             queuedDate,
             cancelDate,
             executedDate,
@@ -57,7 +56,6 @@ export const History: React.FC<HistoryProps> = ({
             againstVotesWei={againstVotesWei}
             abstainedVotesWei={abstainedVotesWei}
             userVoteStatus={support}
-            createdDate={createdDate}
             queuedDate={queuedDate}
             cancelDate={cancelDate}
             executedDate={executedDate}

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -406,6 +406,15 @@
       }
     }
   },
+  "proposalCard": {
+    "activeUntilDate": "Active until: <Date>{{ date, dd MMM h:mm a }}</Date>",
+    "canceled": "Canceled: <Date>{{ date, dd MMM h:mm a }}</Date>",
+    "defeated": "Defeated: <Date>{{ date, dd MMM h:mm a }}</Date>",
+    "executed": "Executed: <Date>{{ date, dd MMM h:mm a }}</Date>",
+    "expired": "Expired: <Date>{{ date, dd MMM h:mm a }}</Date>",
+    "queued": "Queued: <Date>{{ date, dd MMM h:mm a }}</Date>",
+    "succeeded": "Succeeded: <Date>{{ date, dd MMM h:mm a }}</Date>"
+  },
   "riskLevel": {
     "high": "High risk",
     "low": "Low risk",
@@ -737,7 +746,7 @@
     "youSuccessfullyVotedForTheProposal": "You successfully voted for the proposal"
   },
   "voteProposalUi": {
-    "activeUntilDate": "Active until: <Date>{{ date, dd MMM HH:mm }}</Date>",
+    "activeUntilDate": "Active until: <Date>{{ date, dd MMM h:mm a }}</Date>",
     "cancel": "Cancel",
     "countdownFormat": {
       "daysIncluded": "{{days}}d {{hours}}h : {{minutes}}m : {{seconds}}s",
@@ -751,17 +760,11 @@
     "proposalHistory": "Proposal History",
     "proposalState": {
       "active": "Active",
-      "activeTimestamp": "Active: <Span>{{date, dd MMM yyyy HH:mm}}</Span>",
       "canceled": "Canceled",
-      "canceledTimestamp": "Canceled: <Span>{{date, dd MMM yyyy HH:mm}}</Span>",
       "defeated": "Defeated",
-      "defeatedTimestamp": "Defeated: <Span>{{date, dd MMM yyyy HH:mm}}</Span>",
       "executed": "Executed",
-      "executedTimestamp": "Executed: <Span>{{date, dd MMM yyyy HH:mm}}</Span>",
       "passed": "Passed",
-      "queued": "Queued",
-      "queuedTimestamp": "Queued: <Span>{{date, dd MMM yyyy HH:mm}}</Span>",
-      "succeededTimestamp": "Succeeded: <Span>{{date, dd MMM yyyy HH:mm}}</Span>"
+      "queued": "Queued"
     },
     "queue": "Queue",
     "statusCard": {


### PR DESCRIPTION
## Jira ticket(s)

VEN-688

## Changes

- unify format of proposal timestamps 
- remove `footer` prop from `ProposalCard` in favor of displaying the relevant timestamp directly from the component
