### PR TITLE
Update how addresses of isolated lending contracts are retrieved

### DIFF
--- a/src/clients/api/queries/getIsolatedPools/index.ts
+++ b/src/clients/api/queries/getIsolatedPools/index.ts
@@ -4,7 +4,7 @@ import { abi as rewardsDistributorAbi } from '@venusprotocol/isolated-pools/arti
 import { ContractCallContext, ContractCallResults } from 'ethereum-multicall';
 import _cloneDeep from 'lodash/cloneDeep';
 import { Token } from 'types';
-import { areTokensEqual, getIsolatedPoolAddress, getTokenByAddress } from 'utilities';
+import { areTokensEqual, getContractAddress, getTokenByAddress } from 'utilities';
 
 import { getIsolatedPoolParticipantsCount } from 'clients/subgraph';
 import { logError } from 'context/ErrorLogger';
@@ -15,7 +15,7 @@ import { GetIsolatedPoolsInput, GetIsolatedPoolsOutput } from './types';
 
 export type { GetIsolatedPoolsInput, GetIsolatedPoolsOutput } from './types';
 
-const POOL_REGISTRY_ADDRESS = getIsolatedPoolAddress('PoolRegistry');
+const POOL_REGISTRY_ADDRESS = getContractAddress('PoolRegistry');
 
 const getIsolatedPools = async ({
   accountAddress,

--- a/src/clients/api/queries/getPendingRewards/index.ts
+++ b/src/clients/api/queries/getPendingRewards/index.ts
@@ -1,6 +1,6 @@
 import { abi as poolLensAbi } from '@venusprotocol/isolated-pools/artifacts/contracts/Lens/PoolLens.sol/PoolLens.json';
 import { ContractCallContext, ContractCallResults } from 'ethereum-multicall';
-import { getContractAddress, getIsolatedPoolAddress } from 'utilities';
+import { getContractAddress } from 'utilities';
 
 import vaiVaultAbi from 'constants/contracts/abis/vaiVault.json';
 import venusLensAbi from 'constants/contracts/abis/venusLens.json';
@@ -11,7 +11,7 @@ import formatOutput from './formatOutput';
 import { GetPendingRewardGroupsInput, GetPendingRewardGroupsOutput } from './types';
 
 const venusLensAddress = getContractAddress('venusLens');
-const poolLensAddress = getIsolatedPoolAddress('PoolLens');
+const poolLensAddress = getContractAddress('PoolLens');
 const vaiVaultAddress = getContractAddress('vaiVault');
 const xvsVaultAddress = getContractAddress('xvsVaultProxy');
 

--- a/src/clients/contracts/getters.ts
+++ b/src/clients/contracts/getters.ts
@@ -1,7 +1,7 @@
 import { abi as poolLensAbi } from '@venusprotocol/isolated-pools/artifacts/contracts/Lens/PoolLens.sol/PoolLens.json';
 import { Contract, ContractInterface, Signer } from 'ethers';
 import { Token, VToken } from 'types';
-import { areTokensEqual, getContractAddress, getIsolatedPoolAddress } from 'utilities';
+import { areTokensEqual, getContractAddress } from 'utilities';
 
 import { chain, provider } from 'clients/web3';
 import bep20Abi from 'constants/contracts/abis/bep20.json';
@@ -209,6 +209,6 @@ export const getMulticallContract = (signer?: Signer) =>
 export const getPoolLensContract = (signer?: Signer) =>
   getContract({
     abi: poolLensAbi,
-    address: getIsolatedPoolAddress('PoolLens'),
+    address: getContractAddress('PoolLens'),
     signer,
   }) as PoolLens;

--- a/src/utilities/getContractAddress.ts
+++ b/src/utilities/getContractAddress.ts
@@ -3,11 +3,32 @@ import config from 'config';
 
 import mainContractAddresses from 'constants/contracts/addresses/main.json';
 
-const getContractAddress = (contractId: keyof typeof mainContractAddresses) =>
-  mainContractAddresses[contractId][config.chainId];
+type IsolatedLendingContractName = keyof typeof isolatedLendingTestnetDeployments['contracts'];
 
-export const getIsolatedPoolAddress = (
-  contractName: keyof typeof isolatedLendingTestnetDeployments.contracts,
-) => (config.isOnTestnet ? isolatedLendingTestnetDeployments.contracts[contractName].address : '');
+const isolatedLendingContractAddresses = Object.entries(
+  isolatedLendingTestnetDeployments.contracts,
+).reduce(
+  (accContractAddresses, [contractName, contractInfo]) => ({
+    ...accContractAddresses,
+    [contractName]: {
+      97: contractInfo.address,
+      56: '', // TODO: fill up once contracts have been deployed to mainnet
+    },
+  }),
+  {},
+) as Record<
+  IsolatedLendingContractName,
+  {
+    [chainId: number]: string;
+  }
+>;
+
+const contractAddresses = {
+  ...mainContractAddresses,
+  ...isolatedLendingContractAddresses,
+};
+
+const getContractAddress = (contractName: keyof typeof contractAddresses) =>
+  contractAddresses[contractName][config.chainId];
 
 export default getContractAddress;

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -2,7 +2,7 @@ export { promisify } from './promisify';
 export { restService } from './restService';
 export { default as getVTokenByAddress } from './getVTokenByAddress';
 export { default as getTokenByAddress } from './getTokenByAddress';
-export { default as getContractAddress, getIsolatedPoolAddress } from './getContractAddress';
+export { default as getContractAddress } from './getContractAddress';
 export { default as calculateDailyEarningsCents } from './calculateDailyEarningsCents';
 export {
   calculateYearlyEarningsForAssets,


### PR DESCRIPTION
## Changes

- remove `getIsolatedPoolAddress` in favor of adding isolated lending contracts to the existing `getContractAddress` utility function
