### PR TITLE
Fix/index vault result from multicall

### DIFF
--- a/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
+++ b/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
@@ -84,8 +84,8 @@ const formatOutput = ({
     const pendingRewardWei = new BigNumber(xvsVestingVaultResults[v + 1].returnValues[0].hex);
 
     const hasPendingWithdrawalsFromBeforeUpgrade =
-      !!xvsVestingVaultResults[v].returnValues[2] &&
-      new BigNumber(xvsVestingVaultResults[v].returnValues[2].hex).isGreaterThan(0);
+      !!xvsVestingVaultResults[v + 2].returnValues[0] &&
+      new BigNumber(xvsVestingVaultResults[v + 2].returnValues[0].hex).isGreaterThan(0);
 
     if (
       !hasPendingWithdrawalsFromBeforeUpgrade &&


### PR DESCRIPTION
## Jira ticket(s)

## Changes

The pending rewards withdrawl result is the third result in the multicall array and returns one value. This PR updates to index it correctly so we can show vault rewards in the claim modal
