### PR TITLE
feat: add mainnet addresses for DeFi, Tron, GameFi and Liquid Staked BNB

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@sentry/tracing": "^7.43.0",
     "@uiw/react-markdown-preview": "^4.1.13",
     "@uiw/react-md-editor": "^3.14.3",
-    "@venusprotocol/isolated-pools": "^1.1.0-dev.1",
+    "@venusprotocol/isolated-pools": "^1.1.0",
     "bignumber.js": "^9.0.0",
     "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.28.0",

--- a/src/constants/tokens/common/mainnet.ts
+++ b/src/constants/tokens/common/mainnet.ts
@@ -2,10 +2,17 @@ import { Token } from 'types';
 
 import aave from 'assets/img/tokens/aave.svg';
 import ada from 'assets/img/tokens/ada.svg';
+import alpaca from 'assets/img/tokens/alpaca.svg';
+import ankr from 'assets/img/tokens/ankr.svg';
+import ankrbnb from 'assets/img/tokens/ankrBNB.svg';
 import bch from 'assets/img/tokens/bch.svg';
 import beth from 'assets/img/tokens/beth.svg';
+import bifi from 'assets/img/tokens/bifi.png';
 import bnb from 'assets/img/tokens/bnb.svg';
+import bnbx from 'assets/img/tokens/bnbx.png';
+import bsw from 'assets/img/tokens/bsw.svg';
 import btcb from 'assets/img/tokens/btcb.svg';
+import btt from 'assets/img/tokens/btt.svg';
 import busd from 'assets/img/tokens/busd.svg';
 import cake from 'assets/img/tokens/cake.svg';
 import dai from 'assets/img/tokens/dai.svg';
@@ -13,11 +20,15 @@ import doge from 'assets/img/tokens/doge.svg';
 import dot from 'assets/img/tokens/dot.svg';
 import eth from 'assets/img/tokens/eth.svg';
 import fil from 'assets/img/tokens/fil.svg';
+import floki from 'assets/img/tokens/floki.svg';
 import hay from 'assets/img/tokens/hay.png';
 import link from 'assets/img/tokens/link.svg';
 import ltc from 'assets/img/tokens/ltc.svg';
 import luna from 'assets/img/tokens/luna.svg';
 import matic from 'assets/img/tokens/matic.svg';
+import nft from 'assets/img/tokens/nft.png';
+import raca from 'assets/img/tokens/raca.png';
+import stkbnb from 'assets/img/tokens/stkBNB.svg';
 import sxp from 'assets/img/tokens/sxp.svg';
 import trx from 'assets/img/tokens/trx.svg';
 import tusd from 'assets/img/tokens/tusd.svg';
@@ -28,6 +39,8 @@ import ust from 'assets/img/tokens/ust.svg';
 import vai from 'assets/img/tokens/vai.svg';
 import vrt from 'assets/img/tokens/vrt.svg';
 import wbeth from 'assets/img/tokens/wbeth.svg';
+import wbnb from 'assets/img/tokens/wbnb.svg';
+import win from 'assets/img/tokens/win.svg';
 import xrp from 'assets/img/tokens/xrp.svg';
 import xvs from 'assets/img/tokens/xvs.svg';
 
@@ -224,5 +237,84 @@ export const MAINNET_TOKENS = {
     decimals: 18,
     symbol: 'USDD',
     asset: usdd,
+  } as Token,
+  // Underlying tokens for isolated markets
+  btt: {
+    address: '0x352Cb5E19b12FC216548a2677bD0fce83BaE434B',
+    decimals: 18,
+    symbol: 'BTT',
+    asset: btt,
+  } as Token,
+  nft: {
+    address: '0x20eE7B720f4E4c4FFcB00C4065cdae55271aECCa',
+    decimals: 18,
+    symbol: 'NFT',
+    asset: nft,
+  } as Token,
+  win: {
+    address: '0xaeF0d72a118ce24feE3cD1d43d383897D05B4e99',
+    decimals: 18,
+    symbol: 'WIN',
+    asset: win,
+  } as Token,
+  raca: {
+    address: '0x12BB890508c125661E03b09EC06E404bc9289040',
+    decimals: 18,
+    symbol: 'RACA',
+    asset: raca,
+  } as Token,
+  floki: {
+    address: '0xfb5B838b6cfEEdC2873aB27866079AC55363D37E',
+    decimals: 18,
+    symbol: 'FLOKI',
+    asset: floki,
+  } as Token,
+  bifi: {
+    address: '0xCa3F508B8e4Dd382eE878A314789373D80A5190A',
+    decimals: 18,
+    symbol: 'BIFI',
+    asset: bifi,
+  } as Token,
+  bsw: {
+    address: '0x965F527D9159dCe6288a2219DB51fc6Eef120dD1',
+    decimals: 18,
+    symbol: 'BSW',
+    asset: bsw,
+  } as Token,
+  alpaca: {
+    address: '0x8F0528cE5eF7B51152A59745bEfDD91D97091d2F',
+    decimals: 18,
+    symbol: 'ALPACA',
+    asset: alpaca,
+  } as Token,
+  ankr: {
+    address: '0xf307910A4c7bbc79691fD374889b36d8531B08e3',
+    decimals: 18,
+    symbol: 'ANKR',
+    asset: ankr,
+  } as Token,
+  ankrbnb: {
+    address: '0x52F24a5e03aee338Da5fd9Df68D2b6FAe1178827',
+    decimals: 18,
+    symbol: 'ankrBNB',
+    asset: ankrbnb,
+  } as Token,
+  bnbx: {
+    address: '0x1bdd3Cf7F79cfB8EdbB955f20ad99211551BA275',
+    decimals: 18,
+    symbol: 'BNBx',
+    asset: bnbx,
+  } as Token,
+  stkbnb: {
+    address: '0xc2E9d07F66A89c44062459A47a0D2Dc038E4fb16',
+    decimals: 18,
+    symbol: 'stkBNB',
+    asset: stkbnb,
+  } as Token,
+  wbnb: {
+    address: '0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c',
+    decimals: 18,
+    symbol: 'WBNB',
+    asset: wbnb,
   } as Token,
 };

--- a/src/constants/tokens/vBep/mainnet.ts
+++ b/src/constants/tokens/vBep/mainnet.ts
@@ -193,4 +193,128 @@ export const MAINNET_VBEP_TOKENS = {
     symbol: 'vUSDT',
     underlyingToken: MAINNET_TOKENS.usdt,
   } as VToken,
+  // Tron
+  '0x836beb2cb723c498136e1119248436a645845f4e': {
+    address: '0x836beb2cB723C498136e1119248436A645845F4E',
+    decimals: 8,
+    symbol: 'vTRX',
+    underlyingToken: MAINNET_TOKENS.trx,
+  } as VToken,
+  '0x85baa9cd6186b416ef92c0587cd9e9be3bce2a4d': {
+    address: '0x85baA9CD6186B416Ef92c0587Cd9E9Be3BCe2a4D',
+    decimals: 8,
+    symbol: 'vNFT',
+    underlyingToken: MAINNET_TOKENS.nft,
+  } as VToken,
+  '0x49c26e12959345472e2fd95e5f79f8381058d3ee': {
+    address: '0x49c26e12959345472E2Fd95E5f79F8381058d3Ee',
+    decimals: 8,
+    symbol: 'vBTT',
+    underlyingToken: MAINNET_TOKENS.btt,
+  } as VToken,
+  '0x281e5378f99a4bc55b295abc0a3e7ed32deba059': {
+    address: '0x281E5378f99A4bc55b295ABc0A3E7eD32Deba059',
+    decimals: 8,
+    symbol: 'vUSDT',
+    underlyingToken: MAINNET_TOKENS.usdt,
+  } as VToken,
+  '0xf1da185cce5bed1bebbb3007ef738ea4224025f7': {
+    address: '0xf1da185CCe5BeD1BeBbb3007Ef738Ea4224025F7',
+    decimals: 8,
+    symbol: 'vUSDD',
+    underlyingToken: MAINNET_TOKENS.usdd,
+  } as VToken,
+  '0xb114cfa615c828d88021a41bfc524b800e64a9d5': {
+    address: '0xb114cfA615c828D88021a41bFc524B800E64a9D5',
+    decimals: 8,
+    symbol: 'vWIN',
+    underlyingToken: MAINNET_TOKENS.win,
+  } as VToken,
+  // GameFi
+  '0x4978591f17670a846137d9d613e333c38dc68a37': {
+    address: '0x4978591f17670A846137d9d613e333C38dc68A37',
+    decimals: 8,
+    symbol: 'vUSDT',
+    underlyingToken: MAINNET_TOKENS.usdt,
+  } as VToken,
+  '0xe5fe5527a5b76c75eede77fdfa6b80d52444a465': {
+    address: '0xE5FE5527A5b76C75eedE77FdFA6B80D52444A465',
+    decimals: 8,
+    symbol: 'vRACA',
+    underlyingToken: MAINNET_TOKENS.raca,
+  } as VToken,
+  '0x9f2fd23bd0a5e08c5f2b9dd6cf9c96bfb5fa515c': {
+    address: '0x9f2FD23bd0A5E08C5f2b9DD6CF9C96Bfb5fA515C',
+    decimals: 8,
+    symbol: 'vUSDD',
+    underlyingToken: MAINNET_TOKENS.usdd,
+  } as VToken,
+  '0xc353b7a1e13ddba393b5e120d4169da7185aa2cb': {
+    address: '0xc353B7a1E13dDba393B5E120D4169Da7185aA2cb',
+    decimals: 8,
+    symbol: 'vFLOKI',
+    underlyingToken: MAINNET_TOKENS.floki,
+  } as VToken,
+  // DeFi
+  '0x02c5fb0f26761093d297165e902e96d08576d344': {
+    address: '0x02c5Fb0F26761093D297165e902e96D08576D344',
+    decimals: 8,
+    symbol: 'vALPACA',
+    underlyingToken: MAINNET_TOKENS.alpaca,
+  } as VToken,
+  '0x19ce11c8817a1828d1d357dfbf62dcf5b0b2a362': {
+    address: '0x19CE11C8817a1828D1d357DFBF62dCf5b0B2A362',
+    decimals: 8,
+    symbol: 'vANKR',
+    underlyingToken: MAINNET_TOKENS.ankr,
+  } as VToken,
+  '0xc718c51958d3fd44f5f9580c9ffac2f89815c909': {
+    address: '0xC718c51958d3fd44f5F9580c9fFAC2F89815C909',
+    decimals: 8,
+    symbol: 'vBIFI',
+    underlyingToken: MAINNET_TOKENS.bifi,
+  } as VToken,
+  '0x8f657dfd3a1354deb4545765fe6840cc54afd379': {
+    address: '0x8f657dFD3a1354DEB4545765fE6840cc54AFd379',
+    decimals: 8,
+    symbol: 'vBSW',
+    underlyingToken: MAINNET_TOKENS.bsw,
+  } as VToken,
+  '0xa615467cae6b9e0bb98bc04b4411d9296fd1dfa0': {
+    address: '0xA615467caE6B9E0bb98BC04B4411d9296fd1dFa0',
+    decimals: 8,
+    symbol: 'vUSDD',
+    underlyingToken: MAINNET_TOKENS.usdd,
+  } as VToken,
+  '0x1d8bbde12b6b34140604e18e9f9c6e14dec16854': {
+    address: '0x1D8bBDE12B6b34140604E18e9f9c6e14deC16854',
+    decimals: 8,
+    symbol: 'vUSDT',
+    underlyingToken: MAINNET_TOKENS.usdt,
+  } as VToken,
+  // Liquid Staked BNB
+  '0xe10e80b7fd3a29fe46e16c30cc8f4dd938b742e2': {
+    address: '0xe10E80B7FD3a29fE46E16C30CC8F4dd938B742e2',
+    decimals: 8,
+    symbol: 'vWBNB',
+    underlyingToken: MAINNET_TOKENS.wbnb,
+  } as VToken,
+  '0xbfe25459ba784e70e2d7a718be99a1f3521ca17f': {
+    address: '0xBfe25459BA784e70E2D7a718Be99a1f3521cA17f',
+    decimals: 8,
+    symbol: 'vankrBNB',
+    underlyingToken: MAINNET_TOKENS.ankrbnb,
+  } as VToken,
+  '0x5e21bf67a6af41c74c1773e4b473ca5ce8fd3791': {
+    address: '0x5E21bF67a6af41c74C1773E4b473ca5ce8fd3791',
+    decimals: 8,
+    symbol: 'vBNBx',
+    underlyingToken: MAINNET_TOKENS.bnbx,
+  } as VToken,
+  '0xcc5d9e502574cda17215e70bc0b4546663785227': {
+    address: '0xcc5D9e502574cda17215E70bC0B4546663785227',
+    decimals: 8,
+    symbol: 'vstkBNB',
+    underlyingToken: MAINNET_TOKENS.stkbnb,
+  } as VToken,
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6139,10 +6139,10 @@
     "@uiw/react-markdown-preview" "^4.0.10"
     rehype "~12.0.1"
 
-"@venusprotocol/isolated-pools@^1.1.0-dev.1":
-  version "1.1.0-dev.1"
-  resolved "https://registry.yarnpkg.com/@venusprotocol/isolated-pools/-/isolated-pools-1.1.0-dev.1.tgz#1bb4b41530d1d7d834f51f7b2789aae048abb174"
-  integrity sha512-7/mca/No62GCRlTv3ddlZ0qXjjWF9iePPu9GdJpK2ycGFlRxlUEEvHD+uCgTsV6FLcGNHE072432g/rYxWmWAA==
+"@venusprotocol/isolated-pools@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@venusprotocol/isolated-pools/-/isolated-pools-1.1.0.tgz#ef66debe5ba4d55ba9854cf7e4d21173b05c5450"
+  integrity sha512-9X8fhZTybAgFU8GvsNYeRU9Y2dcBzYuZm2cSf7Sbzj7kmJMl2YsHVC6Fm74m/vEsuSGlt2pjMcMl6K7kK/XyNA==
   dependencies:
     "@openzeppelin/contracts" "^4.8.3"
     "@openzeppelin/contracts-upgradeable" "^4.8.3"


### PR DESCRIPTION
## Changes

- Added mainnet addresses for:
DeFi - 6 tokens
GameFi - 4 tokens
Tron - 6 tokens
Liquid Staked BNB - 4 tokens

- Added mainnet underlying tokens to support the new markets
