### PR TITLE
Prevent search engines from indexing dApp

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <meta name="robots" content="noindex" />
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />


### PR DESCRIPTION
## Changes

- add meta tag to prevent search engines from crawling dApp. I'm surprised we didn't have that in the index file already, since the dApp doesn't seem to be crawled anyway (my assumption is we already have a rule on the server side to prevent indexing, but better be safe than sorry)
