### PR TITLE
Remove duplicated % sign

### DIFF
--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -420,7 +420,7 @@
   },
   "myAccount": {
     "safeLimit": "Your safe limit:",
-    "safeLimitTooltip": "{{safeBorrowLimitPercentage}}% of your borrow limit. We consider borrowing above this threshold unsafe."
+    "safeLimitTooltip": "{{safeBorrowLimitPercentage}} of your borrow limit. We consider borrowing above this threshold unsafe."
   },
   "pagination": {
     "itemOf": "Item {{currentPageLastIndex}} out of {{itemsCount}}",


### PR DESCRIPTION
## Changes

- remove duplicated percentage sign in tooltip. Because the value passed to the tooltip already contains a percentage sign, the one present in the tooltip results in two % signs being displayed in the same sentence
