### PR TITLE
Improve auth

### DIFF
--- a/src/App/Switch/index.tsx
+++ b/src/App/Switch/index.tsx
@@ -22,7 +22,7 @@ import VoterLeaderboard from 'pages/VoterLeaderboard';
 import Xvs from 'pages/Xvs';
 
 const Switch = () => {
-  const { isConnected } = useAuth();
+  const { accountAddress } = useAuth();
   const location = useLocation();
   const history = useHistory();
 
@@ -30,16 +30,16 @@ const Switch = () => {
   // visiting the dashboard. If they refresh the page while being on the
   // dashboard, the redirection will not happen
   useEffect(() => {
-    if (isConnected && location.pathname === routes.dashboard.path && history.length <= 2) {
+    if (!!accountAddress && location.pathname === routes.dashboard.path && history.length <= 2) {
       history.replace(routes.account.path);
     }
-  }, [location, isConnected, history]);
+  }, [location, accountAddress, history]);
 
   return (
     <RRSwitch>
       <Route exact path={routes.dashboard.path} component={Dashboard} />
 
-      {isConnected && <Route exact path={routes.account.path} component={Account} />}
+      {!!accountAddress && <Route exact path={routes.account.path} component={Account} />}
 
       {isFeatureEnabled('isolatedPools') && (
         <Route exact path={routes.pools.path} component={Pools} />

--- a/src/clients/web3/Web3Wrapper/client.ts
+++ b/src/clients/web3/Web3Wrapper/client.ts
@@ -54,6 +54,7 @@ const client = createClient({
       },
     }),
     new CoinbaseWalletConnector({
+      chains: [chain],
       options: {
         appName: 'Venus',
       },

--- a/src/components/Layout/Sidebar/index.stories.tsx
+++ b/src/components/Layout/Sidebar/index.stories.tsx
@@ -16,7 +16,6 @@ const context: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: fakeAddress,
 };
 

--- a/src/components/Layout/Sidebar/useGetMenuItems.tsx
+++ b/src/components/Layout/Sidebar/useGetMenuItems.tsx
@@ -9,7 +9,7 @@ import { MenuItem } from '../types';
 const MAIN_POOL_COMPTROLLER_ADDRESS = getContractAddress('comptroller');
 
 const useGetMenuItems = () => {
-  const { isConnected } = useAuth();
+  const { accountAddress } = useAuth();
 
   return useMemo(() => {
     const menuItems: MenuItem[] = [
@@ -23,7 +23,7 @@ const useGetMenuItems = () => {
     ];
 
     // Insert account page if wallet is connected
-    if (isConnected) {
+    if (accountAddress) {
       menuItems.push({
         href: routes.account.path,
         // Translation key: do not remove this comment
@@ -117,7 +117,7 @@ const useGetMenuItems = () => {
     );
 
     return menuItems;
-  }, [isConnected]);
+  }, [accountAddress]);
 };
 
 export default useGetMenuItems;

--- a/src/context/AuthContext/index.tsx
+++ b/src/context/AuthContext/index.tsx
@@ -29,7 +29,6 @@ export interface AuthContextValue {
   openAuthModal: () => void;
   closeAuthModal: () => void;
   provider: Provider;
-  isConnected: boolean;
   accountAddress: string;
   signer?: Signer;
 }
@@ -39,7 +38,6 @@ export const AuthContext = React.createContext<AuthContextValue>({
   logOut: noop,
   openAuthModal: noop,
   closeAuthModal: noop,
-  isConnected: false,
   provider: getDefaultProvider(),
   accountAddress: '',
 });
@@ -59,8 +57,7 @@ export const AuthProvider: React.FC = ({ children }) => {
 
   // Set address as authorized by default
   const isAuthorizedAddress = !accountAuth || accountAuth.authorized;
-  const isUserConnected = isConnected && !!signer;
-  const accountAddress = isUserConnected && address && isAuthorizedAddress ? address : '';
+  const accountAddress = isConnected && !!signer && address && isAuthorizedAddress ? address : '';
 
   const login = useCallback(async (connectorId: Connector) => {
     // If user is attempting to connect their Infinity wallet but the dApp
@@ -122,7 +119,6 @@ export const AuthProvider: React.FC = ({ children }) => {
         logOut,
         openAuthModal,
         closeAuthModal,
-        isConnected: isUserConnected,
         provider,
         signer: signer || undefined,
       }}

--- a/src/hooks/useOperationModal/Modal/index.stories.tsx
+++ b/src/hooks/useOperationModal/Modal/index.stories.tsx
@@ -30,7 +30,6 @@ const context: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: fakeAddress,
 };
 

--- a/src/pages/ConvertVrt/Convert/index.spec.tsx
+++ b/src/pages/ConvertVrt/Convert/index.spec.tsx
@@ -20,7 +20,6 @@ describe('pages/ConvertVRT/Convert', () => {
           logOut: vi.fn(),
           openAuthModal: vi.fn(),
           closeAuthModal: vi.fn(),
-          isConnected: true,
           provider: fakeProvider,
           accountAddress: fakeAccountAddress,
         }}

--- a/src/pages/ConvertVrt/Withdraw/index.spec.tsx
+++ b/src/pages/ConvertVrt/Withdraw/index.spec.tsx
@@ -39,7 +39,6 @@ describe('pages/ConvertVRT/Withdraw', () => {
           logOut: vi.fn(),
           openAuthModal: vi.fn(),
           closeAuthModal: vi.fn(),
-          isConnected: true,
           provider: fakeProvider,
           accountAddress: fakeAccountAddress,
         }}

--- a/src/pages/ConvertVrt/index.stories.tsx
+++ b/src/pages/ConvertVrt/index.stories.tsx
@@ -30,7 +30,6 @@ const context: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: '0x0000000000000000000000000000000000000000',
 };
 

--- a/src/pages/Vai/index.stories.tsx
+++ b/src/pages/Vai/index.stories.tsx
@@ -30,7 +30,6 @@ const context: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: fakeAddress,
 };
 

--- a/src/pages/Vault/modals/ActionModal/index.stories.tsx
+++ b/src/pages/Vault/modals/ActionModal/index.stories.tsx
@@ -26,7 +26,6 @@ const authContext: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: fakeAddress,
 };
 

--- a/src/pages/Vault/modals/StakeModal/index.stories.tsx
+++ b/src/pages/Vault/modals/StakeModal/index.stories.tsx
@@ -25,7 +25,6 @@ const authContext: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: fakeAddress,
 };
 

--- a/src/pages/Vault/modals/WithdrawFromVaiVaultModal/index.stories.tsx
+++ b/src/pages/Vault/modals/WithdrawFromVaiVaultModal/index.stories.tsx
@@ -27,7 +27,6 @@ const authContext: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: '0x0000000000000000000000000000000000000000',
 };
 

--- a/src/pages/Vault/modals/WithdrawFromVestingVaultModal/index.stories.tsx
+++ b/src/pages/Vault/modals/WithdrawFromVestingVaultModal/index.stories.tsx
@@ -26,7 +26,6 @@ const authContext: AuthContextValue = {
   openAuthModal: noop,
   closeAuthModal: noop,
   provider: fakeProvider,
-  isConnected: true,
   accountAddress: fakeAddress,
 };
 

--- a/src/testUtils/renderComponent.tsx
+++ b/src/testUtils/renderComponent.tsx
@@ -37,7 +37,6 @@ const renderComponent = (
     logOut: vi.fn(),
     openAuthModal: vi.fn(),
     closeAuthModal: vi.fn(),
-    isConnected: false,
     provider: getDefaultProvider(),
     accountAddress: '',
     ...authContextValue,


### PR DESCRIPTION
## Changes

- automatically disconnect wallet if it is connected to the wrong network
- only return connected account address if a signer could be retrieved too
- remove redundant `isConnected` prop from `AuthContext`
