### PR TITLE
Fix how supply and borrow caps are handled

### DIFF
--- a/src/hooks/useBorrowRepayModal/Modal/Borrow/Notice.tsx
+++ b/src/hooks/useBorrowRepayModal/Modal/Borrow/Notice.tsx
@@ -27,6 +27,25 @@ const Notice: React.FC<NoticeProps> = ({
   const { t } = useTranslation();
   const styles = useSharedStyles();
 
+  if (
+    asset.borrowCapTokens &&
+    asset.borrowBalanceTokens.isGreaterThanOrEqualTo(asset.borrowCapTokens)
+  ) {
+    // Borrow cap has been reached so borrowing more is forbidden
+    return (
+      <NoticeError
+        css={styles.notice}
+        data-testid={TEST_IDS.notice}
+        description={t('borrowRepayModal.borrow.borrowCapReachedWarning', {
+          assetBorrowCap: formatTokensToReadableValue({
+            value: asset.borrowCapTokens,
+            token: asset.vToken.underlyingToken,
+          }),
+        })}
+      />
+    );
+  }
+
   if (!hasUserCollateralizedSuppliedAssets) {
     // User has not supplied any collateral yet
     return (
@@ -42,7 +61,7 @@ const Notice: React.FC<NoticeProps> = ({
 
   if (
     asset.borrowCapTokens &&
-    asset.userBorrowBalanceTokens.plus(amount).isGreaterThan(asset.borrowCapTokens)
+    asset.borrowBalanceTokens.plus(amount).isGreaterThan(asset.borrowCapTokens)
   ) {
     // User is trying to borrow above borrow cap
     return (
@@ -50,8 +69,16 @@ const Notice: React.FC<NoticeProps> = ({
         css={styles.notice}
         data-testid={TEST_IDS.notice}
         description={t('borrowRepayModal.borrow.aboveBorrowCapWarning', {
-          borrowCap: formatTokensToReadableValue({
+          userMaxBorrowAmount: formatTokensToReadableValue({
+            value: asset.borrowCapTokens.minus(asset.borrowBalanceTokens),
+            token: asset.vToken.underlyingToken,
+          }),
+          assetBorrowCap: formatTokensToReadableValue({
             value: asset.borrowCapTokens,
+            token: asset.vToken.underlyingToken,
+          }),
+          assetBorrowBalance: formatTokensToReadableValue({
+            value: asset.borrowBalanceTokens,
             token: asset.vToken.underlyingToken,
           }),
         })}

--- a/src/hooks/useSupplyWithdrawModal/Modal/Supply/index.tsx
+++ b/src/hooks/useSupplyWithdrawModal/Modal/Supply/index.tsx
@@ -53,7 +53,7 @@ export const SupplyUi: React.FC<SupplyUiProps> = ({
 
     // Handle supply cap if asset has one
     if (asset.supplyCapTokens) {
-      const marginWithSupplyCapTokens = asset.supplyCapTokens.minus(asset.userSupplyBalanceTokens);
+      const marginWithSupplyCapTokens = asset.supplyCapTokens.minus(asset.supplyBalanceTokens);
       maxInputTokens = marginWithSupplyCapTokens.isLessThanOrEqualTo(0)
         ? new BigNumber(0)
         : BigNumber.minimum(maxInputTokens, marginWithSupplyCapTokens);

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -76,10 +76,11 @@
   },
   "borrowRepayModal": {
     "borrow": {
-      "aboveBorrowCapWarning": "You can not borrow more than {{borrowCap}} from this pool",
+      "aboveBorrowCapWarning": "You can not borrow more than {{userMaxBorrowAmount}} from this pool, as the borrow cap for this market is set at {{assetBorrowCap}} and {{assetBorrowBalance}} are currently being borrowed from it.",
       "aboveLiquidityWarning": "Insufficient asset liquidity",
       "aboveSafeLimitWarning": "You entered a high amount, which puts you at risk of liquidation",
       "borrowableAmount": "Borrowable amount: <White>{{amount}}</White>",
+      "borrowCapReachedWarning": "The borrow cap of {{assetBorrowCap}} has been reached for this pool. You can not borrow from this market anymore until loans are repaid or its borrow cap is increased.",
       "connectWalletMessage": "Please connect your wallet to borrow",
       "enableToken": {
         "title": "To borrow {{symbol}} from the Venus Protocol, you need to enable it first"
@@ -457,7 +458,7 @@
   },
   "supplyWithdraw": {
     "supply": {
-      "amountAboveSupplyCapWarning": "You can not supply more than {{supplyCap}} to this pool",
+      "amountAboveSupplyCapWarning": "You can not supply more than {{userMaxSupplyAmount}} to this pool, as the supply cap for this market is set at {{assetSupplyCap}} and {{assetSupplyBalance}} are currently being supplied to it.",
       "connectWalletToSupply": "Please connect your wallet to supply",
       "enableToSupply": "To supply {{symbol}} to the Venus Protocol, you need to enable it first",
       "max": "MAX",
@@ -469,6 +470,7 @@
         "message": "You successfully supplied",
         "title": "Your supply was successful"
       },
+      "supplyCapReachedWarning": "The supply cap of {{assetSupplyCap}} has been reached for this pool. You can not supply to this market anymore until withdraws are made or its supply cap is increased.",
       "walletBalance": "Wallet balance: <White>{{amount}}</White>"
     },
     "supplyTabTitle": "Supply",


### PR DESCRIPTION
## Changes

- update how borrow and supply caps are handled to be per market
- disable supply form and display warning when supply cap has been reached for this market
- disable borrow form and display warning when borrow cap has been reached for this market
