### PR TITLE
fix: parse using input type instead of baseType

### DIFF
--- a/src/components/ReadableActionSignature/formatSignature.ts
+++ b/src/components/ReadableActionSignature/formatSignature.ts
@@ -18,7 +18,7 @@ const formatSignature = (action: FormValues['actions'][number] | ProposalAction)
       });
     } else {
       const unformattedArgs = ethers.utils.defaultAbiCoder.decode(
-        fragment.inputs.map(input => input.baseType),
+        fragment.inputs.map(input => input.type),
         action.callData,
       );
       args = fragment.inputs.map((i, idx) => {


### PR DESCRIPTION
## Jira ticket(s)

VEN-1108

## Changes

Use input type instead of baseType to correct decode function inputs
