### PR TITLE
Fix decimal places of 0 token values

### DIFF
--- a/src/utilities/shortenValueWithSuffix.ts
+++ b/src/utilities/shortenValueWithSuffix.ts
@@ -27,6 +27,10 @@ export const shortenValueWithSuffix = ({
     return value.toFixed(2);
   }
 
+  if (value.isEqualTo(0) && !outputsDollars) {
+    return '0';
+  }
+
   return value.toFixed(outputsDollars ? 2 : 8);
 };
 


### PR DESCRIPTION
## Changes

- prevent 0 token values from being displayed with 8 decimals when using shortenValueWithSuffix

Before:
<img width="155" alt="Screen Shot 2022-12-21 at 15 12 12" src="https://user-images.githubusercontent.com/44675210/208925215-81dee3f5-13ba-4121-b57d-42ec0a78d69c.png">

After:
<img width="112" alt="Screen Shot 2022-12-21 at 15 10 57" src="https://user-images.githubusercontent.com/44675210/208925001-8caabadd-240f-4b59-a39d-9253a08cdeb9.png">
