### PR TITLE
[VEN-1674] Get market utilization rate from contract

### DIFF
--- a/src/clients/api/queries/getVTokenApySimulations/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getVTokenApySimulations/__snapshots__/index.spec.ts.snap
@@ -504,5 +504,6 @@ exports[`api/queries/getVTokenApySimulations > returns the APY simulations in th
       "utilizationRate": 100,
     },
   ],
+  "currentUtilizationRate": 0,
 }
 `;

--- a/src/clients/api/queries/getVTokenApySimulations/formatCurrentUtilizationRate.ts
+++ b/src/clients/api/queries/getVTokenApySimulations/formatCurrentUtilizationRate.ts
@@ -1,0 +1,18 @@
+import BigNumber from 'bignumber.js';
+import { ContractCallResults } from 'ethereum-multicall';
+
+const formatCurrentUtilizationRate = ({
+  vTokenBalanceCallResults,
+}: {
+  vTokenBalanceCallResults: ContractCallResults;
+}): number => {
+  const result = Object.values(vTokenBalanceCallResults.results)[0].callsReturnContext[200];
+
+  const utilizationRate = new BigNumber(result.returnValues[0].hex).dividedToIntegerBy(
+    new BigNumber(10).pow(16),
+  );
+
+  return utilizationRate.toNumber();
+};
+
+export default formatCurrentUtilizationRate;

--- a/src/clients/api/queries/getVTokenApySimulations/formatToApySnapshots.ts
+++ b/src/clients/api/queries/getVTokenApySimulations/formatToApySnapshots.ts
@@ -13,7 +13,10 @@ const formatToApySnapshots = ({
   vTokenBalanceCallResults: ContractCallResults;
 }): VTokenApySnapshot[] => {
   const apySimulations: VTokenApySnapshot[] = [];
-  const results = Object.values(vTokenBalanceCallResults.results)[0].callsReturnContext;
+  const results = Object.values(vTokenBalanceCallResults.results)[0].callsReturnContext.slice(
+    0,
+    200,
+  );
 
   let utilizationRate = 1;
 

--- a/src/clients/api/queries/getVTokenApySimulations/index.spec.ts
+++ b/src/clients/api/queries/getVTokenApySimulations/index.spec.ts
@@ -19,6 +19,7 @@ describe('api/queries/getVTokenApySimulations', () => {
       reserveFactorMantissa: fakeReserveFactorMantissa,
       interestRateModelContractAddress: fakeAddress,
       isIsolatedPoolMarket: false,
+      asset: undefined,
     });
 
     expect(response).toMatchSnapshot();

--- a/src/clients/api/queries/getVTokenApySimulations/types.ts
+++ b/src/clients/api/queries/getVTokenApySimulations/types.ts
@@ -1,11 +1,13 @@
 import BigNumber from 'bignumber.js';
 import { Multicall } from 'ethereum-multicall';
+import { Asset } from 'types';
 
 export interface GetVTokenInterestRatesInput {
   multicall: Multicall;
   reserveFactorMantissa: BigNumber;
   interestRateModelContractAddress: string;
   isIsolatedPoolMarket: boolean;
+  asset: Asset | undefined;
 }
 
 export interface VTokenApySnapshot {
@@ -16,4 +18,5 @@ export interface VTokenApySnapshot {
 
 export type GetVTokenApySimulationsOutput = {
   apySimulations: VTokenApySnapshot[];
+  currentUtilizationRate: number;
 };

--- a/src/clients/api/queries/getVTokenApySimulations/useGetVTokenApySimulations.ts
+++ b/src/clients/api/queries/getVTokenApySimulations/useGetVTokenApySimulations.ts
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 import { QueryObserverOptions, useQuery } from 'react-query';
-import { VToken } from 'types';
+import { Asset, VToken } from 'types';
 
 import getVTokenApySimulations, {
   GetVTokenApySimulationsOutput,
@@ -19,10 +19,16 @@ type Options = QueryObserverOptions<
 
 const useGetVTokenApySimulations = (
   {
+    asset,
     vToken,
     isIsolatedPoolMarket,
     reserveFactorMantissa,
-  }: { vToken: VToken; isIsolatedPoolMarket: boolean; reserveFactorMantissa?: BigNumber },
+  }: {
+    asset: Asset | undefined;
+    vToken: VToken;
+    isIsolatedPoolMarket: boolean;
+    reserveFactorMantissa?: BigNumber;
+  },
   options?: Options,
 ) => {
   const multicall = useMulticall();
@@ -36,6 +42,7 @@ const useGetVTokenApySimulations = (
         reserveFactorMantissa: reserveFactorMantissa || new BigNumber(0),
         interestRateModelContractAddress: interestRateModelData?.contractAddress || '',
         isIsolatedPoolMarket,
+        asset,
       }),
     {
       ...options,

--- a/src/constants/contracts/abis/interestModelV2.json
+++ b/src/constants/contracts/abis/interestModelV2.json
@@ -109,7 +109,8 @@
     "inputs": [
       { "internalType": "uint256", "name": "cash", "type": "uint256" },
       { "internalType": "uint256", "name": "borrows", "type": "uint256" },
-      { "internalType": "uint256", "name": "reserves", "type": "uint256" }
+      { "internalType": "uint256", "name": "reserves", "type": "uint256" },
+      { "internalType": "uint256", "name": "badDebt", "type": "uint256" }
     ],
     "name": "utilizationRate",
     "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],

--- a/src/pages/Market/index.stories.tsx
+++ b/src/pages/Market/index.stories.tsx
@@ -63,5 +63,6 @@ export const Default = () => (
     poolComptrollerAddress={poolData[0].comptrollerAddress}
     isChartDataLoading={false}
     isInterestRateChartDataLoading={false}
+    currentUtilizationRate={0}
   />
 );

--- a/src/pages/Market/index.tsx
+++ b/src/pages/Market/index.tsx
@@ -49,6 +49,7 @@ export interface MarketUiProps {
   isInterestRateChartDataLoading: boolean;
   poolComptrollerAddress: string;
   asset?: Asset;
+  currentUtilizationRate: number;
 }
 
 export const MarketUi: React.FC<MarketUiProps> = ({
@@ -59,6 +60,7 @@ export const MarketUi: React.FC<MarketUiProps> = ({
   borrowChartData,
   isInterestRateChartDataLoading,
   interestRateChartData,
+  currentUtilizationRate,
 }) => {
   const { t } = useTranslation();
   const styles = useStyles();
@@ -68,15 +70,8 @@ export const MarketUi: React.FC<MarketUiProps> = ({
 
   const { openOperationModal, OperationModal } = useOperationModal();
 
-  const { currentUtilizationRate, dailySupplyInterestsCents, dailyBorrowInterestsCents } = useMemo(
+  const { dailySupplyInterestsCents, dailyBorrowInterestsCents } = useMemo(
     () => ({
-      currentUtilizationRate:
-        asset &&
-        asset.borrowBalanceTokens
-          .div(asset.cashTokens.plus(asset.borrowBalanceTokens).minus(asset.reserveTokens))
-          .multipliedBy(100)
-          .dp(0)
-          .toNumber(),
       // Calculate daily interests for suppliers and borrowers. Note that we don't
       // use BigNumber to calculate these values, as this would slow down
       // calculation a lot while the end result doesn't need to be extremely
@@ -467,11 +462,13 @@ const Market: React.FC<MarketProps> = ({ vTokenAddress, poolComptrollerAddress }
     isLoading: isInterestRateChartDataLoading,
     data: interestRateChartData = {
       apySimulations: [],
+      currentUtilizationRate: 0,
     },
   } = useGetVTokenApySimulations({
     vToken,
     reserveFactorMantissa,
     isIsolatedPoolMarket,
+    asset: getAssetData?.asset,
   });
 
   return (
@@ -482,6 +479,7 @@ const Market: React.FC<MarketProps> = ({ vTokenAddress, poolComptrollerAddress }
       {...chartData}
       isInterestRateChartDataLoading={isInterestRateChartDataLoading}
       interestRateChartData={interestRateChartData.apySimulations}
+      currentUtilizationRate={interestRateChartData.currentUtilizationRate}
     />
   );
 };


### PR DESCRIPTION
## Jira ticket(s)

VEN-1674

## Changes

- We now call the corresponding interest rate model contract to retrieve the current utilization rate for a market, instead of calculating it on the frontend
