### PR TITLE
[VEN-546][VEN-547] Wire up Pool and Pools pages

### DIFF
--- a/src/clients/api/queries/getVTokenBalancesAll/useGetVTokenBalancesAll.ts
+++ b/src/clients/api/queries/getVTokenBalancesAll/useGetVTokenBalancesAll.ts
@@ -5,6 +5,7 @@ import getVTokenBalancesAll, {
   IGetVTokenBalancesAllOutput,
 } from 'clients/api/queries/getVTokenBalancesAll';
 import { useVenusLensContract } from 'clients/contracts/hooks';
+import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 
 type Options = QueryObserverOptions<
@@ -23,7 +24,10 @@ const useGetVTokenBalancesAll = (
   return useQuery(
     [FunctionKey.GET_V_TOKEN_BALANCES_ALL, { account, vTokenAddresses }],
     () => getVTokenBalancesAll({ venusLensContract, account, vTokenAddresses }),
-    options,
+    {
+      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+      ...options,
+    },
   );
 };
 

--- a/src/clients/api/queries/useGetTreasuryTotals/__snapshots__/index.spec.tsx.snap
+++ b/src/clients/api/queries/useGetTreasuryTotals/__snapshots__/index.spec.tsx.snap
@@ -2,9 +2,9 @@
 
 exports[`api/queries/useGetTreasuryTotals calculates totals correctly 1`] = `
 Object {
-  "treasuryTotalAvailableLiquidityBalanceCents": "18928013655",
-  "treasuryTotalBalanceCents": "1278673398650.057497628212781879085878",
-  "treasuryTotalBorrowBalanceCents": "858808797230375",
-  "treasuryTotalSupplyBalanceCents": "2099280079056468",
+  "treasuryBalanceCents": 3836020195950,
+  "treasuryBorrowBalanceCents": 2576426391691125,
+  "treasuryLiquidityBalanceCents": 56784040965,
+  "treasurySupplyBalanceCents": 6297840237169404,
 }
 `;

--- a/src/clients/api/queries/useGetTreasuryTotals/index.spec.tsx
+++ b/src/clients/api/queries/useGetTreasuryTotals/index.spec.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 
-import { markets } from '__mocks__/models/markets';
+import { poolData } from '__mocks__/models/pools';
 import { vTokenBalanceTreasury } from '__mocks__/models/vTokenBalanceTreasury';
-import { getMainMarkets, useGetVTokenBalancesAll } from 'clients/api';
+import { useGetPools, useGetVTokenBalancesAll } from 'clients/api';
 import renderComponent from 'testUtils/renderComponent';
 
 import useGetTreasuryTotals, { UseGetTreasuryTotalsOutput } from '.';
@@ -11,7 +11,12 @@ jest.mock('clients/api');
 
 describe('api/queries/useGetTreasuryTotals', () => {
   beforeEach(() => {
-    (getMainMarkets as jest.Mock).mockImplementation(() => ({ markets }));
+    (useGetPools as jest.Mock).mockImplementation(() => ({
+      data: {
+        pools: poolData,
+      },
+      isLoading: false,
+    }));
 
     (useGetVTokenBalancesAll as jest.Mock).mockImplementation(() => ({
       data: {

--- a/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
@@ -55,7 +55,7 @@ const useGetVaiVault = ({ accountAddress }: { accountAddress?: string }): UseGet
   const { data: vaiVaultDailyRateData, isLoading: isGetVaiVaultDailyRateWeiLoading } =
     useGetVenusVaiVaultDailyRate();
 
-  const { data: getMainAssetsData, isLoading: isGetMainMarketsLoading } = useGetMainAssets({
+  const { data: getMainAssetsData, isLoading: isGetMainAssetsLoading } = useGetMainAssets({
     accountAddress,
   });
   const xvsPriceDollars: BigNumber | undefined = useMemo(
@@ -107,7 +107,7 @@ const useGetVaiVault = ({ accountAddress }: { accountAddress?: string }): UseGet
   const isLoading =
     isGetTotalVaiStakedWeiLoading ||
     isGetVaiVaultDailyRateWeiLoading ||
-    isGetMainMarketsLoading ||
+    isGetMainAssetsLoading ||
     isGetVaiVaultUserInfoLoading ||
     isGetUserPendingVaiRewardWeiLoading;
 

--- a/src/components/Layout/Header/Breadcrumbs/PoolName/index.tsx
+++ b/src/components/Layout/Header/Breadcrumbs/PoolName/index.tsx
@@ -1,0 +1,22 @@
+/** @jsxImportSource @emotion/react */
+import React, { useContext } from 'react';
+
+import { useGetPool } from 'clients/api';
+import PLACEHOLDER_KEY from 'constants/placeholderKey';
+import { AuthContext } from 'context/AuthContext';
+
+export interface PoolNameProps {
+  poolComptrollerAddress: string;
+}
+
+const PoolName: React.FC<PoolNameProps> = ({ poolComptrollerAddress }) => {
+  const { account } = useContext(AuthContext);
+  const { data: getPoolData } = useGetPool({
+    accountAddress: account?.address,
+    poolComptrollerAddress,
+  });
+
+  return <>{getPoolData?.pool?.name || PLACEHOLDER_KEY}</>;
+};
+
+export default PoolName;

--- a/src/components/Layout/Header/Breadcrumbs/__snapshots__/index.spec.tsx.snap
+++ b/src/components/Layout/Header/Breadcrumbs/__snapshots__/index.spec.tsx.snap
@@ -1,29 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 1`] = `"Dashboard"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: / 1`] = `"Dashboard"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 2`] = `"Account"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /account 1`] = `"Account"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 3`] = `"Governance"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /convert-vrt 1`] = `"Convert VRT"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 4`] = `"Governance/Leaderboard"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /governance 1`] = `"Governance"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 5`] = `"Governance/Proposal #FAKE_PROPOSAL_ID"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /governance/leaderboard 1`] = `"Governance/Leaderboard"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 6`] = `"Governance/Leaderboard/FAKE_VOTER_ADDRESSFAKE...RESS"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /governance/leaderboard/voter/0x3d759121234cd36F8124C21aFe1c6852d2bEd848 1`] = `"Governance/Leaderboard/0x3d759121234cd36F8124C21aFe1c6852d2bEd8480x3d...d848"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 7`] = `"History"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /governance/proposal/FAKE-PROPOSAL-ID 1`] = `"Governance/Proposal #FAKE-PROPOSAL-ID"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 8`] = `"Pools"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /history 1`] = `"History"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 9`] = `"Pools/Fake pool name"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /pools 1`] = `"Pools"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 10`] = `"Pools/Fake pool name/XVS"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /pools/pool/0x3d759121234cd36F8124C21aFe1c6852d2bEd848 1`] = `"Pools/Venus"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 11`] = `"XVS"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /pools/pool/0x3d759121234cd36F8124C21aFe1c6852d2bEd848/market/0x74469281310195A04840Daf6EdF576F559a3dE80 1`] = `"Pools/Venus/SXP"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 12`] = `"VAI"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /swap 1`] = `"Swap"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 13`] = `"Vaults"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /vai 1`] = `"VAI"`;
 
-exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path 14`] = `"Convert VRT"`;
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /vaults 1`] = `"Vaults"`;
+
+exports[`component/Layout/Header/Breadcrumbs outputs the right DOM based on the current path: /xvs 1`] = `"XVS"`;

--- a/src/components/Layout/Header/Breadcrumbs/index.spec.tsx
+++ b/src/components/Layout/Header/Breadcrumbs/index.spec.tsx
@@ -1,38 +1,49 @@
-import { render } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 
+import fakeAddress from '__mocks__/models/address';
+import { poolData } from '__mocks__/models/pools';
+import { useGetPool } from 'clients/api';
 import { routes } from 'constants/routing';
-import { VBEP_TOKENS } from 'constants/tokens';
-import { MuiThemeProvider } from 'theme/MuiThemeProvider';
+import renderComponent from 'testUtils/renderComponent';
 
 import Breadcrumbs from '.';
 
+jest.mock('clients/api');
+
 describe('component/Layout/Header/Breadcrumbs', () => {
+  beforeEach(() => {
+    (useGetPool as jest.Mock).mockImplementation(() => ({
+      data: {
+        pool: poolData[0],
+      },
+      isLoading: false,
+    }));
+  });
+
   it.each([
     routes.dashboard.path,
     routes.account.path,
     routes.governance.path,
     routes.governanceLeaderBoard.path,
-    routes.governanceProposal.path.replace(':proposalId', 'FAKE_PROPOSAL_ID'),
-    routes.governanceVoter.path.replace(':address', 'FAKE_VOTER_ADDRESS'),
+    routes.governanceProposal.path.replace(':proposalId', 'FAKE-PROPOSAL-ID'),
+    routes.governanceVoter.path.replace(':address', fakeAddress),
     routes.history.path,
     routes.pools.path,
-    routes.pool.path.replace(':poolComptrollerAddress', 'FAKE_POOL_COMPTROLLER_ADDRESS'),
+    routes.pool.path.replace(':poolComptrollerAddress', fakeAddress),
     routes.market.path
-      .replace(':poolComptrollerAddress', 'FAKE_POOL_COMPTROLLER_ADDRESS')
-      .replace(':vTokenAddress', VBEP_TOKENS.xvs.address),
+      .replace(':poolComptrollerAddress', fakeAddress)
+      .replace(':vTokenAddress', poolData[0].assets[0].vToken.address),
     routes.xvs.path,
     routes.vai.path,
     routes.vaults.path,
     routes.convertVrt.path,
-  ])('outputs the right DOM based on the current path', async pathname => {
-    const { container } = render(
-      <MuiThemeProvider>
-        <MemoryRouter initialEntries={[pathname]}>
-          <Breadcrumbs />
-        </MemoryRouter>
-      </MuiThemeProvider>,
+    routes.swap.path,
+  ])('outputs the right DOM based on the current path: %s', async pathname => {
+    const { container } = renderComponent(
+      <MemoryRouter initialEntries={[pathname]}>
+        <Breadcrumbs />
+      </MemoryRouter>,
     );
 
     expect(container.textContent).toMatchSnapshot();

--- a/src/components/Layout/Header/Breadcrumbs/index.spec.tsx
+++ b/src/components/Layout/Header/Breadcrumbs/index.spec.tsx
@@ -18,9 +18,9 @@ describe('component/Layout/Header/Breadcrumbs', () => {
     routes.governanceVoter.path.replace(':address', 'FAKE_VOTER_ADDRESS'),
     routes.history.path,
     routes.pools.path,
-    routes.pool.path.replace(':poolComptrollerAddress', 'FAKE_MARKET_ID'),
+    routes.pool.path.replace(':poolComptrollerAddress', 'FAKE_POOL_COMPTROLLER_ADDRESS'),
     routes.market.path
-      .replace(':poolComptrollerAddress', 'FAKE_MARKET_ID')
+      .replace(':poolComptrollerAddress', 'FAKE_POOL_COMPTROLLER_ADDRESS')
       .replace(':vTokenAddress', VBEP_TOKENS.xvs.address),
     routes.xvs.path,
     routes.vai.path,

--- a/src/components/Layout/Header/Breadcrumbs/index.tsx
+++ b/src/components/Layout/Header/Breadcrumbs/index.tsx
@@ -13,6 +13,7 @@ import useCopyToClipboard from 'hooks/useCopyToClipboard';
 import { TertiaryButton } from '../../../Button';
 import { EllipseAddress } from '../../../EllipseAddress';
 import { Icon } from '../../../Icon';
+import PoolName from './PoolName';
 import { useStyles } from './styles';
 
 export interface PathNode {
@@ -49,11 +50,12 @@ const Breadcrumbs: React.FC = () => {
     }
 
     const activeRoute = routes[activeRouteKey as keyof typeof routes];
+    let href = '';
 
     // Generate path nodes
     return activeRoute.subdirectories.reduce<PathNode[]>((acc, subdirectory) => {
-      let href = '';
       let dom: React.ReactNode;
+      let hrefFragment: string = subdirectory;
 
       switch (subdirectory) {
         case Subdirectory.DASHBOARD:
@@ -66,16 +68,15 @@ const Breadcrumbs: React.FC = () => {
           dom = t('breadcrumbs.pools');
           break;
         case Subdirectory.POOL:
-          href += Subdirectory.POOL.replace(
+          hrefFragment = Subdirectory.POOL.replace(
             ':poolComptrollerAddress',
             params.poolComptrollerAddress,
           );
 
-          // TODO: fetch actual value (see VEN-546)
-          dom = <>Fake pool name</>;
+          dom = <PoolName poolComptrollerAddress={params.poolComptrollerAddress} />;
           break;
         case Subdirectory.MARKET: {
-          href += Subdirectory.MARKET.replace(':vTokenAddress', params.vTokenAddress);
+          hrefFragment = Subdirectory.MARKET.replace(':vTokenAddress', params.vTokenAddress);
 
           const vToken = getVTokenByAddress(params.vTokenAddress);
 
@@ -107,7 +108,7 @@ const Breadcrumbs: React.FC = () => {
           dom = t('breadcrumbs.leaderboard');
           break;
         case Subdirectory.VOTER:
-          href += Subdirectory.VOTER.replace(':address', params.address);
+          hrefFragment = Subdirectory.VOTER.replace(':address', params.address);
 
           dom = (
             <div css={styles.address}>
@@ -142,9 +143,10 @@ const Breadcrumbs: React.FC = () => {
           dom = t('breadcrumbs.vai');
           break;
         default:
-          href += subdirectory;
           break;
       }
+
+      href += hrefFragment;
 
       return dom
         ? [
@@ -158,10 +160,10 @@ const Breadcrumbs: React.FC = () => {
     }, []);
   }, [pathname, t, !!account]);
 
-  return (
-    <Typography component="h1" variant="h3">
-      {pathNodes.map((pathNode, index) => (
-        <span key={`layout-header-breadcrumb-${pathNode.href}`}>
+  const pathNodeDom = useMemo(
+    () =>
+      pathNodes.map((pathNode, index) => (
+        <span key={`layout-header-breadcrumb-${pathNode.href}`} css={styles.pathNode}>
           {pathNodes.length > 0 && index < pathNodes.length - 1 ? (
             <>
               <Link to={pathNode.href}>{pathNode.dom}</Link>
@@ -171,7 +173,13 @@ const Breadcrumbs: React.FC = () => {
             pathNode.dom
           )}
         </span>
-      ))}
+      )),
+    [pathNodes],
+  );
+
+  return (
+    <Typography component="h1" variant="h3" css={styles.container}>
+      {pathNodeDom}
     </Typography>
   );
 };

--- a/src/components/Layout/Header/Breadcrumbs/index.tsx
+++ b/src/components/Layout/Header/Breadcrumbs/index.tsx
@@ -50,30 +50,10 @@ const Breadcrumbs: React.FC = () => {
 
     const activeRoute = routes[activeRouteKey as keyof typeof routes];
 
-    let href = '';
-
     // Generate path nodes
     return activeRoute.subdirectories.reduce<PathNode[]>((acc, subdirectory) => {
+      let href = '';
       let dom: React.ReactNode;
-
-      // Update href
-      switch (subdirectory) {
-        case Subdirectory.POOL:
-          href += Subdirectory.POOL.replace(
-            ':poolComptrollerAddress',
-            params.poolComptrollerAddress,
-          );
-          break;
-        case Subdirectory.MARKET:
-          href += Subdirectory.MARKET.replace(':vTokenAddress', params.vTokenAddress);
-          break;
-        case Subdirectory.VOTER:
-          href += Subdirectory.VOTER.replace(':address', params.address);
-          break;
-        default:
-          href += subdirectory;
-          break;
-      }
 
       switch (subdirectory) {
         case Subdirectory.DASHBOARD:
@@ -86,10 +66,17 @@ const Breadcrumbs: React.FC = () => {
           dom = t('breadcrumbs.pools');
           break;
         case Subdirectory.POOL:
+          href += Subdirectory.POOL.replace(
+            ':poolComptrollerAddress',
+            params.poolComptrollerAddress,
+          );
+
           // TODO: fetch actual value (see VEN-546)
           dom = <>Fake pool name</>;
           break;
         case Subdirectory.MARKET: {
+          href += Subdirectory.MARKET.replace(':vTokenAddress', params.vTokenAddress);
+
           const vToken = getVTokenByAddress(params.vTokenAddress);
 
           if (vToken) {
@@ -120,6 +107,8 @@ const Breadcrumbs: React.FC = () => {
           dom = t('breadcrumbs.leaderboard');
           break;
         case Subdirectory.VOTER:
+          href += Subdirectory.VOTER.replace(':address', params.address);
+
           dom = (
             <div css={styles.address}>
               <Typography variant="h3" color="textPrimary">
@@ -153,6 +142,7 @@ const Breadcrumbs: React.FC = () => {
           dom = t('breadcrumbs.vai');
           break;
         default:
+          href += subdirectory;
           break;
       }
 

--- a/src/components/Layout/Header/Breadcrumbs/styles.ts
+++ b/src/components/Layout/Header/Breadcrumbs/styles.ts
@@ -5,6 +5,14 @@ export const useStyles = () => {
   const theme = useTheme();
 
   return {
+    container: css`
+      display: flex;
+      align-items: center;
+    `,
+    pathNode: css`
+      display: inline-flex;
+      align-items: center;
+    `,
     tokenSymbol: css`
       display: inline-flex;
       align-items: center;

--- a/src/components/TokenGroup/index.tsx
+++ b/src/components/TokenGroup/index.tsx
@@ -23,9 +23,9 @@ export const TokenGroup: React.FC<TokenGroupProps> = ({ className, tokens, limit
         <TokenIcon css={styles.token} token={token} key={`token-group-item-${token.address}`} />
       ))}
 
-      {limit > 0 && filteredTokens.length > limit && (
+      {limit > 0 && tokens.length > limit && (
         <Typography variant="small2" css={styles.leftoverCount}>
-          +{filteredTokens.length - limit}
+          +{tokens.length - limit}
         </Typography>
       )}
     </div>

--- a/src/constants/routing.ts
+++ b/src/constants/routing.ts
@@ -3,7 +3,7 @@ export enum Subdirectory {
   ACCOUNT = '/account',
   XVS = '/xvs',
   POOLS = '/pools',
-  POOL = '/pool/:poolAddress',
+  POOL = '/pool/:poolComptrollerAddress',
   MARKET = '/market/:vTokenAddress',
   HISTORY = '/history',
   VAULTS = '/vaults',

--- a/src/pages/Pools/Header/index.stories.tsx
+++ b/src/pages/Pools/Header/index.stories.tsx
@@ -1,5 +1,4 @@
 import { ComponentMeta } from '@storybook/react';
-import BigNumber from 'bignumber.js';
 import React from 'react';
 
 import { withCenterStory, withRouter } from 'stories/decorators';
@@ -19,9 +18,9 @@ export default {
 
 export const Default = () => (
   <HeaderUi
-    totalSupplyCents={new BigNumber('912902278.25')}
-    totalBorrowCents={new BigNumber('912902278.25')}
-    availableLiquidityCents={new BigNumber('912902278.25')}
-    totalTreasuryCents={new BigNumber('912902278.25')}
+    treasurySupplyBalanceCents={912902278}
+    treasuryBorrowBalanceCents={912902278}
+    treasuryLiquidityBalanceCents={912902278}
+    treasuryBalanceCents={912902278}
   />
 );

--- a/src/pages/Pools/Header/index.tsx
+++ b/src/pages/Pools/Header/index.tsx
@@ -1,5 +1,4 @@
 /** @jsxImportSource @emotion/react */
-import BigNumber from 'bignumber.js';
 import { Cell, CellGroup } from 'components';
 import React from 'react';
 import { useTranslation } from 'translation';
@@ -10,17 +9,17 @@ import { useGetTreasuryTotals } from 'clients/api';
 import { useStyles } from './styles';
 
 interface HeaderProps {
-  totalSupplyCents: BigNumber;
-  totalBorrowCents: BigNumber;
-  availableLiquidityCents: BigNumber;
-  totalTreasuryCents: BigNumber;
+  treasurySupplyBalanceCents: number;
+  treasuryBorrowBalanceCents: number;
+  treasuryLiquidityBalanceCents: number;
+  treasuryBalanceCents: number;
 }
 
 export const HeaderUi: React.FC<HeaderProps> = ({
-  totalSupplyCents,
-  totalBorrowCents,
-  availableLiquidityCents,
-  totalTreasuryCents,
+  treasurySupplyBalanceCents,
+  treasuryBorrowBalanceCents,
+  treasuryLiquidityBalanceCents,
+  treasuryBalanceCents,
 }) => {
   const { t } = useTranslation();
   const styles = useStyles();
@@ -28,19 +27,19 @@ export const HeaderUi: React.FC<HeaderProps> = ({
   const cells: Cell[] = [
     {
       label: t('market.totalSupply'),
-      value: formatCentsToReadableValue({ value: totalSupplyCents }),
+      value: formatCentsToReadableValue({ value: treasurySupplyBalanceCents }),
     },
     {
       label: t('market.totalBorrow'),
-      value: formatCentsToReadableValue({ value: totalBorrowCents }),
+      value: formatCentsToReadableValue({ value: treasuryBorrowBalanceCents }),
     },
     {
       label: t('market.availableLiquidity'),
-      value: formatCentsToReadableValue({ value: availableLiquidityCents }),
+      value: formatCentsToReadableValue({ value: treasuryLiquidityBalanceCents }),
     },
     {
       label: t('market.totalTreasury'),
-      value: formatCentsToReadableValue({ value: totalTreasuryCents }),
+      value: formatCentsToReadableValue({ value: treasuryBalanceCents }),
     },
   ];
 
@@ -51,19 +50,19 @@ const Header = () => {
   // TODO: handle loading state (see VEN-591)
   const {
     data: {
-      treasuryTotalSupplyBalanceCents,
-      treasuryTotalBorrowBalanceCents,
-      treasuryTotalAvailableLiquidityBalanceCents,
-      treasuryTotalBalanceCents,
+      treasurySupplyBalanceCents,
+      treasuryBorrowBalanceCents,
+      treasuryLiquidityBalanceCents,
+      treasuryBalanceCents,
     },
   } = useGetTreasuryTotals();
 
   return (
     <HeaderUi
-      totalSupplyCents={treasuryTotalSupplyBalanceCents}
-      totalBorrowCents={treasuryTotalBorrowBalanceCents}
-      availableLiquidityCents={treasuryTotalAvailableLiquidityBalanceCents}
-      totalTreasuryCents={treasuryTotalBalanceCents}
+      treasurySupplyBalanceCents={treasurySupplyBalanceCents}
+      treasuryBorrowBalanceCents={treasuryBorrowBalanceCents}
+      treasuryLiquidityBalanceCents={treasuryLiquidityBalanceCents}
+      treasuryBalanceCents={treasuryBalanceCents}
     />
   );
 };

--- a/src/pages/Pools/PoolTable/index.spec.tsx
+++ b/src/pages/Pools/PoolTable/index.spec.tsx
@@ -1,8 +1,5 @@
-import BigNumber from 'bignumber.js';
 import React from 'react';
 
-import { assetData } from '__mocks__/models/asset';
-import { useGetMainAssets } from 'clients/api';
 import renderComponent from 'testUtils/renderComponent';
 
 import PoolTable from '.';
@@ -10,18 +7,6 @@ import PoolTable from '.';
 jest.mock('clients/api');
 
 describe('pages/Pools/PoolTable', () => {
-  beforeEach(() => {
-    (useGetMainAssets as jest.Mock).mockImplementation(() => ({
-      data: {
-        assets: assetData,
-        userTotalBorrowLimitCents: new BigNumber('111'),
-        userTotalBorrowBalanceCents: new BigNumber('91'),
-        userTotalSupplyBalanceCents: new BigNumber('910'),
-      },
-      isLoading: false,
-    }));
-  });
-
   it('renders without crashing', async () => {
     renderComponent(<PoolTable />);
   });

--- a/src/pages/Pools/PoolTable/index.tsx
+++ b/src/pages/Pools/PoolTable/index.tsx
@@ -1,12 +1,13 @@
 /** @jsxImportSource @emotion/react */
 import { RiskLevel, Select, Table, TableColumn, TokenGroup } from 'components';
-import React, { useMemo } from 'react';
+import React, { useContext, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Pool } from 'types';
 import { formatCentsToReadableValue } from 'utilities';
 
-import { poolData } from '__mocks__/models/pools';
+import { useGetPools } from 'clients/api';
 import { routes } from 'constants/routing';
+import { AuthContext } from 'context/AuthContext';
 import { useShowXxlDownCss } from 'hooks/responsive';
 
 import { useStyles } from './styles';
@@ -27,9 +28,10 @@ const riskRatingMap = {
 
 export interface PoolTableProps {
   pools: Pool[];
+  isFetchingPools: boolean;
 }
 
-export const PoolTableUi: React.FC<PoolTableProps> = ({ pools }) => {
+export const PoolTableUi: React.FC<PoolTableProps> = ({ pools, isFetchingPools }) => {
   const { t } = useTranslation();
   const styles = useStyles();
 
@@ -168,16 +170,17 @@ export const PoolTableUi: React.FC<PoolTableProps> = ({ pools }) => {
         }
         breakpoint="xxl"
         css={styles.cardContentGrid}
+        isFetching={isFetchingPools}
       />
     </>
   );
 };
 
 const PoolTable = () => {
-  // TODO: fetch actual value (see VEN-546)
-  const pools = poolData;
+  const { account } = useContext(AuthContext);
+  const { data: poolData, isLoading } = useGetPools({ accountAddress: account?.address });
 
-  return <PoolTableUi pools={pools} />;
+  return <PoolTableUi pools={poolData?.pools || []} isFetchingPools={isLoading} />;
 };
 
 export default PoolTable;

--- a/src/pages/Pools/index.spec.tsx
+++ b/src/pages/Pools/index.spec.tsx
@@ -1,9 +1,7 @@
 import BigNumber from 'bignumber.js';
 import React from 'react';
 
-import { markets } from '__mocks__/models/markets';
-import { vTokenBalanceTreasury } from '__mocks__/models/vTokenBalanceTreasury';
-import { getMainMarkets, useGetTreasuryTotals, useGetVTokenBalancesAll } from 'clients/api';
+import { useGetTreasuryTotals } from 'clients/api';
 import renderComponent from 'testUtils/renderComponent';
 
 import Pools from '.';
@@ -12,10 +10,6 @@ jest.mock('clients/api');
 
 describe('pages/Pools', () => {
   beforeEach(() => {
-    (getMainMarkets as jest.Mock).mockImplementation(() => ({ markets }));
-    (useGetVTokenBalancesAll as jest.Mock).mockImplementation(() => ({
-      data: { balances: vTokenBalanceTreasury },
-    }));
     (useGetTreasuryTotals as jest.Mock).mockImplementation(() => ({
       data: {
         treasuryTotalSupplyBalanceCents: new BigNumber(0),

--- a/src/pages/Pools/index.spec.tsx
+++ b/src/pages/Pools/index.spec.tsx
@@ -12,10 +12,10 @@ describe('pages/Pools', () => {
   beforeEach(() => {
     (useGetTreasuryTotals as jest.Mock).mockImplementation(() => ({
       data: {
-        treasuryTotalSupplyBalanceCents: new BigNumber(0),
-        treasuryTotalBorrowBalanceCents: new BigNumber(0),
-        treasuryTotalBalanceCents: new BigNumber(0),
-        treasuryTotalAvailableLiquidityBalanceCents: new BigNumber(0),
+        treasurySupplyBalanceCents: new BigNumber(0),
+        treasuryBorrowBalanceCents: new BigNumber(0),
+        treasuryBalanceCents: new BigNumber(0),
+        treasuryLiquidityBalanceCents: new BigNumber(0),
       },
       isLoading: false,
     }));


### PR DESCRIPTION
## Jira ticket(s)

VEN-546
VEN-547

## Changes

- update `useGetTreasuryTotals` to use `useGetPools`
- update `Breadcrumbs` component to support Pool page
- fetch real data on Pool page
- fetch real data on Pools page
