### PR TITLE
Split TokenIcon into TokenIcon and TokenIconWithSymbol

### DIFF
--- a/src/components/EnableToken/index.tsx
+++ b/src/components/EnableToken/index.tsx
@@ -49,7 +49,7 @@ export const EnableTokenUi: React.FC<EnableTokenUiProps> = ({
         <Spinner />
       ) : (
         <>
-          <TokenIcon token={token} css={styles.mainLogo} showSymbol />
+          <TokenIcon token={token} css={styles.mainLogo} />
 
           <Typography component="h3" variant="h3" css={styles.mainText}>
             {title}

--- a/src/components/SelectTokenTextField/TokenList/index.tsx
+++ b/src/components/SelectTokenTextField/TokenList/index.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'translation';
 import { Token } from 'types';
 
 import { TextField } from '../../TextField';
-import { TokenIcon } from '../../TokenIcon';
+import { TokenIconWithSymbol } from '../../TokenIconWithSymbol';
 import { useStyles as useParentStyles } from '../styles';
 import { useStyles } from './styles';
 
@@ -59,7 +59,7 @@ export const TokenList: React.FC<TokenListProps> = ({ tokens, onTokenClick }) =>
             onClick={() => onTokenClick(token)}
             key={`select-token-text-field-item-${token.symbol}`}
           >
-            <TokenIcon css={parentStyles.token} token={token} showSymbol />
+            <TokenIconWithSymbol css={parentStyles.token} token={token} />
           </div>
         ))}
       </div>

--- a/src/components/SelectTokenTextField/index.tsx
+++ b/src/components/SelectTokenTextField/index.tsx
@@ -9,7 +9,7 @@ import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTok
 
 import { PrimaryButton } from '../Button';
 import { Icon } from '../Icon';
-import { TokenIcon } from '../TokenIcon';
+import { TokenIconWithSymbol } from '../TokenIconWithSymbol';
 import { TokenTextField, TokenTextFieldProps } from '../TokenTextField';
 import TokenList from './TokenList';
 import { useStyles } from './styles';
@@ -64,7 +64,7 @@ export const SelectTokenTextField: React.FC<SelectTokenTextFieldProps> = ({
                 css={styles.getButton({ isTokenListShown })}
                 disabled={disabled}
               >
-                <TokenIcon token={selectedToken} css={styles.token} showSymbol />
+                <TokenIconWithSymbol token={selectedToken} css={styles.token} />
 
                 <Icon css={styles.getArrowIcon({ isTokenListShown })} name="arrowUp" />
               </PrimaryButton>

--- a/src/components/TokenIcon/index.stories.tsx
+++ b/src/components/TokenIcon/index.stories.tsx
@@ -56,5 +56,3 @@ export const Default = () => (
     </div>
   </>
 );
-
-export const ShowSymbol = () => <TokenIcon token={TOKENS.usdc} showSymbol />;

--- a/src/components/TokenIcon/index.tsx
+++ b/src/components/TokenIcon/index.tsx
@@ -1,36 +1,16 @@
 /** @jsxImportSource @emotion/react */
-import Typography from '@mui/material/Typography';
 import React from 'react';
 import { Token } from 'types';
-
-import { TypographyVariant } from 'theme/MuiThemeProvider/muiTheme';
 
 import { useStyles } from './styles';
 
 export interface TokenIconProps {
   token: Token;
   className?: string;
-  variant?: TypographyVariant;
-  showSymbol?: boolean;
 }
 
-export const TokenIcon: React.FC<TokenIconProps> = ({
-  className,
-  token,
-  variant,
-  showSymbol = false,
-}) => {
+export const TokenIcon: React.FC<TokenIconProps> = ({ className, token }) => {
   const styles = useStyles();
 
-  return (
-    <div className={className} css={styles.container}>
-      <img src={token.asset} css={styles.icon} alt={token.symbol} />
-
-      {showSymbol && (
-        <Typography component="span" variant={variant}>
-          {token.symbol}
-        </Typography>
-      )}
-    </div>
-  );
+  return <img src={token.asset} css={styles.icon} alt={token.symbol} className={className} />;
 };

--- a/src/components/TokenIconWithSymbol/index.stories.tsx
+++ b/src/components/TokenIconWithSymbol/index.stories.tsx
@@ -1,0 +1,15 @@
+import { ComponentMeta } from '@storybook/react';
+import React from 'react';
+
+import { TOKENS } from 'constants/tokens';
+import { withCenterStory } from 'stories/decorators';
+
+import { TokenIconWithSymbol } from '.';
+
+export default {
+  title: 'Components/TokenIconWithSymbol',
+  component: TokenIconWithSymbol,
+  decorators: [withCenterStory({ width: '100px' })],
+} as ComponentMeta<typeof TokenIconWithSymbol>;
+
+export const Default = () => <TokenIconWithSymbol token={TOKENS.xvs} />;

--- a/src/components/TokenIconWithSymbol/index.tsx
+++ b/src/components/TokenIconWithSymbol/index.tsx
@@ -1,0 +1,33 @@
+/** @jsxImportSource @emotion/react */
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { Token } from 'types';
+
+import { TypographyVariant } from 'theme/MuiThemeProvider/muiTheme';
+
+import { TokenIcon } from '../TokenIcon';
+import { useStyles } from './styles';
+
+export interface TokenIconWithSymbolProps {
+  token: Token;
+  className?: string;
+  variant?: TypographyVariant;
+}
+
+export const TokenIconWithSymbol: React.FC<TokenIconWithSymbolProps> = ({
+  className,
+  token,
+  variant,
+}) => {
+  const styles = useStyles();
+
+  return (
+    <div className={className} css={styles.container}>
+      <TokenIcon token={token} css={styles.icon} />
+
+      <Typography component="span" variant={variant}>
+        {token.symbol}
+      </Typography>
+    </div>
+  );
+};

--- a/src/components/TokenIconWithSymbol/styles.ts
+++ b/src/components/TokenIconWithSymbol/styles.ts
@@ -5,8 +5,12 @@ export const useStyles = () => {
   const theme = useTheme();
 
   return {
+    container: css`
+      display: flex;
+      align-items: center;
+    `,
     icon: css`
-      margin-top: -2px;
+      margin-right: ${theme.spacing(2)};
       width: ${theme.shape.iconSize.large}px;
       height: ${theme.shape.iconSize.large}px;
     `,

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -37,6 +37,7 @@ export * from './TextField';
 export * from './Toast';
 export * from './Toggle';
 export * from './TokenIcon';
+export * from './TokenIconWithSymbol';
 export * from './TokenTextField';
 export * from './Tooltip';
 export * from './ValueUpdate';

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowMarketTable.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { Table, TableProps, TokenIcon } from 'components';
+import { Table, TableProps, TokenIconWithSymbol } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Asset } from 'types';
@@ -43,7 +43,7 @@ const BorrowMarketTable: React.FC<BorrowMarketTableProps> = ({
     return [
       {
         key: 'asset',
-        render: () => <TokenIcon token={asset.token} showSymbol />,
+        render: () => <TokenIconWithSymbol token={asset.token} />,
         value: asset.token.id,
         align: 'left',
       },

--- a/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
+++ b/src/pages/Dashboard/Markets/BorrowMarket/BorrowingTable.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
-import { LayeredValues, ProgressBar, Table, TableProps, TokenIcon } from 'components';
+import { LayeredValues, ProgressBar, Table, TableProps, TokenIconWithSymbol } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Asset } from 'types';
@@ -57,7 +57,7 @@ const BorrowingTable: React.FC<BorrowingUiProps> = ({
     return [
       {
         key: 'asset',
-        render: () => <TokenIcon token={asset.token} showSymbol />,
+        render: () => <TokenIconWithSymbol token={asset.token} />,
         value: asset.token.id,
         align: 'left',
       },

--- a/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SuppliedTable.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { LayeredValues, Table, TableProps, Toggle, TokenIcon } from 'components';
+import { LayeredValues, Table, TableProps, Toggle, TokenIconWithSymbol } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Asset } from 'types';
@@ -50,7 +50,7 @@ export const SuppliedTable: React.FC<SuppliedTableUiProps> = ({
   const rows: TableProps['data'] = assets.map(asset => [
     {
       key: 'asset',
-      render: () => <TokenIcon token={asset.token} showSymbol />,
+      render: () => <TokenIconWithSymbol token={asset.token} />,
       value: asset.token.id,
       align: 'left',
     },

--- a/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
+++ b/src/pages/Dashboard/Markets/SupplyMarket/SupplyMarketTable.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { Table, TableProps, Toggle, TokenIcon } from 'components';
+import { Table, TableProps, Toggle, TokenIconWithSymbol } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Asset } from 'types';
@@ -49,7 +49,7 @@ export const SupplyMarketTable: React.FC<SupplyMarketTableUiProps> = ({
     return [
       {
         key: 'asset',
-        render: () => <TokenIcon token={asset.token} showSymbol />,
+        render: () => <TokenIconWithSymbol token={asset.token} />,
         value: asset.token.id,
         align: 'left',
       },

--- a/src/pages/Dashboard/Modals/BorrowRepay/index.tsx
+++ b/src/pages/Dashboard/Modals/BorrowRepay/index.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { Modal, ModalProps, TabContent, Tabs, TokenIcon } from 'components';
+import { Modal, ModalProps, TabContent, Tabs, TokenIconWithSymbol } from 'components';
 import React from 'react';
 import { useTranslation } from 'translation';
 import { Asset } from 'types';
@@ -44,7 +44,7 @@ const BorrowRepay: React.FC<BorrowRepayProps> = ({ onClose, asset, isXvsEnabled 
   return (
     <Modal
       isOpen
-      title={<TokenIcon token={asset.token} variant="h4" showSymbol />}
+      title={<TokenIconWithSymbol token={asset.token} variant="h4" />}
       handleClose={onClose}
     >
       <Tabs tabsContent={tabsContent} />

--- a/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
+++ b/src/pages/Dashboard/Modals/SupplyWithdraw/index.tsx
@@ -8,7 +8,7 @@ import {
   ModalProps,
   TabContent,
   Tabs,
-  TokenIcon,
+  TokenIconWithSymbol,
 } from 'components';
 import React, { useContext } from 'react';
 import { useTranslation } from 'translation';
@@ -218,7 +218,7 @@ export const SupplyWithdrawUi: React.FC<SupplyWithdrawUiProps & SupplyWithdrawPr
     <Modal
       isOpen={!!assetId}
       handleClose={onClose}
-      title={assetId ? <TokenIcon token={asset.token} variant="h4" showSymbol /> : undefined}
+      title={assetId ? <TokenIconWithSymbol token={asset.token} variant="h4" /> : undefined}
     >
       <Tabs tabsContent={tabsContent} />
     </Modal>

--- a/src/pages/Market/MarketTable/index.tsx
+++ b/src/pages/Market/MarketTable/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
-import { LayeredValues, Table, TableProps, TokenIcon } from 'components';
+import { LayeredValues, Table, TableProps, TokenIconWithSymbol } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Market } from 'types';
@@ -69,7 +69,7 @@ export const MarketTableUi: React.FC<MarketTableProps> = ({ markets, getRowHref 
         {
           key: 'asset',
           render: () => (
-            <TokenIcon token={unsafelyGetToken(market.id)} css={localStyles.whiteText} showSymbol />
+            <TokenIconWithSymbol token={unsafelyGetToken(market.id)} css={localStyles.whiteText} />
           ),
           value: market.id,
         },

--- a/src/pages/Xvs/Table/index.tsx
+++ b/src/pages/Xvs/Table/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
-import { Table, TableProps, TokenIcon } from 'components';
+import { Table, TableProps, TokenIconWithSymbol } from 'components';
 import React, { useContext, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Asset } from 'types';
@@ -58,7 +58,7 @@ const XvsTableUi: React.FC<XvsTableProps> = ({ assets }) => {
   const rows: TableProps['data'] = assets.map(asset => [
     {
       key: 'asset',
-      render: () => <TokenIcon token={asset.token} showSymbol />,
+      render: () => <TokenIconWithSymbol token={asset.token} />,
       value: asset.token.id,
       align: 'left',
     },


### PR DESCRIPTION
## Changes

- split `TokenIcon` component into `TokenIcon` and `TokenIconWithSymbol` so `TokenIcon` can be used the same way the `Icon` component is used, while `TokenIconWithSymbol` represents a more static display of a token and its symbol (the icon style cannot be modified on purpose)
