### PR TITLE
[VEN-812] Fixed condition to cancel proposals

### DIFF
--- a/src/pages/Proposal/ProposalSummary/index.tsx
+++ b/src/pages/Proposal/ProposalSummary/index.tsx
@@ -272,14 +272,15 @@ const ProposalSummary: React.FC<ProposalSummaryUiProps> = ({ className, proposal
     proposalId: proposal.id,
   });
 
-  const { data: currentVotesData } = useGetCurrentVotes(
-    { accountAddress },
+  const { data: proposerVotesData } = useGetCurrentVotes(
+    { accountAddress: proposal.proposer },
     { enabled: !!accountAddress },
   );
 
   const canCancelProposal =
-    proposalThresholdData?.thresholdWei &&
-    currentVotesData?.votesWei.isGreaterThanOrEqualTo(proposalThresholdData?.thresholdWei);
+    proposal.proposer === account?.address ||
+    (proposalThresholdData?.thresholdWei &&
+      proposerVotesData?.votesWei.isLessThan(proposalThresholdData?.thresholdWei));
 
   return (
     <ProposalSummaryUi

--- a/src/pages/Proposal/ProposalSummary/index.tsx
+++ b/src/pages/Proposal/ProposalSummary/index.tsx
@@ -280,7 +280,7 @@ const ProposalSummary: React.FC<ProposalSummaryUiProps> = ({ className, proposal
   const canCancelProposal =
     proposal.proposer === account?.address ||
     (proposalThresholdData?.thresholdWei &&
-      proposerVotesData?.votesWei.isLessThan(proposalThresholdData?.thresholdWei));
+      proposerVotesData?.votesWei.isLessThan(proposalThresholdData.thresholdWei));
 
   return (
     <ProposalSummaryUi


### PR DESCRIPTION
## Jira ticket(s)

[VEN-812](https://jira.toolsfdg.net/browse/VEN-812)

## Changes
Proposals can now be cancelled if either one of the following conditions are true:
- The connected account is also the proposer
- If the proposer's voting power is less than the proposal threshold, meaning anyone could cancel the proposal if this condition is true
