### PR TITLE
[VEN-1675] Use dark mode with ReactMarkdown

### DIFF
--- a/src/components/Markdown/Viewer/index.tsx
+++ b/src/components/Markdown/Viewer/index.tsx
@@ -20,6 +20,9 @@ const Markdown: React.FC<MarkdownViewerProps> = ({ content, className }) => {
       css={styles.preview}
       {...previewOptions}
       linkTarget="_blank"
+      wrapperElement={{
+        'data-color-mode': 'dark',
+      }}
     />
   );
 };


### PR DESCRIPTION
## Jira ticket(s)

VEN-1675

## Changes

- This fix aims to always use ReactMarkdown on dark mode, to match with the color palette of the dApp
