### PR TITLE
[DO NOT MERGE] Add BIFI as example

### DIFF
--- a/src/constants/tokens/common/testnet.ts
+++ b/src/constants/tokens/common/testnet.ts
@@ -204,4 +204,10 @@ export const TESTNET_TOKENS = {
     symbol: 'USDD',
     asset: xvs, // TODO: add correct asset
   } as Token,
+  bifi: {
+    address: '0x5B662703775171c4212F2FBAdb7F92e64116c154',
+    decimals: 18,
+    symbol: 'BIFI',
+    asset: xvs, // TODO: add correct asset
+  } as Token,
 };

--- a/src/constants/tokens/vBep/testnet.ts
+++ b/src/constants/tokens/vBep/testnet.ts
@@ -228,4 +228,12 @@ export const TESTNET_VBEP_TOKENS = {
     asset: vXvs, // TODO: add correct asset
     underlyingToken: TESTNET_TOKENS.usdd,
   } as VToken,
+  // TODO: replace 0x with correct address (I couldn't figure it out from Simeon's PR
+  '0x': {
+    address: '0x', // TODO: replace this property with the same address used to index this vBEP20 token
+    decimals: 8,
+    symbol: 'vBIFI',
+    asset: vXvs, // TODO: add correct asset
+    underlyingToken: TESTNET_TOKENS.bifi,
+  } as VToken,
 };


### PR DESCRIPTION
This PR shows how to add a new token and vToken to the dApp.
The token I took as example is BIFI (first token of the DEFI isolated pool). The address entered for the token itself is correct, however I couldn't figure out the address of the corresponding vBEP20 token so this will need to be updated.

To sum this up, in order to add a new token to the dApp you only need to add a reference of the vToken and one of the underlying token (note that assets, in the form of SVG icons, need to be imported for each of them).
