### PR TITLE
[HOTFIX] Fix Market Details charts

### DIFF
--- a/src/clients/api/queries/getMarketHistory/useGetMarketHistory.ts
+++ b/src/clients/api/queries/getMarketHistory/useGetMarketHistory.ts
@@ -11,10 +11,14 @@ type Options = QueryObserverOptions<
   Error,
   GetMarketHistoryOutput,
   GetMarketHistoryOutput,
-  FunctionKey.GET_MARKET_HISTORY
+  [FunctionKey.GET_MARKET_HISTORY, { vTokenId: string }]
 >;
 
 const useGetMarketHistory = (input: GetMarketHistoryInput, options?: Options) =>
-  useQuery(FunctionKey.GET_MARKET_HISTORY, () => getMarketHistory(input), options);
+  useQuery(
+    [FunctionKey.GET_MARKET_HISTORY, { vTokenId: input.vTokenId }],
+    () => getMarketHistory(input),
+    options,
+  );
 
 export default useGetMarketHistory;

--- a/src/pages/MarketDetails/useGetChartData.ts
+++ b/src/pages/MarketDetails/useGetChartData.ts
@@ -29,17 +29,13 @@ const useGetChartData = ({ vTokenId }: { vTokenId: Token['id'] }) => {
         supplyChartData.push({
           apyPercentage: formatPercentage(marketSnapshot.supplyApy),
           timestampMs,
-          balanceCents: new BigNumber(marketSnapshot.totalSupply).multipliedBy(
-            marketSnapshot.priceUSD,
-          ),
+          balanceCents: new BigNumber(marketSnapshot.totalSupply).multipliedBy(100),
         });
 
         borrowChartData.push({
           apyPercentage: formatPercentage(marketSnapshot.borrowApy),
           timestampMs,
-          balanceCents: new BigNumber(marketSnapshot.totalBorrow).multipliedBy(
-            marketSnapshot.priceUSD,
-          ),
+          balanceCents: new BigNumber(marketSnapshot.totalBorrow).multipliedBy(100),
         });
       });
 


### PR DESCRIPTION
Charts on the Market Details page assumed the `totalBorrow` and `totalSupply` fields returned from the `/market_history/graph` endpoint of the API corresponded to values in tokens. It turns out these are expressed in dollars.
This PR fixes that issue, as well as making the query key used in the query of the `useGetMarketHistory` hook unique to the vToken it's being called for.