### PR TITLE
[VEN-698] Add token approval step to Swap

### DIFF
--- a/src/components/EnableToken/index.stories.tsx
+++ b/src/components/EnableToken/index.stories.tsx
@@ -1,8 +1,8 @@
 import Typography from '@mui/material/Typography';
 import { ComponentMeta } from '@storybook/react';
-import { noop } from 'lodash';
 import React from 'react';
 
+import fakeTransactionReceipt from '__mocks__/models/transactionReceipt';
 import { TOKENS } from 'constants/tokens';
 import { withCenterStory } from 'stories/decorators';
 
@@ -19,7 +19,7 @@ export const Disabled = () => (
     title="To withdraw XVS to the Venus Protocol, you need to enable it first."
     token={TOKENS.xvs}
     isTokenEnabled={false}
-    enableToken={noop}
+    enableToken={async () => fakeTransactionReceipt}
   >
     <Typography>Invisible Content</Typography>
   </EnableTokenUi>
@@ -34,7 +34,7 @@ export const DisabledWithTokenInfo = () => (
       { iconSrc: TOKENS.usdc, label: 'Supply APY', children: '77.36' },
       { iconSrc: TOKENS.usdc, label: 'Distribution APY', children: '0.82' },
     ]}
-    enableToken={noop}
+    enableToken={async () => fakeTransactionReceipt}
   >
     <Typography>Invisible Content</Typography>
   </EnableTokenUi>
@@ -46,7 +46,7 @@ export const Enabled = () => (
     isTokenEnabled
     token={TOKENS.usdc}
     tokenInfo={[]}
-    enableToken={noop}
+    enableToken={async () => fakeTransactionReceipt}
   >
     <Typography>Visible Content</Typography>
   </EnableTokenUi>

--- a/src/components/EnableToken/index.tsx
+++ b/src/components/EnableToken/index.tsx
@@ -1,16 +1,19 @@
 /** @jsxImportSource @emotion/react */
 import Typography from '@mui/material/Typography';
+import { VError, formatVErrorToReadableString } from 'errors';
 import React, { useContext } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
+import type { TransactionReceipt } from 'web3-core/types';
 
-import { useApproveToken, useGetAllowance } from 'clients/api';
 import { AuthContext } from 'context/AuthContext';
+import useTokenApproval from 'hooks/useTokenApproval';
 
 import { SecondaryButton } from '../Button';
 import { Delimiter } from '../Delimiter';
 import { LabeledInlineContent, LabeledInlineContentProps } from '../LabeledInlineContent';
 import { Spinner } from '../Spinner';
+import { toast } from '../Toast';
 import { TokenIcon } from '../TokenIcon';
 import useStyles from './styles';
 
@@ -18,7 +21,7 @@ export interface EnableTokenUiProps {
   token: Token;
   title: string | React.ReactElement;
   isTokenEnabled: boolean;
-  enableToken: () => void;
+  enableToken: () => Promise<TransactionReceipt | undefined>;
   isInitialLoading?: boolean;
   isEnableTokenLoading?: boolean;
   tokenInfo?: LabeledInlineContentProps[];
@@ -42,6 +45,22 @@ export const EnableTokenUi: React.FC<EnableTokenUiProps> = ({
   if (isTokenEnabled) {
     return <>{children}</>;
   }
+
+  const handleEnableToken = async () => {
+    try {
+      await enableToken();
+    } catch (error) {
+      let { message } = error as Error;
+
+      if (error instanceof VError) {
+        message = formatVErrorToReadableString(error);
+      }
+
+      toast.error({
+        message,
+      });
+    }
+  };
 
   return (
     <div css={styles.container}>
@@ -73,7 +92,7 @@ export const EnableTokenUi: React.FC<EnableTokenUiProps> = ({
             disabled={disabled || isEnableTokenLoading}
             loading={isEnableTokenLoading}
             fullWidth
-            onClick={enableToken}
+            onClick={handleEnableToken}
           >
             {t('enableToken.enableButtonLabel')}
           </SecondaryButton>
@@ -91,42 +110,21 @@ export interface EnableTokenProps
 export const EnableToken: React.FC<EnableTokenProps> = ({ token, spenderAddress, ...rest }) => {
   const { account } = useContext(AuthContext);
 
-  const { data: getTokenAllowanceData, isLoading: isGetAllowanceLoading } = useGetAllowance(
-    {
-      accountAddress: account?.address || '',
-      spenderAddress,
+  const { isTokenApprovalStatusLoading, isTokenApproved, approveToken, isApproveTokenLoading } =
+    useTokenApproval({
       token,
-    },
-    {
-      enabled: !!account?.address,
-    },
-  );
-
-  const isTokenApproved =
-    token.isNative ||
-    (!!getTokenAllowanceData && getTokenAllowanceData.allowanceWei.isGreaterThan(0));
-
-  const { mutate: contractApproveToken, isLoading: isApproveTokenLoading } = useApproveToken({
-    token,
-  });
-
-  const approveToken = () => {
-    if (account?.address) {
-      contractApproveToken({
-        accountAddress: account.address,
-        spenderAddress,
-      });
-    }
-  };
+      spenderAddress,
+      accountAddress: account?.address,
+    });
 
   return (
     <EnableTokenUi
       {...rest}
       token={token}
       enableToken={approveToken}
-      isTokenEnabled={isTokenApproved}
+      isTokenEnabled={isTokenApproved ?? false}
       isEnableTokenLoading={isApproveTokenLoading}
-      isInitialLoading={isGetAllowanceLoading}
+      isInitialLoading={isTokenApprovalStatusLoading}
       disabled={!account}
     />
   );

--- a/src/components/SelectTokenTextField/TokenList/styles.ts
+++ b/src/components/SelectTokenTextField/TokenList/styles.ts
@@ -16,6 +16,7 @@ export const useStyles = () => {
       border-radius: ${theme.spacing(3)};
       background-color: ${theme.palette.background.default};
       box-shadow: 0 4px 15px 0 rgba(22, 23, 30, 0.8);
+      overflow: hidden;
     `,
     searchField: css`
       margin: ${theme.spacing(3, 3, 2)};

--- a/src/components/SelectTokenTextField/TokenList/styles.ts
+++ b/src/components/SelectTokenTextField/TokenList/styles.ts
@@ -18,7 +18,7 @@ export const useStyles = () => {
       box-shadow: 0 4px 15px 0 rgba(22, 23, 30, 0.8);
     `,
     searchField: css`
-      margin: ${theme.spacing(4, 4, 3)};
+      margin: ${theme.spacing(3, 3, 2)};
 
       > div {
         background-color: ${theme.palette.secondary.main};

--- a/src/constants/tokens/pancakeSwap/mainnet.ts
+++ b/src/constants/tokens/pancakeSwap/mainnet.ts
@@ -1,42 +1,11 @@
 import { Token } from 'types';
 
-import bnb from 'assets/img/tokens/bnb.svg';
-import vai from 'assets/img/tokens/vai.svg';
-import vrt from 'assets/img/tokens/vrt.svg';
-import xvs from 'assets/img/tokens/xvs.svg';
+import { MAINNET_TOKENS } from '../common/mainnet';
 
 // List adapted from PancakeSwap's repository:
 // https://github.com/pancakeswap/token-list/blob/main/src/tokens/pancakeswap-extended.json
 export const MAINNET_PANCAKE_SWAP_TOKENS = {
-  bnb: {
-    id: 'bnb',
-    symbol: 'BNB',
-    decimals: 18,
-    address: '',
-    asset: bnb,
-    isNative: true,
-  } as Token,
-  xvs: {
-    id: 'xvs',
-    symbol: 'XVS',
-    decimals: 18,
-    address: '0xcF6BB5389c92Bdda8a3747Ddb454cB7a64626C63',
-    asset: xvs,
-  } as Token,
-  vai: {
-    id: 'vai',
-    symbol: 'VAI',
-    decimals: 18,
-    address: '0x4BD17003473389A42DAF6a0a729f6Fdb328BbBd7',
-    asset: vai,
-  } as Token,
-  vrt: {
-    id: 'vrt',
-    symbol: 'VRT',
-    decimals: 18,
-    address: '0x5F84ce30DC3cF7909101C69086c50De191895883',
-    asset: vrt,
-  } as Token,
+  ...MAINNET_TOKENS,
   wbnb: {
     id: 'wbnb',
     symbol: 'WBNB',
@@ -44,46 +13,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
     asset:
       'https://tokens.pancakeswap.finance/images/0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c.png',
-  } as Token,
-  cake: {
-    id: 'cake',
-    symbol: 'CAKE',
-    decimals: 18,
-    address: '0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82.png',
-  } as Token,
-  busd: {
-    id: 'busd',
-    symbol: 'BUSD',
-    decimals: 18,
-    address: '0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56.png',
-  } as Token,
-  usdt: {
-    id: 'usdt',
-    symbol: 'USDT',
-    decimals: 18,
-    address: '0x55d398326f99059fF775485246999027B3197955',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x55d398326f99059fF775485246999027B3197955.png',
-  } as Token,
-  btcb: {
-    id: 'btcb',
-    symbol: 'BTCB',
-    decimals: 18,
-    address: '0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x7130d2A12B9BCbFAe4f2634d864A1Ee1Ce3Ead9c.png',
-  } as Token,
-  eth: {
-    id: 'eth',
-    symbol: 'ETH',
-    decimals: 18,
-    address: '0x2170Ed0880ac9A755fd29B2688956BD959F933F8',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x2170Ed0880ac9A755fd29B2688956BD959F933F8.png',
   } as Token,
   bunny: {
     id: 'bunny',
@@ -93,7 +22,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     asset:
       'https://tokens.pancakeswap.finance/images/0xC9849E6fdB743d08fAeE3E34dd2D1bc69EA11a51.png',
   } as Token,
-
   alpaca: {
     id: 'alpaca',
     symbol: 'ALPACA',
@@ -101,14 +29,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     address: '0x8F0528cE5eF7B51152A59745bEfDD91D97091d2F',
     asset:
       'https://tokens.pancakeswap.finance/images/0x8F0528cE5eF7B51152A59745bEfDD91D97091d2F.png',
-  } as Token,
-  dot: {
-    id: 'dot',
-    symbol: 'DOT',
-    decimals: 18,
-    address: '0x7083609fCE4d1d8Dc0C979AAb8c869Ea2C873402',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x7083609fCE4d1d8Dc0C979AAb8c869Ea2C873402.png',
   } as Token,
   fine: {
     id: 'fine',
@@ -118,15 +38,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     asset:
       'https://tokens.pancakeswap.finance/images/0x4e6415a5727ea08aAE4580057187923aeC331227.png',
   } as Token,
-  dai: {
-    id: 'dai',
-    symbol: 'DAI',
-    decimals: 18,
-    address: '0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x1AF3F329e8BE154074D8769D1FFa4eE058B1DBc3.png',
-  } as Token,
-
   bake: {
     id: 'bake',
     symbol: 'BAKE',
@@ -150,38 +61,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     address: '0x56b6fB708fC5732DEC1Afc8D8556423A2EDcCbD6',
     asset:
       'https://tokens.pancakeswap.finance/images/0x56b6fB708fC5732DEC1Afc8D8556423A2EDcCbD6.png',
-  } as Token,
-  xrp: {
-    id: 'xrp',
-    symbol: 'XRP',
-    decimals: 18,
-    address: '0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x1D2F0da169ceB9fC7B3144628dB156f3F6c60dBE.png',
-  } as Token,
-  bch: {
-    id: 'bch',
-    symbol: 'BCH',
-    decimals: 18,
-    address: '0x8fF795a6F4D97E7887C79beA79aba5cc76444aDf',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x8fF795a6F4D97E7887C79beA79aba5cc76444aDf.png',
-  } as Token,
-  ltc: {
-    id: 'ltc',
-    symbol: 'LTC',
-    decimals: 18,
-    address: '0x4338665CBB7B2485A8855A139b75D5e34AB0DB94',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x4338665CBB7B2485A8855A139b75D5e34AB0DB94.png',
-  } as Token,
-  ada: {
-    id: 'ada',
-    symbol: 'ADA',
-    decimals: 18,
-    address: '0x3EE2200Efb3400fAbB9AacF31297cBdD1d435D47',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x3EE2200Efb3400fAbB9AacF31297cBdD1d435D47.png',
   } as Token,
   atom: {
     id: 'atom',
@@ -247,14 +126,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     asset:
       'https://tokens.pancakeswap.finance/images/0xf307910A4c7bbc79691fD374889b36d8531B08e3.png',
   } as Token,
-  link: {
-    id: 'link',
-    symbol: 'LINK',
-    decimals: 18,
-    address: '0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0xF8A0BF9cF54Bb92F17374d9e9A321E6a111a51bD.png',
-  } as Token,
   burger: {
     id: 'burger',
     symbol: 'BURGER',
@@ -311,14 +182,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     asset:
       'https://tokens.pancakeswap.finance/images/0xBf5140A22578168FD562DCcF235E5D43A02ce9B1.png',
   } as Token,
-  fil: {
-    id: 'fil',
-    symbol: 'FIL',
-    decimals: 18,
-    address: '0x0D8Ce2A99Bb6e3B7Db580eD848240e4a0F9aE153',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x0D8Ce2A99Bb6e3B7Db580eD848240e4a0F9aE153.png',
-  } as Token,
   kava: {
     id: 'kava',
     symbol: 'KAVA',
@@ -342,14 +205,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     address: '0x47BEAd2563dCBf3bF2c9407fEa4dC236fAbA485A',
     asset:
       'https://tokens.pancakeswap.finance/images/0x47BEAd2563dCBf3bF2c9407fEa4dC236fAbA485A.png',
-  } as Token,
-  usdc: {
-    id: 'usdc',
-    symbol: 'USDC',
-    decimals: 18,
-    address: '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d.png',
   } as Token,
   ctk: {
     id: 'ctk',
@@ -575,14 +430,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     asset:
       'https://tokens.pancakeswap.finance/images/0x62D71B23bF15218C7d2D7E48DBbD9e9c650B173f.png',
   } as Token,
-  ust: {
-    id: 'ust',
-    symbol: 'UST',
-    decimals: 18,
-    address: '0x23396cF899Ca06c4472205fC903bDB4de249D6fC',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x23396cF899Ca06c4472205fC903bDB4de249D6fC.png',
-  } as Token,
   bfi: {
     id: 'bfi',
     symbol: 'BFI',
@@ -638,14 +485,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     address: '0x762539b45A1dCcE3D36d080F74d1AED37844b878',
     asset:
       'https://tokens.pancakeswap.finance/images/0x762539b45A1dCcE3D36d080F74d1AED37844b878.png',
-  } as Token,
-  beth: {
-    id: 'beth',
-    symbol: 'BETH',
-    decimals: 18,
-    address: '0x250632378E573c6Be1AC2f97Fcdf00515d0Aa91B',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x250632378E573c6Be1AC2f97Fcdf00515d0Aa91B.png',
   } as Token,
   lusd: {
     id: 'lusd',
@@ -1159,14 +998,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     asset:
       'https://tokens.pancakeswap.finance/images/0x352Cb5E19b12FC216548a2677bD0fce83BaE434B.png',
   } as Token,
-  trx: {
-    id: 'trx',
-    symbol: 'TRX',
-    decimals: 18,
-    address: '0x85EAC5Ac2F758618dFa09bDbe0cf174e7d574D5B',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x85EAC5Ac2F758618dFa09bDbe0cf174e7d574D5B.png',
-  } as Token,
   win: {
     id: 'win',
     symbol: 'WIN',
@@ -1190,14 +1021,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     address: '0x07AaA29E63FFEB2EBf59B33eE61437E1a91A3bb2',
     asset:
       'https://tokens.pancakeswap.finance/images/0x07AaA29E63FFEB2EBf59B33eE61437E1a91A3bb2.png',
-  } as Token,
-  doge: {
-    id: 'doge',
-    symbol: 'DOGE',
-    decimals: 8,
-    address: '0xbA2aE424d960c26247Dd6c32edC70B295c744C43',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0xbA2aE424d960c26247Dd6c32edC70B295c744C43.png',
   } as Token,
   oin: {
     id: 'oin',
@@ -1327,14 +1150,6 @@ export const MAINNET_PANCAKE_SWAP_TOKENS = {
     address: '0x431e0cD023a32532BF3969CddFc002c00E98429d',
     asset:
       'https://tokens.pancakeswap.finance/images/0x431e0cD023a32532BF3969CddFc002c00E98429d.png',
-  } as Token,
-  tusd: {
-    id: 'tusd',
-    symbol: 'TUSD',
-    decimals: 18,
-    address: '0x14016E85a25aeb13065688cAFB43044C2ef86784',
-    asset:
-      'https://tokens.pancakeswap.finance/images/0x14016E85a25aeb13065688cAFB43044C2ef86784.png',
   } as Token,
   mtrg: {
     id: 'mtrg',

--- a/src/hooks/useTokenApproval/index.ts
+++ b/src/hooks/useTokenApproval/index.ts
@@ -1,0 +1,71 @@
+import { useMemo } from 'react';
+import { Token } from 'types';
+import type { TransactionReceipt } from 'web3-core/types';
+
+import { useApproveToken, useGetAllowance } from 'clients/api';
+
+interface UseTokenApprovalInput {
+  token: Token;
+  spenderAddress: string;
+  accountAddress?: string;
+}
+
+interface UseTokenApprovalOutput {
+  isTokenApproved: boolean | undefined;
+  isTokenApprovalStatusLoading: boolean;
+  approveToken: () => Promise<TransactionReceipt | undefined>;
+  isApproveTokenLoading: boolean;
+}
+
+// TODO: add tests
+
+const useTokenApproval = ({
+  token,
+  spenderAddress,
+  accountAddress,
+}: UseTokenApprovalInput): UseTokenApprovalOutput => {
+  const { data: getTokenAllowanceData, isLoading: isTokenApprovalStatusLoading } = useGetAllowance(
+    {
+      accountAddress: accountAddress || '',
+      spenderAddress,
+      token,
+    },
+    {
+      enabled: !!accountAddress && !token.isNative,
+    },
+  );
+
+  const isTokenApproved = useMemo(() => {
+    if (token.isNative) {
+      return true;
+    }
+
+    if (!getTokenAllowanceData) {
+      return undefined;
+    }
+
+    return getTokenAllowanceData.allowanceWei.isGreaterThan(0);
+  }, [token.isNative, getTokenAllowanceData]);
+
+  const { mutateAsync: approveTokenMutation, isLoading: isApproveTokenLoading } = useApproveToken({
+    token,
+  });
+
+  const approveToken = async () => {
+    if (accountAddress) {
+      return approveTokenMutation({
+        accountAddress,
+        spenderAddress,
+      });
+    }
+  };
+
+  return {
+    isTokenApproved,
+    isTokenApprovalStatusLoading,
+    approveToken,
+    isApproveTokenLoading,
+  };
+};
+
+export default useTokenApproval;

--- a/src/pages/Swap/SubmitSection/index.tsx
+++ b/src/pages/Swap/SubmitSection/index.tsx
@@ -1,0 +1,204 @@
+/** @jsxImportSource @emotion/react */
+import { Typography } from '@mui/material';
+import { Icon, PrimaryButton, Tooltip, toast } from 'components';
+import { VError, formatVErrorToReadableString } from 'errors';
+import React, { useMemo } from 'react';
+import { useTranslation } from 'translation';
+import { Swap } from 'types';
+import { convertWeiToTokens, getContractAddress } from 'utilities';
+import type { TransactionReceipt } from 'web3-core/types';
+
+import { AuthContext } from 'context/AuthContext';
+import useTokenApproval from 'hooks/useTokenApproval';
+
+import { FormError, FormValues } from '../types';
+import { SwapError } from '../useGetSwapInfo';
+import { useStyles } from './styles';
+
+const pancakeRouterContractAddress = getContractAddress('pancakeRouter');
+
+export interface SubmitSectionUiProps extends Omit<SubmitSectionProps, 'fromTokenAmountTokens'> {
+  onSubmit: () => Promise<void>;
+  isSubmitting: boolean;
+  isFromTokenEnabled: boolean | undefined;
+  isFromTokenApprovalStatusLoading: boolean;
+  enableFromToken: () => Promise<TransactionReceipt | undefined>;
+  isEnableFromTokenLoading: boolean;
+}
+
+const SubmitSectionUi: React.FC<SubmitSectionUiProps> = ({
+  onSubmit,
+  isSubmitting,
+  fromToken,
+  isFromTokenEnabled,
+  isFromTokenApprovalStatusLoading,
+  enableFromToken,
+  isEnableFromTokenLoading,
+  isFormValid,
+  swapError,
+  swap,
+  formErrors,
+}) => {
+  const styles = useStyles();
+  const { t } = useTranslation();
+
+  const submitButtonLabel = useMemo(() => {
+    if (swapError === 'INSUFFICIENT_LIQUIDITY') {
+      return t('swapPage.submitButton.disabledLabels.insufficientLiquidity');
+    }
+
+    if (formErrors[0] === 'INVALID_FROM_TOKEN_AMOUNT') {
+      return t('swapPage.submitButton.disabledLabels.invalidFromTokenAmount');
+    }
+
+    if (formErrors[0] === 'WRAPPING_UNSUPPORTED') {
+      return t('swapPage.submitButton.disabledLabels.wrappingUnsupported');
+    }
+
+    if (formErrors[0] === 'UNWRAPPING_UNSUPPORTED') {
+      return t('swapPage.submitButton.disabledLabels.unwrappingUnsupported');
+    }
+
+    if (formErrors[0] === 'FROM_TOKEN_AMOUNT_HIGHER_THAN_USER_BALANCE') {
+      return t('swapPage.submitButton.disabledLabels.insufficientUserBalance', {
+        tokenSymbol: fromToken.symbol,
+      });
+    }
+
+    if (swap) {
+      return t('swapPage.submitButton.enabledLabel', {
+        fromTokenAmount: convertWeiToTokens({
+          valueWei:
+            swap.direction === 'exactAmountIn'
+              ? swap.fromTokenAmountSoldWei
+              : swap.maximumFromTokenAmountSoldWei,
+          token: swap.fromToken,
+          returnInReadableFormat: true,
+        }),
+        toTokenAmount: convertWeiToTokens({
+          valueWei:
+            swap.direction === 'exactAmountIn'
+              ? swap.minimumToTokenAmountReceivedWei
+              : swap.toTokenAmountReceivedWei,
+          token: swap.toToken,
+          returnInReadableFormat: true,
+        }),
+      });
+    }
+
+    return t('swapPage.submitButton.processing');
+  }, [swap, swapError, formErrors[0], isFormValid]);
+
+  const handleEnableFromToken = async () => {
+    try {
+      await enableFromToken();
+    } catch (error) {
+      let { message } = error as Error;
+
+      if (error instanceof VError) {
+        message = formatVErrorToReadableString(error);
+      }
+
+      toast.error({
+        message,
+      });
+    }
+  };
+
+  const showTokenEnablingStep =
+    !isFromTokenApprovalStatusLoading &&
+    isFromTokenEnabled === false &&
+    !swapError &&
+    formErrors.length === 0;
+
+  return (
+    <div css={styles.container}>
+      {showTokenEnablingStep && (
+        <>
+          <div css={styles.buttonLabelContainer}>
+            <Typography variant="small1" component="label" css={styles.buttonLabel}>
+              {t('swapPage.enablingStep.step1')}
+            </Typography>
+
+            <Tooltip
+              title={t('swapPage.enablingStep.enableTokenButton.tooltip')}
+              css={styles.enableTokenTooltip}
+            >
+              <Icon name="info" />
+            </Tooltip>
+          </div>
+
+          <PrimaryButton
+            fullWidth
+            onClick={handleEnableFromToken}
+            loading={isEnableFromTokenLoading}
+            css={styles.enableTokenButton}
+          >
+            {t('swapPage.enablingStep.enableTokenButton.text', {
+              tokenSymbol: fromToken.symbol,
+            })}
+          </PrimaryButton>
+
+          <div css={styles.buttonLabelContainer}>
+            <Typography variant="small1" component="label" css={styles.buttonLabel}>
+              {t('swapPage.enablingStep.step2')}
+            </Typography>
+          </div>
+        </>
+      )}
+
+      <PrimaryButton
+        fullWidth
+        disabled={
+          !isFormValid ||
+          isEnableFromTokenLoading ||
+          isFromTokenApprovalStatusLoading ||
+          !isFromTokenEnabled
+        }
+        onClick={onSubmit}
+        loading={isSubmitting}
+      >
+        {submitButtonLabel}
+      </PrimaryButton>
+    </div>
+  );
+};
+
+export interface SubmitSectionProps {
+  fromToken: FormValues['fromToken'];
+  onSubmit: () => Promise<void>;
+  isSubmitting: boolean;
+  isFormValid: boolean;
+  formErrors: FormError[];
+  swap?: Swap;
+  swapError?: SwapError;
+}
+
+const SubmitSection: React.FC<SubmitSectionProps> = ({ fromToken, formErrors, ...otherProps }) => {
+  const { account } = React.useContext(AuthContext);
+
+  const {
+    isTokenApproved: isFromTokenEnabled,
+    approveToken: enableFromToken,
+    isApproveTokenLoading: isEnableFromTokenLoading,
+    isTokenApprovalStatusLoading: isFromTokenApprovalStatusLoading,
+  } = useTokenApproval({
+    token: fromToken,
+    spenderAddress: pancakeRouterContractAddress,
+    accountAddress: account?.address,
+  });
+
+  return (
+    <SubmitSectionUi
+      enableFromToken={enableFromToken}
+      isFromTokenEnabled={isFromTokenEnabled}
+      isFromTokenApprovalStatusLoading={isFromTokenApprovalStatusLoading}
+      isEnableFromTokenLoading={isEnableFromTokenLoading}
+      fromToken={fromToken}
+      formErrors={formErrors}
+      {...otherProps}
+    />
+  );
+};
+
+export default SubmitSection;

--- a/src/pages/Swap/SubmitSection/styles.ts
+++ b/src/pages/Swap/SubmitSection/styles.ts
@@ -1,0 +1,28 @@
+import { css } from '@emotion/react';
+import { useTheme } from '@mui/material';
+
+export const useStyles = () => {
+  const theme = useTheme();
+
+  return {
+    container: css`
+      margin-top: ${theme.spacing(8)};
+    `,
+    buttonLabelContainer: css`
+      margin-bottom: ${theme.spacing(1)};
+      display: flex;
+      align-items: center;
+    `,
+    buttonLabel: css`
+      display: block;
+      color: ${theme.palette.text.primary};
+    `,
+    enableTokenButton: css`
+      margin-bottom: ${theme.spacing(8)};
+    `,
+    enableTokenTooltip: css`
+      display: flex;
+      margin-left: ${theme.spacing(2)};
+    `,
+  };
+};

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -5,7 +5,6 @@ import {
   ConnectWallet,
   Icon,
   LabeledInlineContent,
-  PrimaryButton,
   SelectTokenTextField,
   TertiaryButton,
   toast,
@@ -28,6 +27,7 @@ import {
 import { AuthContext } from 'context/AuthContext';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 
+import SubmitSection from './SubmitSection';
 import { useStyles } from './styles';
 import { FormValues } from './types';
 import useFormValidation from './useFormValidation';
@@ -50,10 +50,10 @@ const initialFormValues: FormValues = {
 export interface SwapPageUiProps {
   formValues: FormValues;
   setFormValues: (setter: (currentFormValues: FormValues) => FormValues) => void;
-  fromTokenUserBalanceWei?: BigNumber;
-  toTokenUserBalanceWei?: BigNumber;
   onSubmit: (swap: Swap) => Promise<TransactionReceipt>;
   isSubmitting: boolean;
+  fromTokenUserBalanceWei?: BigNumber;
+  toTokenUserBalanceWei?: BigNumber;
   swap?: Swap;
   swapError?: SwapError;
 }
@@ -147,7 +147,7 @@ const SwapPageUi: React.FC<SwapPageUiProps> = ({
   }, [formValues.fromToken.address, formValues.toToken.address]);
 
   // Form validation
-  const { isValid, errors: formErrors } = useFormValidation({
+  const { isFormValid, errors: formErrors } = useFormValidation({
     swap,
     formValues,
     fromTokenUserBalanceWei,
@@ -268,55 +268,15 @@ const SwapPageUi: React.FC<SwapPageUiProps> = ({
           </>
         )}
 
-        <PrimaryButton
-          fullWidth
-          disabled={!isValid}
-          css={styles.submitButton}
-          onClick={handleSubmit}
-          loading={isSubmitting}
-        >
-          {swapError === 'INSUFFICIENT_LIQUIDITY' &&
-            t('swapPage.submitButton.disabledLabels.insufficientLiquidity')}
-
-          {!swapError &&
-            formErrors[0] === 'INVALID_FROM_TOKEN_AMOUNT' &&
-            t('swapPage.submitButton.disabledLabels.invalidFromTokenAmount')}
-
-          {!swapError &&
-            formErrors[0] === 'FROM_TOKEN_AMOUNT_HIGHER_THAN_USER_BALANCE' &&
-            t('swapPage.submitButton.disabledLabels.insufficientUserBalance', {
-              tokenSymbol: formValues.fromToken.symbol,
-            })}
-
-          {!swapError &&
-            formErrors[0] === 'WRAPPING_UNSUPPORTED' &&
-            t('swapPage.submitButton.disabledLabels.wrappingUnsupported')}
-
-          {!swapError &&
-            formErrors[0] === 'UNWRAPPING_UNSUPPORTED' &&
-            t('swapPage.submitButton.disabledLabels.unwrappingUnsupported')}
-
-          {isValid &&
-            swap &&
-            t('swapPage.submitButton.enabledLabel', {
-              fromTokenAmount: convertWeiToTokens({
-                valueWei:
-                  swap.direction === 'exactAmountIn'
-                    ? swap.fromTokenAmountSoldWei
-                    : swap.maximumFromTokenAmountSoldWei,
-                token: swap.fromToken,
-                returnInReadableFormat: true,
-              }),
-              toTokenAmount: convertWeiToTokens({
-                valueWei:
-                  swap.direction === 'exactAmountIn'
-                    ? swap.minimumToTokenAmountReceivedWei
-                    : swap.toTokenAmountReceivedWei,
-                token: swap.toToken,
-                returnInReadableFormat: true,
-              }),
-            })}
-        </PrimaryButton>
+        <SubmitSection
+          onSubmit={handleSubmit}
+          fromToken={formValues.fromToken}
+          isSubmitting={isSubmitting}
+          isFormValid={isFormValid}
+          formErrors={formErrors}
+          swap={swap}
+          swapError={swapError}
+        />
       </ConnectWallet>
     </Paper>
   );

--- a/src/pages/Swap/useFormValidation.ts
+++ b/src/pages/Swap/useFormValidation.ts
@@ -14,7 +14,7 @@ interface UseFormValidationInput {
 }
 
 interface UseFormValidationOutput {
-  isValid: boolean;
+  isFormValid: boolean;
   errors: FormError[];
 }
 
@@ -70,10 +70,10 @@ const useFormValidation = ({
   }, [formValues.fromToken, formValues.toToken]);
 
   const errors = wrapUnwrapErrors.concat(fromTokenAmountErrors);
-  const isValid = !!swap && errors.length === 0;
+  const isFormValid = !!swap && errors.length === 0;
 
   return {
-    isValid,
+    isFormValid,
     errors,
   };
 };

--- a/src/pages/Swap/useGetSwapInfo/index.ts
+++ b/src/pages/Swap/useGetSwapInfo/index.ts
@@ -142,7 +142,13 @@ const useGetSwapInfo = (input: UseGetSwapInfoInput) => {
       swap,
       error,
     };
-  }, [getPancakeSwapPairsData?.pairs, input.fromTokenAmountTokens, input.toTokenAmountTokens]);
+  }, [
+    getPancakeSwapPairsData?.pairs,
+    input.fromToken,
+    input.toToken,
+    input.fromTokenAmountTokens,
+    input.toTokenAmountTokens,
+  ]);
 };
 
 export default useGetSwapInfo;

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -393,6 +393,14 @@
   },
   "swapPage": {
     "connectWalletToSwap": "Please connect your wallet to swap tokens",
+    "enablingStep": {
+      "enableTokenButton": {
+        "text": "Enable {{tokenSymbol}}",
+        "tooltip": "We use PancakeSwap to support our swap feature, which requires spending approval for any token you wish to exchange from"
+      },
+      "step1": "Step 1",
+      "step2": "Step 2"
+    },
     "exchangeRate": {
       "label": "Exchange rate",
       "value": "1 {{fromTokenSymbol}} ≈ {{rate}} {{toTokenSymbol}}"
@@ -417,7 +425,8 @@
         "unwrappingUnsupported": "Unwrapping unsupported",
         "wrappingUnsupported": "Wrapping unsupported"
       },
-      "enabledLabel": "Swap {{fromTokenAmount}} for {{toTokenAmount}}"
+      "enabledLabel": "Swap {{fromTokenAmount}} for {{toTokenAmount}}",
+      "processing": "Processing"
     },
     "successfulConvertTransactionModal": {
       "message": "You successfully swapped your tokens",


### PR DESCRIPTION
## Jira ticket(s)

VEN-698

## Changes

- create `useTokenApproval` hook that returns the approval status of a token for a given spender address as well as a function to ask for approval
- update mainnet Pancake Swap token list to include all mainnet tokens (main list)
- update submit section of Swap form to include approval step when required
