### PR TITLE
Use blockTimestamp on chart data

### DIFF
--- a/src/pages/Market/useGetChartData.ts
+++ b/src/pages/Market/useGetChartData.ts
@@ -24,7 +24,7 @@ const useGetChartData = ({ vToken }: { vToken: VToken }) => {
       // pass them to the charts in the right order
       .reverse()
       .forEach(marketSnapshot => {
-        const timestampMs = new Date(marketSnapshot.createdAt).getTime();
+        const timestampMs = marketSnapshot.blockTimestamp * 1000;
 
         supplyChartData.push({
           apyPercentage: formatPercentage(marketSnapshot.supplyApy),


### PR DESCRIPTION
## Changes

- use `blockTimestamp` field on chart data instead of `createdAt`
