### PR TITLE
feat: added testnet addresses for DeFi, Tron, GameFi and Liquid Staked BNB

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@sentry/tracing": "^7.43.0",
     "@uiw/react-markdown-preview": "^4.1.13",
     "@uiw/react-md-editor": "^3.14.3",
-    "@venusprotocol/isolated-pools": "^1.0.0",
+    "@venusprotocol/isolated-pools": "^1.1.0-dev.1",
     "bignumber.js": "^9.0.0",
     "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.28.0",

--- a/src/constants/contracts/swapRouters/mainnet.ts
+++ b/src/constants/contracts/swapRouters/mainnet.ts
@@ -6,12 +6,36 @@ const MAIN_POOL_COMPTROLLER_ADDRESS = getContractAddress('comptroller').toLowerC
 
 const STABLE_COINS_POOL_COMPTROLLER_ADDRESS =
   isolatedLendingMainnetDeployments.contracts.Comptroller_Stablecoins.address.toLowerCase();
-
 const STABLE_COINS_POOL_SWAP_ROUTER_ADDRESS =
   isolatedLendingMainnetDeployments.contracts.SwapRouter_Stablecoins.address.toLowerCase();
+
+const TRON_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.Comptroller_Tron.address.toLowerCase();
+const TRON_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.SwapRouter_Tron.address.toLowerCase();
+
+const GAMEFI_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.Comptroller_GameFi.address.toLowerCase();
+const GAMEFI_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.SwapRouter_GameFi.address.toLowerCase();
+
+const DEFI_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.Comptroller_DeFi.address.toLowerCase();
+const DEFI_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.SwapRouter_DeFi.address.toLowerCase();
+
+const LIQUID_STAKED_BNB_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.Comptroller_LiquidStakedBNB.address.toLowerCase();
+const LIQUID_STAKED_BNB_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingMainnetDeployments.contracts.SwapRouter_LiquidStakedBNB.address.toLowerCase();
 
 export const MAINNET_SWAP_ROUTERS: SwapRouterAddressMapping = {
   // Main pool
   [MAIN_POOL_COMPTROLLER_ADDRESS]: '0x8938E6dA30b59c1E27d5f70a94688A89F7c815a4',
+  // Isolated Pools
   [STABLE_COINS_POOL_COMPTROLLER_ADDRESS]: STABLE_COINS_POOL_SWAP_ROUTER_ADDRESS,
+  [TRON_POOL_COMPTROLLER_ADDRESS]: TRON_POOL_SWAP_ROUTER_ADDRESS,
+  [GAMEFI_POOL_COMPTROLLER_ADDRESS]: GAMEFI_POOL_SWAP_ROUTER_ADDRESS,
+  [DEFI_POOL_COMPTROLLER_ADDRESS]: DEFI_POOL_SWAP_ROUTER_ADDRESS,
+  [LIQUID_STAKED_BNB_POOL_COMPTROLLER_ADDRESS]: LIQUID_STAKED_BNB_POOL_SWAP_ROUTER_ADDRESS,
 };

--- a/src/constants/contracts/swapRouters/testnet.ts
+++ b/src/constants/contracts/swapRouters/testnet.ts
@@ -6,10 +6,36 @@ const MAIN_POOL_COMPTROLLER_ADDRESS = getContractAddress('comptroller').toLowerC
 
 const STABLE_COINS_POOL_COMPTROLLER_ADDRESS =
   isolatedLendingTestnetDeployments.contracts.Comptroller_StableCoins.address.toLowerCase();
+const STABLE_COINS_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.SwapRouter_StableCoins.address.toLowerCase();
+
+const TRON_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.Comptroller_Tron.address.toLowerCase();
+const TRON_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.SwapRouter_Tron.address.toLowerCase();
+
+const GAMEFI_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.Comptroller_GameFi.address.toLowerCase();
+const GAMEFI_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.SwapRouter_GameFi.address.toLowerCase();
+
+const DEFI_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.Comptroller_DeFi.address.toLowerCase();
+const DEFI_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.SwapRouter_DeFi.address.toLowerCase();
+
+const LIQUID_STAKED_BNB_POOL_COMPTROLLER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.Comptroller_LiquidStakedBNB.address.toLowerCase();
+const LIQUID_STAKED_BNB_POOL_SWAP_ROUTER_ADDRESS =
+  isolatedLendingTestnetDeployments.contracts.SwapRouter_LiquidStakedBNB.address.toLowerCase();
 
 export const TESTNET_SWAP_ROUTERS: SwapRouterAddressMapping = {
   // Main pool
   [MAIN_POOL_COMPTROLLER_ADDRESS]: '0x83edf1dee1b730b7e8e13c00ba76027d63a51ac0',
   // Isolated pools
-  [STABLE_COINS_POOL_COMPTROLLER_ADDRESS]: '0xca59d9e8889bc6034ccd749c4ddd09c865432ba8',
+  [STABLE_COINS_POOL_COMPTROLLER_ADDRESS]: STABLE_COINS_POOL_SWAP_ROUTER_ADDRESS,
+  [TRON_POOL_COMPTROLLER_ADDRESS]: TRON_POOL_SWAP_ROUTER_ADDRESS,
+  [GAMEFI_POOL_COMPTROLLER_ADDRESS]: GAMEFI_POOL_SWAP_ROUTER_ADDRESS,
+  [DEFI_POOL_COMPTROLLER_ADDRESS]: DEFI_POOL_SWAP_ROUTER_ADDRESS,
+  [LIQUID_STAKED_BNB_POOL_COMPTROLLER_ADDRESS]: LIQUID_STAKED_BNB_POOL_SWAP_ROUTER_ADDRESS,
 };

--- a/src/constants/tokens/vBep/testnet.ts
+++ b/src/constants/tokens/vBep/testnet.ts
@@ -151,4 +151,134 @@ export const TESTNET_VBEP_TOKENS = {
     symbol: 'vHAY',
     underlyingToken: TESTNET_TOKENS.hay,
   } as VToken,
+  // Tron
+  '0x410286c43a525e1dcc7468a9b091c111c8324cd1': {
+    address: '0x410286c43a525E1DCC7468a9B091C111C8324cd1',
+    decimals: 8,
+    symbol: 'vTRX',
+    underlyingToken: TESTNET_TOKENS.trx,
+  } as VToken,
+  '0x47793540757c6e6d84155b33cd8d9535cfdb9334': {
+    address: '0x47793540757c6E6D84155B33cd8D9535CFdb9334',
+    decimals: 8,
+    symbol: 'vBTT',
+    underlyingToken: TESTNET_TOKENS.btt,
+  } as VToken,
+  '0x712774cbffcbd60e9825871cceff2f917442b2c3': {
+    address: '0x712774CBFFCBD60e9825871CcEFF2F917442b2c3',
+    decimals: 8,
+    symbol: 'vUSDT',
+    underlyingToken: TESTNET_TOKENS.usdt,
+  } as VToken,
+  '0xd804f74fe21290d213c46610ab171f7c2eeebde7': {
+    address: '0xD804F74fe21290d213c46610ab171f7c2EeEBDE7',
+    decimals: 8,
+    symbol: 'vUSDD',
+    underlyingToken: TESTNET_TOKENS.usdd,
+  } as VToken,
+  '0xee543d5de2dbb5b07675fc72831a2f1812428393': {
+    address: '0xEe543D5de2Dbb5b07675Fc72831A2f1812428393',
+    decimals: 8,
+    symbol: 'vWIN',
+    underlyingToken: TESTNET_TOKENS.win,
+  } as VToken,
+  // GameFi
+  '0x0bfe4e0b8a2a096a27e5b18b078d25be57c08634': {
+    address: '0x0bFE4e0B8A2a096A27e5B18b078d25be57C08634',
+    decimals: 8,
+    symbol: 'vUSDT',
+    underlyingToken: TESTNET_TOKENS.usdt,
+  } as VToken,
+  '0x1958035231e125830ba5d17d168cea07bb42184a': {
+    address: '0x1958035231E125830bA5d17D168cEa07Bb42184a',
+    decimals: 8,
+    symbol: 'vRACA',
+    underlyingToken: TESTNET_TOKENS.raca,
+  } as VToken,
+  '0xdedf3b2bcf25d0023115fd71a0f8221c91c92b1a': {
+    address: '0xdeDf3B2bcF25d0023115fd71a0F8221C91C92B1a',
+    decimals: 8,
+    symbol: 'vUSDD',
+    underlyingToken: TESTNET_TOKENS.usdd,
+  } as VToken,
+  '0xef470abc365f88e4582d8027172a392c473a5b53': {
+    address: '0xef470AbC365F88e4582D8027172a392C473A5B53',
+    decimals: 8,
+    symbol: 'vFLOKI',
+    underlyingToken: TESTNET_TOKENS.floki,
+  } as VToken,
+  // DeFi
+  '0xb7cac5ef82cb7f9197ee184779bdc52c5490c02a': {
+    address: '0xb7caC5Ef82cb7f9197ee184779bdc52c5490C02a',
+    decimals: 8,
+    symbol: 'vALPACA',
+    underlyingToken: TESTNET_TOKENS.alpaca,
+  } as VToken,
+  '0xb677e080148368eeee70fa3865d07e92c6500174': {
+    address: '0xb677e080148368EeeE70fA3865d07E92c6500174',
+    decimals: 8,
+    symbol: 'vANKR',
+    underlyingToken: TESTNET_TOKENS.ankr,
+  } as VToken,
+  '0xef949287834be010c1a5edd757c385fb9b644e4a': {
+    address: '0xEF949287834Be010C1A5EDd757c385FB9b644E4A',
+    decimals: 8,
+    symbol: 'vBIFI',
+    underlyingToken: TESTNET_TOKENS.bifi,
+  } as VToken,
+  '0x5e68913fbbfb91af30366ab1b21324410b49a308': {
+    address: '0x5e68913fbbfb91af30366ab1B21324410b49a308',
+    decimals: 8,
+    symbol: 'vBSW',
+    underlyingToken: TESTNET_TOKENS.bsw,
+  } as VToken,
+  '0xa109de0abaeefc521ec29d89ea42e64f37a6882e': {
+    address: '0xa109DE0abaeefC521Ec29D89eA42E64F37A6882E',
+    decimals: 8,
+    symbol: 'vUSDD',
+    underlyingToken: TESTNET_TOKENS.usdd,
+  } as VToken,
+  '0x80cc30811e362ac9ab857c3d7875cbccc0b65750': {
+    address: '0x80CC30811e362aC9aB857C3d7875CbcCc0b65750',
+    decimals: 8,
+    symbol: 'vUSDT',
+    underlyingToken: TESTNET_TOKENS.usdt,
+  } as VToken,
+  // Liquid Staked BNB
+  '0xd5b20708d8f0fca52cb609938d0594c4e32e5dad': {
+    address: '0xD5b20708d8f0FcA52cb609938D0594C4e32E5DaD',
+    decimals: 8,
+    symbol: 'vUSDD',
+    underlyingToken: TESTNET_TOKENS.usdd,
+  } as VToken,
+  '0x2197d02cc9cd1ad51317a0a85a656a0c82383a7c': {
+    address: '0x2197d02cC9cd1ad51317A0a85A656a0c82383A7c',
+    decimals: 8,
+    symbol: 'vUSDT',
+    underlyingToken: TESTNET_TOKENS.usdt,
+  } as VToken,
+  '0x231ded0dfc99634e52ee1a1329586bc970d773b3': {
+    address: '0x231dED0Dfc99634e52EE1a1329586bc970d773b3',
+    decimals: 8,
+    symbol: 'vWBNB',
+    underlyingToken: TESTNET_TOKENS.wbnb,
+  } as VToken,
+  '0x57a664dd7f1de19545fee9c86c949e3bf43d6d47': {
+    address: '0x57a664Dd7f1dE19545fEE9c86C949e3BF43d6D47',
+    decimals: 8,
+    symbol: 'vankrBNB',
+    underlyingToken: TESTNET_TOKENS.ankrbnb,
+  } as VToken,
+  '0x644a149853e5507adf3e682218b8ac86cdd62951': {
+    address: '0x644A149853E5507AdF3e682218b8AC86cdD62951',
+    decimals: 8,
+    symbol: 'vBNBx',
+    underlyingToken: TESTNET_TOKENS.bnbx,
+  } as VToken,
+  '0x75aa42c832a8911b77219dbebabbb40040d16987': {
+    address: '0x75aa42c832a8911B77219DbeBABBB40040d16987',
+    decimals: 8,
+    symbol: 'vstkBNB',
+    underlyingToken: TESTNET_TOKENS.stkbnb,
+  } as VToken,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6139,10 +6139,10 @@
     "@uiw/react-markdown-preview" "^4.0.10"
     rehype "~12.0.1"
 
-"@venusprotocol/isolated-pools@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@venusprotocol/isolated-pools/-/isolated-pools-1.0.0.tgz#833881f56fa437d3b358d2f2bdf8c3fa09e0e084"
-  integrity sha512-K+L9XYHGD1mNgNdfmX9SjWhDpMVp8YdcxrTzDK+/dmpZFxUYpu0KzdZ5rXitxnm0UtZuk7jI4FxcWAL2kjWQZg==
+"@venusprotocol/isolated-pools@^1.1.0-dev.1":
+  version "1.1.0-dev.1"
+  resolved "https://registry.yarnpkg.com/@venusprotocol/isolated-pools/-/isolated-pools-1.1.0-dev.1.tgz#1bb4b41530d1d7d834f51f7b2789aae048abb174"
+  integrity sha512-7/mca/No62GCRlTv3ddlZ0qXjjWF9iePPu9GdJpK2ycGFlRxlUEEvHD+uCgTsV6FLcGNHE072432g/rYxWmWAA==
   dependencies:
     "@openzeppelin/contracts" "^4.8.3"
     "@openzeppelin/contracts-upgradeable" "^4.8.3"
@@ -8224,6 +8224,21 @@ cheerio@^1.0.0-rc.2:
     parse5 "^7.0.0"
     parse5-htmlparser2-tree-adapter "^7.0.0"
 
+"chokidar@>=3.0.0 <4.0.0", chokidar@^3.4.2, chokidar@^3.5.2, chokidar@^3.5.3:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
+  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
+  dependencies:
+    anymatch "~3.1.2"
+    braces "~3.0.2"
+    glob-parent "~5.1.2"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.6.0"
+  optionalDependencies:
+    fsevents "~2.3.2"
+
 chokidar@^1.6.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-1.7.0.tgz#798e689778151c8076b4b360e5edd28cda2bb468"
@@ -8239,21 +8254,6 @@ chokidar@^1.6.0:
     readdirp "^2.0.0"
   optionalDependencies:
     fsevents "^1.0.0"
-
-chokidar@^3.4.2, chokidar@^3.5.2, chokidar@^3.5.3:
-  version "3.5.3"
-  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.5.3.tgz#1cf37c8707b932bd1af1ae22c0432e2acd1903bd"
-  integrity sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==
-  dependencies:
-    anymatch "~3.1.2"
-    braces "~3.0.2"
-    glob-parent "~5.1.2"
-    is-binary-path "~2.1.0"
-    is-glob "~4.0.1"
-    normalize-path "~3.0.0"
-    readdirp "~3.6.0"
-  optionalDependencies:
-    fsevents "~2.3.2"
 
 chownr@^1.1.1:
   version "1.1.4"
@@ -11978,6 +11978,11 @@ img-diff-js@0.5.2:
     mkdirp "^1.0.4"
     pixelmatch "^5.2.1"
     pngjs "^6.0.0"
+
+immutable@^4.0.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.3.0.tgz#eb1738f14ffb39fd068b1dbe1296117484dd34be"
+  integrity sha512-0AOCmOip+xgJwEVTQj1EfiDDOkPmuyllDuTuEX+DDXUgapLAsBIfkg3sxCYyCEA8mQqZrrxPUGjcOQ2JS3WLkg==
 
 immutable@~3.7.6:
   version "3.7.6"
@@ -17658,6 +17663,15 @@ safe-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sass@^1.49.7:
+  version "1.63.6"
+  resolved "https://registry.yarnpkg.com/sass/-/sass-1.63.6.tgz#481610e612902e0c31c46b46cf2dad66943283ea"
+  integrity sha512-MJuxGMHzaOW7ipp+1KdELtqKbfAWbH7OLIdoSMnVe3EXPMTmxTmlaZDCTsgIpPCs3w99lLo9/zDKkOrJuT5byw==
+  dependencies:
+    chokidar ">=3.0.0 <4.0.0"
+    immutable "^4.0.0"
+    source-map-js ">=0.6.2 <2.0.0"
+
 sax@1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
@@ -18032,7 +18046,7 @@ sort-keys@^5.0.0:
   dependencies:
     is-plain-obj "^4.0.0"
 
-source-map-js@^1.0.2:
+"source-map-js@>=0.6.2 <2.0.0", source-map-js@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==


### PR DESCRIPTION
## Changes

- Added testnet addresses for:
DeFi - 6 tokens
GameFi - 4 tokens
Tron - 5 tokens
Liquid Staked BNB - 6 tokens

- Added testnet and mainnet swap routers for each of these pools