### PR TITLE
[VEN-1132] Market table now has sorting options when in mobile view (master)

### DIFF
--- a/src/components/Form/FormikSelectField.tsx
+++ b/src/components/Form/FormikSelectField.tsx
@@ -1,4 +1,3 @@
-import { SelectChangeEvent } from '@mui/material/Select';
 import { useField } from 'formik';
 import React from 'react';
 
@@ -11,7 +10,8 @@ interface FormikSelectFieldProps extends Omit<SelectProps, 'name' | 'onChange' |
 
 export const FormikSelectField = ({ name, onBlur, ...rest }: FormikSelectFieldProps) => {
   const [{ value, onBlur: formikOnBlur }, _formState, { setValue }] = useField(name); // eslint-disable-line @typescript-eslint/naming-convention
-  const onChange = (e: SelectChangeEvent) => {
+
+  const onChange: SelectProps['onChange'] = e => {
     const val = e.target.value;
     setValue(val);
   };

--- a/src/components/Select/index.tsx
+++ b/src/components/Select/index.tsx
@@ -13,7 +13,7 @@ import { TextButton } from '../Button';
 import { Icon } from '../Icon';
 import { SELECTED_MENU_ITEM_CLASSNAME, useStyles } from './styles';
 
-interface Option {
+export interface Option {
   value: string | number;
   label: string;
 }
@@ -21,11 +21,12 @@ interface Option {
 export interface SelectProps {
   className?: string;
   options: Option[];
-  value: string | undefined;
-  onChange: (e: SelectChangeEvent) => void;
+  value: string | number | undefined;
+  onChange: (e: SelectChangeEvent<string | number | undefined>) => void;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   ariaLabel: string;
   label?: string;
+  placeLabelToLeft?: boolean;
   name?: string;
 }
 
@@ -37,6 +38,7 @@ export const Select: React.FC<SelectProps> = ({
   onBlur,
   ariaLabel,
   label,
+  placeLabelToLeft = false,
   name,
 }) => {
   const { t } = useTranslation();
@@ -74,14 +76,14 @@ export const Select: React.FC<SelectProps> = ({
   }, [isSmDown]);
 
   return (
-    <div className={className}>
-      <div css={styles.label}>
+    <div className={className} css={styles.getContainer({ placeLabelToLeft })}>
+      <div css={styles.getLabel({ placeLabelToLeft })}>
         <Typography variant="small1" component="label" htmlFor="proposalType">
           {label || t('select.defaultLabel')}
         </Typography>
       </div>
 
-      <MuiSelect
+      <MuiSelect<string | number | undefined>
         name={name}
         open={isOpen}
         onClose={handleClose}

--- a/src/components/Select/styles.ts
+++ b/src/components/Select/styles.ts
@@ -17,12 +17,33 @@ export const useStyles = () => {
         padding: ${theme.spacing(3, 4)};
       }
     `,
+    getContainer: ({ placeLabelToLeft }: { placeLabelToLeft: boolean }) => css`
+      ${placeLabelToLeft &&
+      css`
+        display: inline-flex;
+        align-items: center;
+      `}
+    `,
+    getLabel: ({ placeLabelToLeft }: { placeLabelToLeft: boolean }) => css`
+      ${placeLabelToLeft
+        ? css`
+            flex-shrink: 0;
+            margin-right: ${theme.spacing(3)};
+          `
+        : css`
+            margin-bottom: ${theme.spacing(1)};
+
+            label {
+              color: ${theme.palette.text.primary};
+            }
+          `}
+    `,
     getArrowIcon: ({ isMenuOpened }: { isMenuOpened: boolean }) => css`
       position: absolute;
       right: ${theme.spacing(4)};
       width: ${theme.spacing(3)};
       transition: transform 0.3s;
-      transform: rotate(${isMenuOpened ? '180deg' : '0'});
+      transform: rotate(${isMenuOpened ? '0' : '180deg'});
     `,
     menuItem: css`
       display: flex;

--- a/src/components/Table/TableCards.tsx
+++ b/src/components/Table/TableCards.tsx
@@ -1,72 +1,132 @@
 /** @jsxImportSource @emotion/react */
 import { Paper, Typography } from '@mui/material';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
+import { useTranslation } from 'translation';
 
 import { Delimiter } from '../Delimiter';
+import { Select, Option as SelectOption, SelectProps } from '../Select';
 import { useStyles } from './styles';
-import { TableRowProps } from './types';
+import { Order, TableColumn, TableRowProps } from './types';
 
-interface TableCardProps {
+interface TableCardProps<R> {
   rows: TableRowProps[][];
   rowKeyIndex: number;
-  columns: { key: string; label: string; orderable: boolean }[];
+  columns: TableColumn<R>[];
   className?: string;
   rowOnClick?: (e: React.MouseEvent<HTMLDivElement>, row: TableRowProps[]) => void;
   getRowHref?: (row: TableRowProps[]) => string;
+  order: Order | undefined;
+  onOrderChange: (newOrder: Order) => void;
 }
 
-const TableCards: React.FC<TableCardProps> = ({
+function TableCards<R>({
   rows,
   rowKeyIndex,
   rowOnClick,
   getRowHref,
   columns,
   className,
-}) => {
+  order,
+  onOrderChange,
+}: TableCardProps<R>) {
+  const { t } = useTranslation();
   const styles = useStyles();
 
-  return (
-    <div className={className}>
-      {rows.map((row, idx) => {
-        const rowKey = `${row[rowKeyIndex].value.toString()}-${idx}-cards`;
-        const [titleColumn, ...otherColumns] = columns;
-        const titleCell = row.find(cell => titleColumn.key === cell.key);
-        return (
-          <Paper
-            key={rowKey}
-            css={styles.tableWrapperMobile({ clickable: !!(rowOnClick || getRowHref) })}
-            onClick={rowOnClick && ((e: React.MouseEvent<HTMLDivElement>) => rowOnClick(e, row))}
-            component={
-              getRowHref
-                ? ({ children, ...props }) => (
-                    <div {...props}>
-                      <Link to={getRowHref(row)}>{children}</Link>
-                    </div>
-                  )
-                : 'div'
-            }
-          >
-            <div css={styles.rowTitleMobile}>{titleCell?.render()}</div>
-            <Delimiter css={styles.delimiterMobile} />
-            <div className="table__table-cards__card-content" css={styles.rowWrapperMobile}>
-              {otherColumns.map(column => {
-                const currentCell = row.find(cell => column.key === cell.key);
-                return (
-                  <div key={`${rowKey}-${currentCell?.key}`} css={styles.cellMobile}>
-                    <Typography variant="body2" css={styles.columnLabelMobile}>
-                      {column?.label}
-                    </Typography>
-                    <div css={styles.cellValueMobile}>{currentCell?.render()}</div>
-                  </div>
-                );
-              })}
-            </div>
-          </Paper>
-        );
-      })}
-    </div>
+  const selectOptions = useMemo(
+    () =>
+      columns.reduce((acc, column) => {
+        if (!column.sortRows) {
+          return acc;
+        }
+
+        const option: SelectOption = {
+          value: column.key,
+          label: column.label,
+        };
+
+        return [...acc, option];
+      }, [] as SelectOption[]),
+    [columns],
   );
-};
+
+  const selectedOption = useMemo(
+    () => (order ? selectOptions.find(option => option.value === order.orderBy) : selectOptions[1]),
+    [order, selectOptions],
+  );
+
+  const handleOrderChange: SelectProps['onChange'] = selectChangeEvent => {
+    const newSelectedOption = selectOptions.find(
+      option => option.value === selectChangeEvent.target.value,
+    );
+    const orderBy =
+      newSelectedOption && columns.find(column => column.key === newSelectedOption.value);
+
+    if (orderBy) {
+      onOrderChange({
+        orderBy: orderBy.key,
+        orderDirection: 'desc',
+      });
+    }
+  };
+
+  return (
+    <>
+      {selectOptions.length > 0 && (
+        <div css={styles.cardsSelectContainer}>
+          <Select
+            label={t('table.cardsSelect.label')}
+            ariaLabel={t('table.cardsSelect.accessibilityLabel')}
+            options={selectOptions}
+            value={selectedOption?.value}
+            onChange={handleOrderChange}
+            css={styles.cardsSelect}
+            placeLabelToLeft
+          />
+        </div>
+      )}
+
+      <div className={className}>
+        {rows.map((row, idx) => {
+          const rowKey = `${row[rowKeyIndex].value.toString()}-${idx}-cards`;
+          const [titleColumn, ...otherColumns] = columns;
+          const titleCell = row.find(cell => titleColumn.key === cell.key);
+          return (
+            <Paper
+              key={rowKey}
+              css={styles.tableWrapperMobile({ clickable: !!(rowOnClick || getRowHref) })}
+              onClick={rowOnClick && ((e: React.MouseEvent<HTMLDivElement>) => rowOnClick(e, row))}
+              component={
+                getRowHref
+                  ? ({ children, ...props }) => (
+                      <div {...props}>
+                        <Link to={getRowHref(row)}>{children}</Link>
+                      </div>
+                    )
+                  : 'div'
+              }
+            >
+              <div css={styles.rowTitleMobile}>{titleCell?.render()}</div>
+              <Delimiter css={styles.delimiterMobile} />
+              <div className="table__table-cards__card-content" css={styles.rowWrapperMobile}>
+                {otherColumns.map(column => {
+                  const currentCell = row.find(cell => column.key === cell.key);
+                  return (
+                    <div key={`${rowKey}-${currentCell?.key}`} css={styles.cellMobile}>
+                      <Typography variant="body2" css={styles.columnLabelMobile}>
+                        {column?.label}
+                      </Typography>
+                      <div css={styles.cellValueMobile}>{currentCell?.render()}</div>
+                    </div>
+                  );
+                })}
+              </div>
+            </Paper>
+          );
+        })}
+      </div>
+    </>
+  );
+}
 
 export default TableCards;

--- a/src/components/Table/index.tsx
+++ b/src/components/Table/index.tsx
@@ -53,7 +53,7 @@ interface TableCardHrefProps extends TableBaseProps {
 
 export type TableProps = TableCardRowOnClickProps | TableCardHrefProps;
 
-export const Table = ({
+export function Table({
   columns,
   cardColumns,
   data,
@@ -67,7 +67,7 @@ export const Table = ({
   tableCss,
   cardsCss,
   isFetching,
-}: TableProps) => {
+}: TableProps) {
   const styles = useStyles();
 
   const [orderBy, setOrderBy] = React.useState<typeof columns[number]['key'] | undefined>(
@@ -77,6 +77,14 @@ export const Table = ({
   const [orderDirection, setOrderDirection] = React.useState<'asc' | 'desc' | undefined>(
     initialOrder?.orderDirection,
   );
+
+  const order =
+    orderBy && orderDirection
+      ? {
+          orderBy,
+          orderDirection,
+        }
+      : undefined;
 
   const onRequestOrder = (property: typeof columns[number]['key']) => {
     let newOrder: 'asc' | 'desc' = 'asc';
@@ -168,7 +176,12 @@ export const Table = ({
         getRowHref={getRowHref}
         columns={cardColumns || columns}
         css={cardsCss}
+        order={order}
+        onOrderChange={newOrder => {
+          setOrderBy(newOrder.orderBy);
+          setOrderDirection(newOrder.orderDirection);
+        }}
       />
     </Paper>
   );
-};
+}

--- a/src/components/Table/styles.ts
+++ b/src/components/Table/styles.ts
@@ -36,6 +36,18 @@ export const useStyles = () => {
         }
       `}
     `,
+    cardsSelectContainer: css`
+      display: none;
+
+      ${theme.breakpoints.down('xxl')} {
+        display: block;
+      }
+    `,
+    cardsSelect: css`
+      width: ${theme.spacing(56)};
+      margin-bottom: ${theme.spacing(4)};
+      border-radius: 0;
+    `,
     rowTitleMobile: css`
       padding-left: ${theme.spacing(4)};
       padding-right: ${theme.spacing(4)};

--- a/src/components/Table/types.ts
+++ b/src/components/Table/types.ts
@@ -5,3 +5,16 @@ export interface TableRowProps {
   render: () => React.ReactNode | string;
   value: string | number | boolean;
 }
+
+export interface TableColumn<R> {
+  key: string;
+  label: string;
+  orderable: boolean;
+  sortRows?: (rowA: R, rowB: R, direction: 'asc' | 'desc') => number;
+  align?: 'left' | 'center' | 'right';
+}
+
+export interface Order {
+  orderBy: string;
+  orderDirection: 'asc' | 'desc';
+}

--- a/src/pages/Market/MarketTable/index.tsx
+++ b/src/pages/Market/MarketTable/index.tsx
@@ -1,9 +1,10 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
+import BigNumber from 'bignumber.js';
 import { LayeredValues, Table, TableProps, TokenIconWithSymbol } from 'components';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
-import { Market } from 'types';
+import { Asset, Market } from 'types';
 import {
   convertPercentageFromSmartContract,
   formatCentsToReadableValue,
@@ -13,6 +14,7 @@ import {
 } from 'utilities';
 
 import { useGetMarkets } from 'clients/api';
+import { TableColumn } from 'components/Table/types';
 
 import { useStyles as useSharedStyles } from '../styles';
 import { useStyles as useLocalStyles } from './styles';
@@ -21,36 +23,91 @@ export interface MarketTableProps extends Pick<TableProps, 'getRowHref'> {
   markets: Market[];
 }
 
+const compareBigNumbers = (
+  valueA: BigNumber | undefined,
+  valueB: BigNumber | undefined,
+  direction: 'asc' | 'desc',
+): number => {
+  if (!valueA || !valueB) {
+    return 0;
+  }
+
+  if (valueA.isLessThan(valueB)) {
+    return direction === 'asc' ? -1 : 1;
+  }
+
+  if (valueA.isGreaterThan(valueB)) {
+    return direction === 'asc' ? 1 : -1;
+  }
+
+  return 0;
+};
+
 export const MarketTableUi: React.FC<MarketTableProps> = ({ markets, getRowHref }) => {
   const { t } = useTranslation();
   const sharedStyles = useSharedStyles();
   const localStyles = useLocalStyles();
 
-  const columns = useMemo(
+  const columns: TableColumn<Asset>[] = useMemo(
     () => [
-      { key: 'asset', label: t('market.columns.asset'), orderable: false, align: 'left' },
+      {
+        key: 'asset',
+        label: t('market.columns.asset'),
+        orderable: false,
+        align: 'left',
+      },
       {
         key: 'totalSupply',
         label: t('market.columns.totalSupply'),
         orderable: true,
         align: 'right',
+        sortRows: (rowA, rowB, direction) =>
+          compareBigNumbers(rowA.supplyBalance, rowB.supplyBalance, direction),
       },
-      { key: 'supplyApy', label: t('market.columns.supplyApy'), orderable: true, align: 'right' },
+      {
+        key: 'supplyApy',
+        label: t('market.columns.supplyApy'),
+        orderable: true,
+        align: 'right',
+        sortRows: (rowA, rowB, direction) =>
+          compareBigNumbers(rowA.supplyApy, rowB.supplyApy, direction),
+      },
       {
         key: 'totalBorrows',
         label: t('market.columns.totalBorrow'),
         orderable: true,
         align: 'right',
+        sortRows: (rowA, rowB, direction) =>
+          compareBigNumbers(rowA.borrowBalance, rowB.borrowBalance, direction),
       },
-      { key: 'borrowApy', label: t('market.columns.borrowApy'), orderable: true, align: 'right' },
-      { key: 'liquidity', label: t('market.columns.liquidity'), orderable: true, align: 'right' },
+      {
+        key: 'borrowApy',
+        label: t('market.columns.borrowApy'),
+        orderable: true,
+        align: 'right',
+        sortRows: (rowA, rowB, direction) =>
+          compareBigNumbers(rowA.borrowApy, rowB.borrowApy, direction),
+      },
+      {
+        key: 'liquidity',
+        label: t('market.columns.liquidity'),
+        orderable: true,
+        align: 'right',
+        sortRows: (rowA, rowB, direction) =>
+          compareBigNumbers(rowA.liquidity, rowB.liquidity, direction),
+      },
       {
         key: 'collateralFactor',
         label: t('market.columns.collateralFactor'),
         orderable: true,
         align: 'right',
       },
-      { key: 'price', label: t('market.columns.price'), orderable: true, align: 'right' },
+      {
+        key: 'price',
+        label: t('market.columns.price'),
+        orderable: true,
+        align: 'right',
+      },
     ],
     [],
   );
@@ -180,7 +237,7 @@ export const MarketTableUi: React.FC<MarketTableProps> = ({ markets, getRowHref 
       cardColumns={cardColumns}
       data={rows}
       initialOrder={{
-        orderBy: 'asset',
+        orderBy: 'totalSupply',
         orderDirection: 'desc',
       }}
       rowKeyIndex={0}

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -461,6 +461,12 @@
       "label": "To"
     }
   },
+  "table": {
+    "cardsSelect": {
+      "accessibilityLabel": "Choose an option to sort table rows by",
+      "label": "Sort by"
+    }
+  },
   "transactionErrors": {
     "acceptAdminPendingAdminCheck": "Accept Admin Pending Admin Check",
     "acceptPendingImplementationAddressCheck": "Accept Pending Implementation Address Check",


### PR DESCRIPTION
## Jira ticket(s)

VEN-1132

## Changes

- Mobile viewport now lets the user is sort markets by: total supply, supply APY, liquidity, total borrow and borrow APY.
