### PR TITLE
[VEN-816] Add vToken to Asset type

### DIFF
--- a/src/containers/MarketTable/index.tsx
+++ b/src/containers/MarketTable/index.tsx
@@ -3,7 +3,6 @@ import { Table, TableProps, switchAriaLabel, toast } from 'components';
 import { VError, formatVErrorToReadableString } from 'errors';
 import React, { useContext, useMemo } from 'react';
 import { Asset } from 'types';
-import { unsafelyGetVToken } from 'utilities';
 
 import { TOKENS } from 'constants/tokens';
 import { DisableLunaUstWarningContext } from 'context/DisableLunaUstWarning';
@@ -101,13 +100,10 @@ export const MarketTable: React.FC<MarketTableProps> = ({
       return;
     }
 
-    // TODO: get vToken from asset directly
-    const vToken = unsafelyGetVToken(row.token.id);
-
     if (marketType === 'borrow') {
-      openBorrowRepayModal({ token: row.token, vToken });
+      openBorrowRepayModal({ token: row.token, vToken: row.vToken });
     } else {
-      openSupplyWithdrawModal({ token: row.token, vToken });
+      openSupplyWithdrawModal({ token: row.token, vToken: row.vToken });
     }
   };
 

--- a/src/hooks/useBorrowRepayModal/Modal/index.tsx
+++ b/src/hooks/useBorrowRepayModal/Modal/index.tsx
@@ -3,7 +3,7 @@ import { Modal, ModalProps, TabContent, Tabs, TokenIconWithSymbol } from 'compon
 import React from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
-import { isAssetEnabled } from 'utilities';
+import { isTokenEnabled } from 'utilities';
 
 import Borrow from './Borrow';
 import Repay from './Repay';
@@ -31,7 +31,7 @@ const BorrowRepay: React.FC<BorrowRepayProps> = ({ onClose, token, vToken, inclu
     },
   ];
 
-  if (isAssetEnabled(vToken.id)) {
+  if (isTokenEnabled(token)) {
     tabsContent.unshift({
       title: t('borrowRepayModal.borrowTabTitle'),
       content: (

--- a/src/hooks/useCollateral/index.tsx
+++ b/src/hooks/useCollateral/index.tsx
@@ -2,7 +2,6 @@ import BigNumber from 'bignumber.js';
 import { VError } from 'errors';
 import React, { useCallback, useContext, useState } from 'react';
 import { Asset } from 'types';
-import { unsafelyGetVToken } from 'utilities';
 
 import {
   getHypotheticalAccountLiquidity,
@@ -62,12 +61,10 @@ const useCollateral = () => {
       });
     }
 
-    const vToken = unsafelyGetVToken(asset.token.id);
-
     setSelectedAsset(asset);
 
     if (asset.collateral) {
-      const vTokenContract = getVTokenContract(vToken, web3);
+      const vTokenContract = getVTokenContract(asset.vToken, web3);
 
       try {
         const vTokenBalanceOf = await getVTokenBalanceOf({
@@ -78,12 +75,12 @@ const useCollateral = () => {
         const assetHypotheticalLiquidity = await getHypotheticalAccountLiquidity({
           comptrollerContract,
           accountAddress,
-          vTokenAddress: vToken.address,
+          vTokenAddress: asset.vToken.address,
           vTokenBalanceOfWei: new BigNumber(vTokenBalanceOf.balanceWei),
         });
 
         if (+assetHypotheticalLiquidity['1'] > 0 || +assetHypotheticalLiquidity['2'] === 0) {
-          await exitMarket({ vtokenAddress: vToken.address, accountAddress });
+          await exitMarket({ vtokenAddress: asset.vToken.address, accountAddress });
         }
       } catch (error) {
         if (error instanceof VError) {
@@ -100,7 +97,7 @@ const useCollateral = () => {
       }
     } else {
       try {
-        await enterMarkets({ vTokenAddresses: [vToken.address], accountAddress });
+        await enterMarkets({ vTokenAddresses: [asset.vToken.address], accountAddress });
       } catch (error) {
         if (error instanceof VError) {
           throw error;

--- a/src/hooks/useSupplyWithdrawModal/Modal/index.tsx
+++ b/src/hooks/useSupplyWithdrawModal/Modal/index.tsx
@@ -14,7 +14,7 @@ import {
 import React, { useContext } from 'react';
 import { useTranslation } from 'translation';
 import { Asset, Token } from 'types';
-import { convertTokensToWei, formatToReadablePercentage, isAssetEnabled } from 'utilities';
+import { convertTokensToWei, formatToReadablePercentage, isTokenEnabled } from 'utilities';
 
 import {
   useGetUserAsset,
@@ -39,7 +39,7 @@ export interface SupplyWithdrawProps {
   vToken: Token;
 }
 
-export interface SupplyWithdrawUiProps extends SupplyWithdrawProps {
+export interface SupplyWithdrawUiProps extends Omit<SupplyWithdrawProps, 'token' | 'vToken'> {
   userTotalBorrowBalanceCents: BigNumber;
   userTotalBorrowLimitCents: BigNumber;
   onSubmitSupply: AmountFormProps['onSubmit'];
@@ -59,8 +59,6 @@ export const SupplyWithdrawUi: React.FC<SupplyWithdrawUiProps> = ({
   className,
   onClose,
   asset,
-  token,
-  vToken,
   assets,
   userTotalBorrowBalanceCents,
   userTotalBorrowLimitCents,
@@ -72,7 +70,6 @@ export const SupplyWithdrawUi: React.FC<SupplyWithdrawUiProps> = ({
 }) => {
   const styles = useStyles();
 
-  const { id: assetId, symbol } = asset?.token || {};
   const { t } = useTranslation();
 
   const tokenInfo: LabeledInlineContentProps[] = asset
@@ -158,7 +155,7 @@ export const SupplyWithdrawUi: React.FC<SupplyWithdrawUiProps> = ({
           {asset ? (
             <EnableToken
               token={asset.token}
-              spenderAddress={vToken.address}
+              spenderAddress={asset.vToken.address}
               title={title}
               tokenInfo={tokenInfo}
             >
@@ -194,7 +191,7 @@ export const SupplyWithdrawUi: React.FC<SupplyWithdrawUiProps> = ({
       content: renderTabContent({
         type: 'withdraw',
         message: t('supplyWithdraw.connectWalletToWithdraw'),
-        title: t('supplyWithdraw.enableToWithdraw', { symbol }),
+        title: t('supplyWithdraw.enableToWithdraw', { symbol: asset?.token.symbol }),
         inputLabel: t('supplyWithdraw.withdrawableAmount'),
         enabledButtonKey: t('supplyWithdraw.withdraw'),
         disabledButtonKey: t('supplyWithdraw.enterValidAmountWithdraw'),
@@ -206,13 +203,13 @@ export const SupplyWithdrawUi: React.FC<SupplyWithdrawUiProps> = ({
   ];
 
   // Prevent user from being able to supply UST or LUNA
-  if (assetId && isAssetEnabled(assetId)) {
+  if (asset && isTokenEnabled(asset.token)) {
     tabsContent.unshift({
       title: t('supplyWithdraw.supply'),
       content: renderTabContent({
         type: 'supply',
         message: t('supplyWithdraw.connectWalletToSupply'),
-        title: t('supplyWithdraw.enableToSupply', { symbol }),
+        title: t('supplyWithdraw.enableToSupply', { symbol: asset?.token.symbol }),
         inputLabel: t('supplyWithdraw.walletBalance'),
         enabledButtonKey: t('supplyWithdraw.supply'),
         disabledButtonKey: t('supplyWithdraw.enterValidAmountSupply'),
@@ -225,9 +222,9 @@ export const SupplyWithdrawUi: React.FC<SupplyWithdrawUiProps> = ({
 
   return (
     <Modal
-      isOpen={!!assetId}
+      isOpen={!!asset}
       handleClose={onClose}
-      title={assetId ? <TokenIconWithSymbol token={token} variant="h4" /> : undefined}
+      title={asset && <TokenIconWithSymbol token={asset.token} variant="h4" />}
     >
       <Tabs tabsContent={tabsContent} />
     </Modal>
@@ -340,8 +337,6 @@ const SupplyWithdrawModal: React.FC<SupplyWithdrawProps> = ({
   return (
     <SupplyWithdrawUi
       onClose={onClose}
-      token={token}
-      vToken={vToken}
       asset={asset}
       assets={assets}
       userTotalBorrowBalanceCents={userTotalBorrowBalanceCents}

--- a/src/utilities/featureFlags.ts
+++ b/src/utilities/featureFlags.ts
@@ -1,7 +1,8 @@
+import { Token } from 'types';
+
 import { TOKENS } from 'constants/tokens';
 
 export const DISABLED_TOKENS = [TOKENS.ust, TOKENS.luna];
 
-// TODO: update to use vToken address
-export const isAssetEnabled = (assetId: string) =>
-  !DISABLED_TOKENS.some(disabledToken => disabledToken.id === assetId);
+export const isTokenEnabled = (token: Token) =>
+  !DISABLED_TOKENS.some(disabledToken => disabledToken.address === token.address);


### PR DESCRIPTION
## Jira ticket(s)

VEN-816

## Changes

- add `vToken` field to `Asset` type
- update `isAssetEnabled` utility function to `isTokenEnabled`, which takes a token as parameter instead of a token ID
- use `vToken` and `token` from asset where applicable
