### PR TITLE
Fix Market Details charts (develop)

### DIFF
--- a/src/clients/api/queries/getMarketHistory/useGetMarketHistory.ts
+++ b/src/clients/api/queries/getMarketHistory/useGetMarketHistory.ts
@@ -11,10 +11,14 @@ type Options = QueryObserverOptions<
   Error,
   GetMarketHistoryOutput,
   GetMarketHistoryOutput,
-  FunctionKey.GET_MARKET_HISTORY
+  [FunctionKey.GET_MARKET_HISTORY, { vTokenAddress: string }]
 >;
 
 const useGetMarketHistory = (input: GetMarketHistoryInput, options?: Options) =>
-  useQuery(FunctionKey.GET_MARKET_HISTORY, () => getMarketHistory(input), options);
+  useQuery(
+    [FunctionKey.GET_MARKET_HISTORY, { vTokenAddress: input.vToken.address }],
+    () => getMarketHistory(input),
+    options,
+  );
 
 export default useGetMarketHistory;

--- a/src/pages/Market/useGetChartData.ts
+++ b/src/pages/Market/useGetChartData.ts
@@ -29,17 +29,13 @@ const useGetChartData = ({ vToken }: { vToken: Token }) => {
         supplyChartData.push({
           apyPercentage: formatPercentage(marketSnapshot.supplyApy),
           timestampMs,
-          balanceCents: new BigNumber(marketSnapshot.totalSupply).multipliedBy(
-            marketSnapshot.priceUSD,
-          ),
+          balanceCents: new BigNumber(marketSnapshot.totalSupply).multipliedBy(100),
         });
 
         borrowChartData.push({
           apyPercentage: formatPercentage(marketSnapshot.borrowApy),
           timestampMs,
-          balanceCents: new BigNumber(marketSnapshot.totalBorrow).multipliedBy(
-            marketSnapshot.priceUSD,
-          ),
+          balanceCents: new BigNumber(marketSnapshot.totalBorrow).multipliedBy(100),
         });
       });
 


### PR DESCRIPTION
This is the equivalent of https://github.com/VenusProtocol/venus-protocol-interface/pull/871, but for the `develop` branch (the fix can't just be rebased in since the type definition of the type of `useGetMarketHistory` is different on this branch).