### PR TITLE
Filter out transactions without a vTokenAddress field

### DIFF
--- a/src/clients/api/queries/getTransactions/index.ts
+++ b/src/clients/api/queries/getTransactions/index.ts
@@ -68,7 +68,10 @@ const getTransactions = async ({
     throw new VError({ type: 'unexpected', code: 'somethingWentWrongRetrievingTransactions' });
   }
   const { limit, page: payloadPage, total } = payload;
-  const transactions = payload.result.map(data => formatTransaction(data));
+  const transactions = payload.result
+    // HOTFIX: filter out transactions without a vTokenAddress field
+    .filter(data => !!data.vTokenAddress)
+    .map(data => formatTransaction(data));
   return { limit, page: payloadPage, total, transactions };
 };
 


### PR DESCRIPTION
This is a temporary hotfix following changes made to the API that cause it to return some transactions with a `vTokenAddress` field set to `null`.
