### PR TITLE
Additional fixes related to isolated assets

### DIFF
--- a/src/clients/api/queries/getIsolatedPools/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getIsolatedPools/__tests__/__snapshots__/index.spec.ts.snap
@@ -97,7 +97,7 @@ Object {
       "riskRating": "VERY_HIGH_RISK",
       "userBorrowBalanceCents": 0,
       "userBorrowLimitCents": 0,
-      "userSupplyBalanceCents": 23743960,
+      "userSupplyBalanceCents": 0,
     },
     Object {
       "assets": Array [
@@ -193,7 +193,7 @@ Object {
       "riskRating": "VERY_HIGH_RISK",
       "userBorrowBalanceCents": 0,
       "userBorrowLimitCents": 0,
-      "userSupplyBalanceCents": 308290,
+      "userSupplyBalanceCents": 0,
     },
   ],
 }

--- a/src/clients/api/queries/getIsolatedPools/formatToPool.ts
+++ b/src/clients/api/queries/getIsolatedPools/formatToPool.ts
@@ -218,8 +218,8 @@ const formatToPool = ({
         : 0;
 
       return {
-        userSupplyBalanceCents: accAssets.userSupplyBalanceCents + asset.supplyBalanceCents,
-        userBorrowBalanceCents: accAssets.userBorrowBalanceCents + asset.borrowBalanceCents,
+        userSupplyBalanceCents: accAssets.userSupplyBalanceCents + asset.userSupplyBalanceCents,
+        userBorrowBalanceCents: accAssets.userBorrowBalanceCents + asset.userBorrowBalanceCents,
         userBorrowLimitCents: accAssets.userBorrowLimitCents + assetUserCollateralValue,
       };
     },

--- a/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
+++ b/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
@@ -29,16 +29,14 @@ const formatOutput = ({
   }
 
   // Extract pending rewards from isolated pools
-  const isolatedPoolPendingRewardGroups =
-    (contractCallResults.results.poolLens?.callsReturnContext).reduce<PendingRewardGroup[]>(
-      (acc, callsReturnContext) => {
-        const isolatedPoolPendingRewardGroup =
-          formatToIsolatedPoolPendingRewardGroup(callsReturnContext);
+  const isolatedPoolPendingRewardGroups = (
+    contractCallResults.results.poolLens?.callsReturnContext || []
+  ).reduce<PendingRewardGroup[]>((acc, callsReturnContext) => {
+    const isolatedPoolPendingRewardGroup =
+      formatToIsolatedPoolPendingRewardGroup(callsReturnContext);
 
-        return isolatedPoolPendingRewardGroup ? [...acc, isolatedPoolPendingRewardGroup] : acc;
-      },
-      [],
-    );
+    return isolatedPoolPendingRewardGroup ? [...acc, isolatedPoolPendingRewardGroup] : acc;
+  }, []);
   pendingRewardGroups.push(...isolatedPoolPendingRewardGroups);
 
   // Extract pending rewards from VRT vault

--- a/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
+++ b/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
@@ -29,17 +29,16 @@ const formatOutput = ({
   }
 
   // Extract pending rewards from isolated pools
-  const isolatedPoolPendingRewardGroups = (
-    contractCallResults.results.poolLens?.callsReturnContext
-      // Ignore last call result as it is the oracle address
-      .slice(0, -1) || []
-  ).reduce<PendingRewardGroup[]>((acc, callsReturnContext) => {
-    const isolatedPoolPendingRewardGroup =
-      formatToIsolatedPoolPendingRewardGroup(callsReturnContext);
+  const isolatedPoolPendingRewardGroups =
+    (contractCallResults.results.poolLens?.callsReturnContext).reduce<PendingRewardGroup[]>(
+      (acc, callsReturnContext) => {
+        const isolatedPoolPendingRewardGroup =
+          formatToIsolatedPoolPendingRewardGroup(callsReturnContext);
 
-    return isolatedPoolPendingRewardGroup ? [...acc, isolatedPoolPendingRewardGroup] : acc;
-  }, []);
-
+        return isolatedPoolPendingRewardGroup ? [...acc, isolatedPoolPendingRewardGroup] : acc;
+      },
+      [],
+    );
   pendingRewardGroups.push(...isolatedPoolPendingRewardGroups);
 
   // Extract pending rewards from VRT vault

--- a/src/components/AccountData/useGetValues.ts
+++ b/src/components/AccountData/useGetValues.ts
@@ -46,12 +46,12 @@ const useGetValues = ({
         : undefined;
 
     const poolUserBorrowLimitUsedPercentage =
-      pool.userBorrowBalanceCents &&
-      pool.userBorrowLimitCents &&
-      calculatePercentage({
-        numerator: pool.userBorrowBalanceCents,
-        denominator: pool.userBorrowLimitCents,
-      });
+      pool.userBorrowBalanceCents !== undefined && pool.userBorrowLimitCents !== undefined
+        ? calculatePercentage({
+            numerator: pool.userBorrowBalanceCents,
+            denominator: pool.userBorrowLimitCents,
+          })
+        : undefined;
 
     const returnValues: UseGetValuesOutput = {
       poolUserBorrowLimitUsedPercentage,
@@ -164,13 +164,6 @@ const useGetValues = ({
       calculateDailyEarningsCents(hypotheticalUserYearlyEarningsCents).dp(0).toNumber();
 
     return returnValues;
-  }, [
-    {
-      asset,
-      pool,
-      action,
-      amountTokens,
-    },
-  ]);
+  }, [asset, pool, action, amountTokens]);
 
 export default useGetValues;

--- a/src/constants/tokens/common/testnet.ts
+++ b/src/constants/tokens/common/testnet.ts
@@ -181,4 +181,11 @@ export const TESTNET_TOKENS = {
     symbol: 'BNX',
     asset: xvs, // TODO: add correct asset
   } as Token,
+  // This token is distributed when supplying WBNB to the Pool 2
+  mockXvs: {
+    address: '0xADBed07126B7b70cbc5E07Bf73599d55Be571b9c',
+    decimals: 18,
+    symbol: 'XVS',
+    asset: xvs,
+  } as Token,
 };

--- a/src/utilities/formatToPool.ts
+++ b/src/utilities/formatToPool.ts
@@ -24,7 +24,7 @@ const formatToPool = (input: FormatToPoolInput): Pool => {
       }
 
       // Calculate user borrow limit
-      // Initialize user borrow limit if it necessary
+      // Initialize user borrow limit if necessary
       if (acc.userBorrowLimitCents === undefined && assetUserSupplyBalanceCents !== undefined) {
         acc.userBorrowLimitCents = 0;
       }

--- a/src/utilities/formatToPool.ts
+++ b/src/utilities/formatToPool.ts
@@ -24,6 +24,11 @@ const formatToPool = (input: FormatToPoolInput): Pool => {
       }
 
       // Calculate user borrow limit
+      // Initialize user borrow limit if it necessary
+      if (acc.userBorrowLimitCents === undefined && assetUserSupplyBalanceCents !== undefined) {
+        acc.userBorrowLimitCents = 0;
+      }
+
       if (assetUserSupplyBalanceCents && asset.isCollateralOfUser) {
         acc.userBorrowLimitCents =
           (acc.userBorrowLimitCents || 0) + assetUserSupplyBalanceCents * asset.collateralFactor;


### PR DESCRIPTION
## Changes

- fix `formatToPool` that used asset balances to defined user balances
- remove slice operation on poolLens results
- add `mockXvs` token
- initialize `userBorrowLimitCents` if user supply balance cents is not `undefined` in `formatToPool`
