### PR TITLE
Only display loading indicators on pages when fetching new data

### DIFF
--- a/src/pages/Governance/ProposalList/index.tsx
+++ b/src/pages/Governance/ProposalList/index.tsx
@@ -134,10 +134,14 @@ const ProposalList: React.FC<ProposalListPageProps> = ({ currentPage, setCurrent
 
   const {
     data: { proposals, total, limit = 5 } = { proposals: [] },
+    isLoading,
     isFetching: isGetProposalsFetching,
+    isPreviousData: isGetProposalsPreviousData,
   } = useGetProposals({
     page: currentPage,
   });
+
+  const isFetchingProposals = isLoading || (isGetProposalsFetching && isGetProposalsPreviousData);
 
   const { mutateAsync: createProposal, isLoading: isCreateProposalLoading } = useCreateProposal();
 
@@ -165,7 +169,7 @@ const ProposalList: React.FC<ProposalListPageProps> = ({ currentPage, setCurrent
   return (
     <ProposalListUi
       proposals={proposals}
-      isLoading={isGetProposalsFetching}
+      isLoading={isFetchingProposals}
       total={total}
       limit={limit}
       setCurrentPage={setCurrentPage}

--- a/src/pages/History/index.spec.tsx
+++ b/src/pages/History/index.spec.tsx
@@ -32,6 +32,7 @@ describe('pages/History', () => {
     (useGetTransactions as jest.Mock).mockImplementation(() => ({
       data: undefined,
       isFetching: true,
+      isPreviousData: true,
     }));
     const { getByTestId } = renderComponent(History);
     getByTestId(TEST_IDS.spinner);

--- a/src/pages/History/index.tsx
+++ b/src/pages/History/index.tsx
@@ -60,12 +60,19 @@ const History: React.FC<RouteComponentProps> = ({ history, location }) => {
 
   const [eventType, setEventType] = useState<TransactionEvent | typeof ALL_VALUE>(ALL_VALUE);
   const [showOnlyMyTxns, setShowOnlyMyTxns] = useState(false);
-  const { data: { transactions, total, limit } = { transactions: [] }, isFetching } =
-    useGetTransactions({
-      page: currentPage,
-      address: showOnlyMyTxns ? accountAddress : undefined,
-      event: eventType !== ALL_VALUE ? eventType : undefined,
-    });
+  const {
+    data: { transactions, total, limit } = { transactions: [] },
+    isLoading: isGetTransactionsLoading,
+    isFetching: isGetTransactionsFetching,
+    isPreviousData: isGetTransactionsPreviousData,
+  } = useGetTransactions({
+    page: currentPage,
+    address: showOnlyMyTxns ? accountAddress : undefined,
+    event: eventType !== ALL_VALUE ? eventType : undefined,
+  });
+
+  const isFetching =
+    isGetTransactionsLoading || (isGetTransactionsFetching && isGetTransactionsPreviousData);
 
   return (
     <HistoryUi

--- a/src/pages/Voter/index.tsx
+++ b/src/pages/Voter/index.tsx
@@ -79,8 +79,13 @@ const Voter: React.FC<VoterDetailsPageProps> = ({ history, location }) => {
   const { data: voterDetails } = useGetVoterDetails({ address });
   const {
     data: { voterHistory, total, limit } = { voterHistory: [], total: 0, limit: 16 },
-    isFetching,
+    isLoading: isGetVoterHistoryLoading,
+    isFetching: isGetVoterHistoryFetching,
+    isPreviousData: isGetVoterHistoryPreviousData,
   } = useGetVoterHistory({ address, page: currentPage });
+
+  const isFetching =
+    isGetVoterHistoryLoading || (isGetVoterHistoryFetching && isGetVoterHistoryPreviousData);
 
   return (
     <VoterUi

--- a/src/pages/VoterLeaderboard/index.tsx
+++ b/src/pages/VoterLeaderboard/index.tsx
@@ -59,8 +59,13 @@ const VoterLeaderboard: React.FC<VoterLeaderboardPageProps> = ({ history, locati
       total: undefined,
       limit: undefined,
     },
-    isFetching,
+    isLoading: isGetVoterAccountsLoading,
+    isFetching: isGetVoterAccountsFetching,
+    isPreviousData: isGetVoterAccountsPreviousData,
   } = useGetVoterAccounts({ page: currentPage });
+
+  const isFetching =
+    isGetVoterAccountsLoading || (isGetVoterAccountsFetching && isGetVoterAccountsPreviousData);
 
   return (
     <VoterLeaderboardUi


### PR DESCRIPTION
## Changes

- update loading behavior of lists so loader indicators are only displayed when fetching new data
