### PR TITLE
Remove TUSD from swap

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -70,7 +70,9 @@ module.exports = {
     '@typescript-eslint/no-unused-vars': [
       'error',
       {
-        varsIgnorePattern: '^_.+',
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
       },
     ],
     '@typescript-eslint/member-delimiter-style': [

--- a/src/constants/tokens/swap/mainnet.ts
+++ b/src/constants/tokens/swap/mainnet.ts
@@ -1,7 +1,14 @@
 import { MAINNET_TOKENS } from '../common/mainnet';
 import { MAINNET_PANCAKE_SWAP_TOKENS } from './mainnetPancakeSwapTokens';
 
-export const MAINNET_SWAP_TOKENS = {
+// Temporary fix to exclude TUSD as liquidities are low in PancakeSwap V2
+const {
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  tusd: _tusd,
+  ...filteredPancakeSwapTokens
+} = {
   ...MAINNET_PANCAKE_SWAP_TOKENS,
   ...MAINNET_TOKENS,
 };
+
+export const MAINNET_SWAP_TOKENS = filteredPancakeSwapTokens;

--- a/src/hooks/useOperationModal/Modal/RepayForm/index.tsx
+++ b/src/hooks/useOperationModal/Modal/RepayForm/index.tsx
@@ -24,6 +24,7 @@ import {
 } from 'utilities';
 
 import { useRepay, useSwapTokensAndRepay } from 'clients/api';
+import { TOKENS } from 'constants/tokens';
 import { useAuth } from 'context/AuthContext';
 import useFormatTokensToReadableValue from 'hooks/useFormatTokensToReadableValue';
 import useGetSwapInfo from 'hooks/useGetSwapInfo';
@@ -82,12 +83,19 @@ export const RepayFormUi: React.FC<RepayFormUiProps> = ({
   const sharedStyles = useSharedStyles();
   const styles = useStyles();
 
-  const isUsingSwap = useMemo(
+  const isIntegratedSwapEnabled = useMemo(
     () =>
       isFeatureEnabled('integratedSwap') &&
-      formValues.fromToken &&
+      // Temporary fix to exclude TUSD as liquidities are low in PancakeSwap V2
+      !areTokensEqual(asset.vToken.underlyingToken, TOKENS.tusd),
+    [asset.vToken.underlyingToken],
+  );
+
+  const isUsingSwap = useMemo(
+    () =>
+      isIntegratedSwapEnabled &&
       !areTokensEqual(asset.vToken.underlyingToken, formValues.fromToken),
-    [formValues.fromToken, asset.vToken.underlyingToken],
+    [isIntegratedSwapEnabled, formValues.fromToken, asset.vToken.underlyingToken],
   );
 
   const fromTokenUserWalletBalanceTokens = useMemo(() => {
@@ -166,7 +174,7 @@ export const RepayFormUi: React.FC<RepayFormUiProps> = ({
       </LabeledInlineContent>
 
       <div css={sharedStyles.getRow({ isLast: false })}>
-        {isFeatureEnabled('integratedSwap') ? (
+        {isIntegratedSwapEnabled ? (
           <SelectTokenTextField
             data-testid={TEST_IDS.selectTokenTextField}
             selectedToken={formValues.fromToken}

--- a/src/hooks/useOperationModal/Modal/SupplyForm/index.tsx
+++ b/src/hooks/useOperationModal/Modal/SupplyForm/index.tsx
@@ -85,7 +85,10 @@ export const SupplyFormUi: React.FC<SupplyFormUiProps> = ({
   const isIntegratedSwapEnabled = useMemo(
     () =>
       isFeatureEnabled('integratedSwap') &&
-      !areTokensEqual(asset.vToken.underlyingToken, TOKENS.bnb),
+      // The swap router contract does not support the swap and supply flow for BNB
+      !areTokensEqual(asset.vToken.underlyingToken, TOKENS.bnb) &&
+      // Temporary fix to exclude TUSD as liquidities are low in PancakeSwap V2
+      !areTokensEqual(asset.vToken.underlyingToken, TOKENS.tusd),
     [asset.vToken.underlyingToken],
   );
 


### PR DESCRIPTION
## Changes

- remove TUSD from mainnet PancakeSwap tokens
- disable swap and supply/swap and repay features for TUSD
- update `@typescript-eslint/no-unused-vars` eslint rule
