### PR TITLE
Improve sorting of market table for collaterals

### DIFF
--- a/src/containers/MarketTable/useGenerateColumns.tsx
+++ b/src/containers/MarketTable/useGenerateColumns.tsx
@@ -229,6 +229,11 @@ const useGenerateColumns = ({
                   return compareBigNumbers(roaASupplyApy, roaBSupplyApy, direction);
                 }
 
+                // Put rows of tokens that can't be enabled as collateral at the
+                // bottom of the list
+                if (column === 'collateral' && rowA.collateralFactor === 0) return 1;
+                if (column === 'collateral' && rowB.collateralFactor === 0) return -1;
+                // Sort other rows normally
                 if (column === 'collateral') {
                   return compareBooleans(
                     rowA.isCollateralOfUser,


### PR DESCRIPTION
## Changes

- when sorting rows by collateral, put rows of tokens that can't be enabled as collateral at the bottom of the list
