### PR TITLE
Fix token references used to compute swap info

### DIFF
--- a/src/pages/Swap/useGetSwapInfo/__tests__/__snapshots__/formatToSwap.spec.ts.snap
+++ b/src/pages/Swap/useGetSwapInfo/__tests__/__snapshots__/formatToSwap.spec.ts.snap
@@ -1,0 +1,57 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`pages/Swap/useGetSwapInfo/formatToSwap formats trade to swap correctly when direction is "exactAmountIn" 1`] = `
+Object {
+  "direction": "exactAmountIn",
+  "exchangeRate": "1",
+  "expectedToTokenAmountReceivedWei": "10000000000000000000",
+  "fromToken": Object {
+    "address": "0xaB1a4d4f1D656d2450692D237fdD6C7f9146e814",
+    "asset": "https://pancakeswap.finance/images/tokens/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56.svg",
+    "decimals": 18,
+    "id": "busd",
+    "symbol": "BUSD",
+  },
+  "fromTokenAmountSoldWei": "10000000000000000000",
+  "minimumToTokenAmountReceivedWei": "9000000000000000000",
+  "routePath": Array [
+    "0xaB1a4d4f1D656d2450692D237fdD6C7f9146e814",
+    "0xFa60D973F7642B748046464e165A65B7323b0DEE",
+  ],
+  "toToken": Object {
+    "address": "0xFa60D973F7642B748046464e165A65B7323b0DEE",
+    "asset": "https://pancakeswap.finance/images/tokens/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82.svg",
+    "decimals": 18,
+    "id": "cake",
+    "symbol": "CAKE",
+  },
+}
+`;
+
+exports[`pages/Swap/useGetSwapInfo/formatToSwap formats trade to swap correctly when direction is "exactAmountOut" 1`] = `
+Object {
+  "direction": "exactAmountOut",
+  "exchangeRate": "1",
+  "expectedFromTokenAmountSoldWei": "10000000000000000000",
+  "fromToken": Object {
+    "address": "0xaB1a4d4f1D656d2450692D237fdD6C7f9146e814",
+    "asset": "https://pancakeswap.finance/images/tokens/0xe9e7CEA3DedcA5984780Bafc599bD69ADd087D56.svg",
+    "decimals": 18,
+    "id": "busd",
+    "symbol": "BUSD",
+  },
+  "maximumFromTokenAmountSoldWei": "11000000000000000000",
+  "routePath": Array [
+    "0xaB1a4d4f1D656d2450692D237fdD6C7f9146e814",
+    "0xFa60D973F7642B748046464e165A65B7323b0DEE",
+  ],
+  "toToken": Object {
+    "address": "0xFa60D973F7642B748046464e165A65B7323b0DEE",
+    "asset": "https://pancakeswap.finance/images/tokens/0x0E09FaBB73Bd3Ade0a17ECC321fD13a19e81cE82.svg",
+    "decimals": 18,
+    "id": "cake",
+    "symbol": "CAKE",
+  },
+  "toTokenAmountReceivedWei": "10000000000000000000",
+}
+`;

--- a/src/pages/Swap/useGetSwapInfo/__tests__/formatToSwap.spec.ts
+++ b/src/pages/Swap/useGetSwapInfo/__tests__/formatToSwap.spec.ts
@@ -1,0 +1,67 @@
+import { Token as PSToken } from '@pancakeswap/sdk/dist/index.js';
+import BigNumber from 'bignumber.js';
+import { BscChainId } from 'types';
+
+import { PANCAKE_SWAP_TOKENS } from 'constants/tokens';
+
+import formatToSwap from '../formatToSwap';
+import { FormatToSwapInput } from '../types';
+
+const fakeRoute = {
+  path: [
+    new PSToken(
+      BscChainId.TESTNET,
+      PANCAKE_SWAP_TOKENS.busd.address,
+      PANCAKE_SWAP_TOKENS.busd.decimals,
+      PANCAKE_SWAP_TOKENS.busd.symbol,
+    ),
+    new PSToken(
+      BscChainId.TESTNET,
+      PANCAKE_SWAP_TOKENS.cake.address,
+      PANCAKE_SWAP_TOKENS.cake.decimals,
+      PANCAKE_SWAP_TOKENS.cake.symbol,
+    ),
+  ],
+};
+
+describe('pages/Swap/useGetSwapInfo/formatToSwap', () => {
+  it('formats trade to swap correctly when direction is "exactAmountIn"', () => {
+    const fakeTrade = {
+      route: fakeRoute,
+      inputAmount: new BigNumber(10),
+      outputAmount: new BigNumber(10),
+      executionPrice: new BigNumber(1),
+      minimumAmountOut: jest.fn(() => new BigNumber(9)),
+    } as unknown as FormatToSwapInput['trade'];
+
+    const fakeInput: FormatToSwapInput['input'] = {
+      fromToken: PANCAKE_SWAP_TOKENS.busd,
+      toToken: PANCAKE_SWAP_TOKENS.cake,
+      direction: 'exactAmountIn',
+    };
+
+    const res = formatToSwap({ trade: fakeTrade, input: fakeInput });
+
+    expect(res).toMatchSnapshot();
+  });
+
+  it('formats trade to swap correctly when direction is "exactAmountOut"', () => {
+    const fakeTrade = {
+      route: fakeRoute,
+      inputAmount: new BigNumber(10),
+      outputAmount: new BigNumber(10),
+      executionPrice: new BigNumber(1),
+      maximumAmountIn: jest.fn(() => new BigNumber(11)),
+    } as unknown as FormatToSwapInput['trade'];
+
+    const fakeInput: FormatToSwapInput['input'] = {
+      fromToken: PANCAKE_SWAP_TOKENS.busd,
+      toToken: PANCAKE_SWAP_TOKENS.cake,
+      direction: 'exactAmountOut',
+    };
+
+    const res = formatToSwap({ trade: fakeTrade, input: fakeInput });
+
+    expect(res).toMatchSnapshot();
+  });
+});

--- a/src/pages/Swap/useGetSwapInfo/formatToSwap.ts
+++ b/src/pages/Swap/useGetSwapInfo/formatToSwap.ts
@@ -7,9 +7,9 @@ import { SLIPPAGE_TOLERANCE_PERCENTAGE } from 'constants/swap';
 
 import { FormatToSwapInput, FormatToSwapOutput } from './types';
 
-// Format trade to swap info
 const slippagePercent = new PSPercent(`${SLIPPAGE_TOLERANCE_PERCENTAGE * 10}`, 1000);
 
+// Format trade to swap info
 const formatToSwap = ({ trade, input }: FormatToSwapInput): FormatToSwapOutput => {
   const routePath = trade.route.path.map(token => token.address);
 
@@ -25,11 +25,11 @@ const formatToSwap = ({ trade, input }: FormatToSwapInput): FormatToSwapOutput =
       }),
       expectedToTokenAmountReceivedWei: convertTokensToWei({
         value: new BigNumber(trade.outputAmount.toFixed()),
-        token: input.fromToken,
+        token: input.toToken,
       }),
       minimumToTokenAmountReceivedWei: convertTokensToWei({
         value: new BigNumber(trade.minimumAmountOut(slippagePercent).toFixed()),
-        token: input.fromToken,
+        token: input.toToken,
       }),
       exchangeRate: new BigNumber(trade.executionPrice.toFixed(input.toToken.decimals)).dp(
         input.toToken.decimals,
@@ -51,11 +51,11 @@ const formatToSwap = ({ trade, input }: FormatToSwapInput): FormatToSwapOutput =
     }),
     maximumFromTokenAmountSoldWei: convertTokensToWei({
       value: new BigNumber(trade.maximumAmountIn(slippagePercent).toFixed()),
-      token: input.fromToken,
+      token: input.toToken,
     }),
     toTokenAmountReceivedWei: convertTokensToWei({
       value: new BigNumber(trade.outputAmount.toFixed()),
-      token: input.fromToken,
+      token: input.toToken,
     }),
     exchangeRate: new BigNumber(trade.executionPrice.toFixed(input.toToken.decimals)).dp(
       input.toToken.decimals,


### PR DESCRIPTION
`formatToSwap` used the wrong token references when computing wei values, resulting in incorrect values being used for swap where `toToken` and `fromToken` have different decimals.