### PR TITLE
[HOTFIX] Hide Stake and Withdraw buttons on vesting vaults

### DIFF
--- a/src/pages/Vault/VaultItem/index.tsx
+++ b/src/pages/Vault/VaultItem/index.tsx
@@ -152,6 +152,8 @@ export const VaultItemUi: React.FC<VaultItemUiProps> = ({
     ],
   );
 
+  const isVestingVault = typeof poolIndex === 'number';
+
   return (
     <>
       <Paper css={styles.container} className={className}>
@@ -225,22 +227,25 @@ export const VaultItemUi: React.FC<VaultItemUiProps> = ({
           ))}
         </ul>
 
-        <div css={styles.buttonsWrapper}>
-          <Button onClick={onStake} css={styles.button} variant="primary">
-            {t('vaultItem.stakeButton')}
-          </Button>
-
-          {canWithdraw && (
-            <Button
-              onClick={handleWithdraw}
-              css={styles.button}
-              variant="secondary"
-              loading={isWithdrawLoading}
-            >
-              {t('vaultItem.withdrawButton')}
+        {/* Hide stake and withdraw buttons on vesting vaults. This is a temporary hotfix following a failed upgrade of the XVS Vault contract */}
+        {!isVestingVault && (
+          <div css={styles.buttonsWrapper}>
+            <Button onClick={onStake} css={styles.button} variant="primary">
+              {t('vaultItem.stakeButton')}
             </Button>
-          )}
-        </div>
+
+            {canWithdraw && (
+              <Button
+                onClick={handleWithdraw}
+                css={styles.button}
+                variant="secondary"
+                loading={isWithdrawLoading}
+              >
+                {t('vaultItem.withdrawButton')}
+              </Button>
+            )}
+          </div>
+        )}
       </Paper>
 
       {activeModal === 'stake' && (


### PR DESCRIPTION
This is a temporary hotfix following a failed upgrade of the XVS Vault contract