### PR TITLE
Add bottom margin to header on History page on tablet

### DIFF
--- a/src/pages/History/Filters/styles.ts
+++ b/src/pages/History/Filters/styles.ts
@@ -15,6 +15,7 @@ export const useStyles = () => {
       ${theme.breakpoints.down('xl')} {
         background-color: transparent;
         padding: 0;
+        margin-bottom: ${theme.spacing(3)};
       }
     `,
     checkbox: css`


### PR DESCRIPTION
## Changes

- add bottom margin to header on History page on tablet
