### PR TITLE
Update navigation to use hash routing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY package.json ./
 COPY yarn.lock ./
 COPY src/constants/contracts/abis ./src/constants/contracts/abis
+COPY scripts ./scripts
 COPY patches ./patches
 
 RUN yarn

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,9 @@ RUN ln -s /usr/bin/python3 /usr/bin/python
 
 COPY package.json ./
 COPY yarn.lock ./
-COPY src/constants/contracts/abis ./src/constants/contracts/abis
 COPY scripts ./scripts
+COPY src/constants/contracts/abis ./src/constants/contracts/abis
+COPY src/clients/subgraph ./src/clients/subgraph
 COPY patches ./patches
 
 RUN yarn

--- a/scripts/run-generate-subgraph-types.sh
+++ b/scripts/run-generate-subgraph-types.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/ash
 
 if [[ "${REACT_APP_CHAIN_ID}" == "56" ]]; then
   export SUBGRAPH_GRAPHQL_ENDPOINT="https://api.thegraph.com/subgraphs/name/venusprotocol/venus-isolated-pools"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -14,4 +14,13 @@ BigNumber.config({
   },
 });
 
-ReactDOM.render(<App />, document.getElementById('root'));
+// Add hash to URL on the fly if it doesn't contain any (e.g.:
+// /governance?page=1 => /#/governance?page=1). This is done to redirect users
+// to the correct route if they followed an old link from before we switched to
+// hash routing
+if (window.location.pathname !== '/') {
+  const url = `${window.location.origin}#${window.location.pathname}${window.location.search}`;
+  window.location.replace(url);
+} else {
+  ReactDOM.render(<App />, document.getElementById('root'));
+}

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,7 +1,7 @@
 import { Layout, ResetScrollOnRouteChange } from 'components';
 import React from 'react';
 import { QueryClientProvider } from 'react-query';
-import { BrowserRouter, Redirect, Route, Switch } from 'react-router-dom';
+import { HashRouter, Redirect, Route, Switch } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 
 import 'assets/styles/App.scss';
@@ -35,7 +35,7 @@ const App = () => (
         <AuthProvider>
           <SuccessfulTransactionModalProvider>
             <DisableLunaUstWarningProvider>
-              <BrowserRouter>
+              <HashRouter>
                 <ToastContainer />
 
                 <Layout>
@@ -74,7 +74,7 @@ const App = () => (
                     <Redirect to={routes.dashboard.path} />
                   </Switch>
                 </Layout>
-              </BrowserRouter>
+              </HashRouter>
             </DisableLunaUstWarningProvider>
           </SuccessfulTransactionModalProvider>
         </AuthProvider>

--- a/src/pages/Governance/index.spec.tsx
+++ b/src/pages/Governance/index.spec.tsx
@@ -118,7 +118,7 @@ describe('pages/Governance', () => {
     const { getByTestId } = renderComponent(Governance);
     const deposityYourTokensText = getByTestId(VOTING_WALLET_TEST_IDS.depositYourTokens);
 
-    expect(deposityYourTokensText).toHaveAttribute('href', routes.vaults.path);
+    expect(deposityYourTokensText).toHaveAttribute('href', `#${routes.vaults.path}`);
   });
 
   it('prompts user to connect Wallet', async () => {
@@ -148,7 +148,7 @@ describe('pages/Governance', () => {
 
     expect(getByTestId(VOTING_WALLET_TEST_IDS.votingWeightValue)).toHaveTextContent('0');
     expect(getByTestId(VOTING_WALLET_TEST_IDS.totalLockedValue)).toHaveTextContent('0');
-    expect(depositXvsButton).toHaveAttribute('href', routes.vaults.path);
+    expect(depositXvsButton).toHaveAttribute('href', `#${routes.vaults.path}`);
   });
 
   it('successfully delegates to other address', async () => {
@@ -254,7 +254,7 @@ describe('pages/Governance', () => {
 
     expect(firstProposalAnchor[0].firstChild).toHaveAttribute(
       'href',
-      routes.governanceProposal.path.replace(':proposalId', '98'),
+      `#${routes.governanceProposal.path.replace(':proposalId', '98')}`,
     );
   });
 });

--- a/src/stories/decorators.tsx
+++ b/src/stories/decorators.tsx
@@ -2,7 +2,7 @@ import Box from '@mui/material/Box';
 import { Story as StoryType, addDecorator } from '@storybook/react';
 import React, { useState } from 'react';
 import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
-import { BrowserRouter } from 'react-router-dom';
+import { HashRouter } from 'react-router-dom';
 import { Token } from 'types';
 
 import setCachedTokenAllowanceToMax from 'clients/api/queries/getAllowance/setCachedTokenAllowanceToMax';
@@ -13,9 +13,9 @@ import { MuiThemeProvider } from 'theme/MuiThemeProvider';
 export type DecoratorFunction = Parameters<typeof addDecorator>[0];
 
 export const withRouter: DecoratorFunction = Story => (
-  <BrowserRouter>
+  <HashRouter>
     <Story />
-  </BrowserRouter>
+  </HashRouter>
 );
 
 export const withWeb3Provider: DecoratorFunction = Story => (

--- a/src/testUtils/renderComponent.tsx
+++ b/src/testUtils/renderComponent.tsx
@@ -1,7 +1,7 @@
 import { render } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from 'react-query';
-import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import { HashRouter, Route, Switch } from 'react-router-dom';
 import { ToastContainer } from 'react-toastify';
 
 import { Web3Wrapper } from 'clients/web3';
@@ -43,7 +43,7 @@ const renderComponent = (
           <AuthContext.Provider value={defaultAuthContextValues}>
             <SuccessfulTransactionModalProvider>
               <DisableLunaUstWarningProvider>
-                <BrowserRouter>
+                <HashRouter>
                   <ToastContainer />
 
                   <Switch>
@@ -52,7 +52,7 @@ const renderComponent = (
                       component={typeof children === 'function' ? children : () => children}
                     />
                   </Switch>
-                </BrowserRouter>
+                </HashRouter>
               </DisableLunaUstWarningProvider>
             </SuccessfulTransactionModalProvider>
           </AuthContext.Provider>


### PR DESCRIPTION
## Changes

- update navigation to use hash routing
- add logic to handle redirecting users to hash routes if they come from an old route (.e.g: going to `https://app.venus.io/governance/proposal/82` will redirect to `https://app.venus.io/#/governance/proposal/82`)
