### PR TITLE
[VEN-834] Fixes PR test coverage comment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,8 +102,12 @@ jobs:
           --outputFile=./coverage/report.json
 
       - uses: ArtiomTr/jest-coverage-report-action@v2
+        id: coverage
         with:
           package-manager: yarn
           coverage-file: ./coverage/report.json
           skip-step: all
           github-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: ${{ steps.coverage.outputs.report }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -101,13 +101,19 @@ jobs:
           yarn test --ci --json --coverage --testLocationInResults
           --outputFile=./coverage/report.json
 
+      - uses: jwalton/gh-find-current-pr@v1
+        id: findPr
+
       - uses: ArtiomTr/jest-coverage-report-action@v2
         id: coverage
         with:
           package-manager: yarn
           coverage-file: ./coverage/report.json
           skip-step: all
+          output: report-markdown
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: marocchino/sticky-pull-request-comment@v2
         with:
+          number: ${{ steps.findPr.outputs.number }}
           message: ${{ steps.coverage.outputs.report }}


### PR DESCRIPTION
## Jira ticket(s)

VEN-834

## Changes

- Now uses `marocchino/sticky-pull-request-comment@v2` to output the result of the test coverage
