### PR TITLE
Fix reserves and minted token values displayed on Market Details page

### DIFF
--- a/src/pages/MarketDetails/index.tsx
+++ b/src/pages/MarketDetails/index.tsx
@@ -188,7 +188,7 @@ export const MarketDetailsUi: React.FC<MarketDetailsUiProps> = ({
           : formatTokensToReadableValue({
               value: borrowCapTokens,
               minimizeDecimals: true,
-              token: vToken,
+              token,
             }),
       },
       {
@@ -236,7 +236,7 @@ export const MarketDetailsUi: React.FC<MarketDetailsUiProps> = ({
           value: mintedTokens,
           minimizeDecimals: true,
           addSymbol: false,
-          token: vToken,
+          token,
         }),
       },
       {

--- a/src/pages/MarketDetails/useGetMarketData.ts
+++ b/src/pages/MarketDetails/useGetMarketData.ts
@@ -22,6 +22,7 @@ const useGetMarketData = ({ vTokenId }: { vTokenId: Token['id'] }) => {
   const assetMarket = (getMarketData?.markets || []).find(market => market.id === vTokenId);
 
   return React.useMemo(() => {
+    const token = unsafelyGetToken(vTokenId);
     const vToken = unsafelyGetVToken(vTokenId);
     const totalBorrowBalanceCents = assetMarket && +assetMarket.totalBorrowsUsd * 100;
     const totalSupplyBalanceCents = assetMarket && +assetMarket.totalSupplyUsd * 100;
@@ -84,14 +85,14 @@ const useGetMarketData = ({ vTokenId }: { vTokenId: Token['id'] }) => {
       assetMarket &&
       convertWeiToTokens({
         valueWei: new BigNumber(assetMarket.totalReserves),
-        token: vToken,
+        token,
       });
 
     const exchangeRateVTokens =
       assetMarket &&
       new BigNumber(1).div(
         new BigNumber(assetMarket.exchangeRate).div(
-          new BigNumber(10).pow(18 + unsafelyGetToken(vTokenId).decimals - vToken.decimals),
+          new BigNumber(10).pow(18 + token.decimals - vToken.decimals),
         ),
       );
 
@@ -99,7 +100,7 @@ const useGetMarketData = ({ vTokenId }: { vTokenId: Token['id'] }) => {
     if (vTokenCashData?.cashWei && assetMarket && reserveTokens) {
       const vTokenCashTokens = convertWeiToTokens({
         valueWei: vTokenCashData.cashWei,
-        token: vToken,
+        token,
       });
 
       currentUtilizationRate = new BigNumber(assetMarket.totalBorrows2)


### PR DESCRIPTION
The wrong token references were being used to compute the reserves and minted token values on the Market Details page, resulting in incorrect readable values being displayed.