### PR TITLE
Remove top margin on Swap and Convert VRT pages

### DIFF
--- a/src/pages/ConvertVrt/index.tsx
+++ b/src/pages/ConvertVrt/index.tsx
@@ -63,7 +63,7 @@ export const ConvertVrtUi = ({
   ];
 
   return (
-    <div css={[styles.root, styles.marginTop]}>
+    <div css={[styles.root]}>
       <Paper css={styles.tabs}>
         <Tabs tabsContent={tabsContent} />
       </Paper>

--- a/src/pages/ConvertVrt/styles.ts
+++ b/src/pages/ConvertVrt/styles.ts
@@ -4,20 +4,12 @@ import { useTheme } from '@mui/material';
 export const useStyles = () => {
   const theme = useTheme();
   return {
-    marginTop: css`
-      margin-top: ${theme.spacing(34)};
-
-      ${theme.breakpoints.down('md')} {
-        margin-top: ${theme.spacing(0)};
-      }
-    `,
     root: css`
       display: flex;
       align-items: center;
       min-height: 100%;
       flex: 1;
       flex-direction: column;
-      margin-top: ${theme.spacing(12)};
     `,
     tabs: css`
       max-width: ${theme.spacing(136)};

--- a/src/pages/Swap/styles.ts
+++ b/src/pages/Swap/styles.ts
@@ -9,12 +9,11 @@ export const useStyles = () => {
       max-width: ${theme.spacing(136)};
       width: 100%;
       padding: ${theme.spacing(10)};
-      margin: ${theme.spacing(34, 'auto', 0)};
+      margin: ${theme.spacing(0, 'auto')};
 
       ${theme.breakpoints.down('md')} {
         max-width: 100%;
         padding: ${theme.spacing(4)};
-        margin-top: ${theme.spacing(0)};
       }
     `,
     selectTokenTextField: css`


### PR DESCRIPTION
This as been lingering for some time and we've received more complaints from users, so here it is.

This PR removes the top margin applied to the Swap and Convert VRT pages and that would add unnecessary scrolling space on some screens.