### PR TITLE
refactor: reduce maintence by pulling address from deployments in isolated lending package

### DIFF
--- a/src/clients/api/queries/getIsolatedPools/index.ts
+++ b/src/clients/api/queries/getIsolatedPools/index.ts
@@ -4,7 +4,7 @@ import { abi as rewardsDistributorAbi } from '@venusprotocol/isolated-pools/arti
 import { ContractCallContext, ContractCallResults } from 'ethereum-multicall';
 import _cloneDeep from 'lodash/cloneDeep';
 import { Token } from 'types';
-import { areTokensEqual, getContractAddress, getTokenByAddress } from 'utilities';
+import { areTokensEqual, getIsolatedPoolAddress, getTokenByAddress } from 'utilities';
 
 import { getIsolatedPoolParticipantsCount } from 'clients/subgraph';
 import { logError } from 'context/ErrorLogger';
@@ -15,7 +15,7 @@ import { GetIsolatedPoolsInput, GetIsolatedPoolsOutput } from './types';
 
 export type { GetIsolatedPoolsInput, GetIsolatedPoolsOutput } from './types';
 
-const POOL_REGISTRY_ADDRESS = getContractAddress('poolRegistry');
+const POOL_REGISTRY_ADDRESS = getIsolatedPoolAddress('PoolRegistry');
 
 const getIsolatedPools = async ({
   accountAddress,

--- a/src/clients/api/queries/getPendingRewards/index.ts
+++ b/src/clients/api/queries/getPendingRewards/index.ts
@@ -1,6 +1,6 @@
 import { abi as poolLensAbi } from '@venusprotocol/isolated-pools/artifacts/contracts/Lens/PoolLens.sol/PoolLens.json';
 import { ContractCallContext, ContractCallResults } from 'ethereum-multicall';
-import { getContractAddress } from 'utilities';
+import { getContractAddress, getIsolatedPoolAddress } from 'utilities';
 
 import vaiVaultAbi from 'constants/contracts/abis/vaiVault.json';
 import venusLensAbi from 'constants/contracts/abis/venusLens.json';
@@ -12,7 +12,7 @@ import formatOutput from './formatOutput';
 import { GetPendingRewardGroupsInput, GetPendingRewardGroupsOutput } from './types';
 
 const venusLensAddress = getContractAddress('venusLens');
-const poolLensAddress = getContractAddress('poolLens');
+const poolLensAddress = getIsolatedPoolAddress('PoolLens');
 const vrtVaultAddress = getContractAddress('vrtVaultProxy');
 const vaiVaultAddress = getContractAddress('vaiVault');
 const xvsVaultAddress = getContractAddress('xvsVaultProxy');

--- a/src/clients/contracts/getters.ts
+++ b/src/clients/contracts/getters.ts
@@ -1,7 +1,7 @@
 import { abi as poolLensAbi } from '@venusprotocol/isolated-pools/artifacts/contracts/Lens/PoolLens.sol/PoolLens.json';
 import { Contract, ContractInterface, Signer } from 'ethers';
 import { Token, VToken } from 'types';
-import { areTokensEqual, getContractAddress } from 'utilities';
+import { areTokensEqual, getContractAddress, getIsolatedPoolAddress } from 'utilities';
 
 import { chain, provider } from 'clients/web3';
 import bep20Abi from 'constants/contracts/abis/bep20.json';
@@ -219,6 +219,6 @@ export const getMulticallContract = (signer?: Signer) =>
 export const getPoolLensContract = (signer?: Signer) =>
   getContract({
     abi: poolLensAbi,
-    address: getContractAddress('poolLens'),
+    address: getIsolatedPoolAddress('PoolLens'),
     signer,
   }) as PoolLens;

--- a/src/constants/contracts/addresses/main.json
+++ b/src/constants/contracts/addresses/main.json
@@ -27,10 +27,6 @@
     "56": "0x2a914D534715F1A84205fb05d1dc8281F8da6540",
     "97": "0x11c8dC3DcA87E8205ec01e6d79Be9442d31701d3"
   },
-  "poolLens": {
-    "56": "",
-    "97": "0x73Ac8216b93597264e2bf233B92a8F8cf413D609"
-  },
   "xvsVault": {
     "56": "0x6eF49b4e0772Fe78128F981d42D54172b55eCF9F",
     "97": "0xa4Fd54cACdA379FB7CaA783B83Cc846f8ac0Faa6"
@@ -70,9 +66,5 @@
   "multicall": {
     "56": "0xca11bde05977b3631167028862be2a173976ca11",
     "97": "0xca11bde05977b3631167028862be2a173976ca11"
-  },
-  "poolRegistry": {
-    "56": "",
-    "97": "0xF57fdd25224807B1113f40E4F95c5f625fB458E2"
   }
 }

--- a/src/utilities/getContractAddress.ts
+++ b/src/utilities/getContractAddress.ts
@@ -1,8 +1,13 @@
+import isolatedLendingTestnetDeployments from '@venusprotocol/isolated-pools/deployments/bsctestnet.json';
 import config from 'config';
 
 import mainContractAddresses from 'constants/contracts/addresses/main.json';
 
 const getContractAddress = (contractId: keyof typeof mainContractAddresses) =>
   mainContractAddresses[contractId][config.chainId];
+
+export const getIsolatedPoolAddress = (
+  contractName: keyof typeof isolatedLendingTestnetDeployments.contracts,
+) => (config.isOnTestnet ? isolatedLendingTestnetDeployments.contracts[contractName].address : '');
 
 export default getContractAddress;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -2,7 +2,7 @@ export { promisify } from './promisify';
 export { restService } from './restService';
 export { default as getVTokenByAddress } from './getVTokenByAddress';
 export { default as getTokenByAddress } from './getTokenByAddress';
-export { default as getContractAddress } from './getContractAddress';
+export { default as getContractAddress, getIsolatedPoolAddress } from './getContractAddress';
 export { default as calculateDailyEarningsCents } from './calculateDailyEarningsCents';
 export {
   calculateYearlyEarningsForAssets,


### PR DESCRIPTION
## Changes

Rather than hard code address, we can pull them from packages, this way if they are updated we don't need to copy and paste addresses between projects. Instead we can update the package version to the desired release.

This PR refactors out PoolLens and PoolRegistry to pull from package.
