### PR TITLE
[VEN-1708] Calculate distributions using underlying decimals

### DIFF
--- a/src/clients/api/queries/getIsolatedPools/formatOutput/formatToDistributions.ts
+++ b/src/clients/api/queries/getIsolatedPools/formatOutput/formatToDistributions.ts
@@ -32,12 +32,18 @@ const formatToDistributions = (rewardsDistributorsResults: ContractCallReturnCon
         const {
           apyPercentage: supplyApyPercentage,
           dailyDistributedTokens: supplyDailyDistributedTokens,
-        } = calculateApy(supplySpeedMantissa);
+        } = calculateApy({
+          ratePerBlockMantissa: supplySpeedMantissa,
+          decimals: rewardToken.decimals,
+        });
 
         const {
           apyPercentage: borrowApyPercentage,
           dailyDistributedTokens: borrowDailyDistributedTokens,
-        } = calculateApy(borrowSpeedMantissa);
+        } = calculateApy({
+          ratePerBlockMantissa: borrowSpeedMantissa,
+          decimals: rewardToken.decimals,
+        });
 
         // Initialize with an empty array if necessary
         accCopy[vTokenAddress] = accCopy[vTokenAddress] || [];

--- a/src/clients/api/queries/getIsolatedPools/formatOutput/index.ts
+++ b/src/clients/api/queries/getIsolatedPools/formatOutput/index.ts
@@ -131,12 +131,16 @@ const formatToPools = ({
       const {
         apyPercentage: supplyApyPercentage,
         dailyDistributedTokens: supplyDailyDistributedTokens,
-      } = calculateApy(new BigNumber(vTokenMetaData.supplyRatePerBlock.toString()));
+      } = calculateApy({
+        ratePerBlockMantissa: new BigNumber(vTokenMetaData.supplyRatePerBlock.toString()),
+      });
 
       const {
         apyPercentage: borrowApyPercentage,
         dailyDistributedTokens: borrowDailyDistributedTokens,
-      } = calculateApy(new BigNumber(vTokenMetaData.borrowRatePerBlock.toString()));
+      } = calculateApy({
+        ratePerBlockMantissa: new BigNumber(vTokenMetaData.borrowRatePerBlock.toString()),
+      });
 
       const supplyRatePerBlockTokens = supplyDailyDistributedTokens.dividedBy(BLOCKS_PER_DAY);
       const borrowRatePerBlockTokens = borrowDailyDistributedTokens.dividedBy(BLOCKS_PER_DAY);

--- a/src/clients/api/queries/getVaiRepayApy/index.ts
+++ b/src/clients/api/queries/getVaiRepayApy/index.ts
@@ -16,7 +16,9 @@ const getVaiRepayApy = async ({
 }: GetVaiRepayApyInput): Promise<GetVaiRepayApyOutput> => {
   const vaiRepayRatePerBlockMantissa = await vaiControllerContract.getVAIRepayRatePerBlock();
 
-  const { apyPercentage } = calculateApy(vaiRepayRatePerBlockMantissa.toString());
+  const { apyPercentage } = calculateApy({
+    ratePerBlockMantissa: vaiRepayRatePerBlockMantissa.toString(),
+  });
 
   return {
     repayApyPercentage: apyPercentage,

--- a/src/utilities/calculateApy.ts
+++ b/src/utilities/calculateApy.ts
@@ -1,20 +1,28 @@
 import BigNumber from 'bignumber.js';
 
 import { BLOCKS_PER_DAY } from 'constants/bsc';
-import { COMPOUND_DECIMALS, COMPOUND_MANTISSA } from 'constants/compoundMantissa';
+import { COMPOUND_DECIMALS } from 'constants/compoundMantissa';
 import { DAYS_PER_YEAR } from 'constants/daysPerYear';
 
-const calculateApy = (ratePerBlockMantissa: BigNumber | string | number) => {
+export interface CalculateApyInput {
+  ratePerBlockMantissa: BigNumber | string | number;
+  decimals?: number;
+}
+
+const calculateApy = ({
+  ratePerBlockMantissa,
+  decimals = COMPOUND_DECIMALS,
+}: CalculateApyInput) => {
   const dailyDistributedTokens = new BigNumber(ratePerBlockMantissa)
-    .div(COMPOUND_MANTISSA)
+    .div(new BigNumber(10).pow(decimals))
     .multipliedBy(BLOCKS_PER_DAY)
-    .dp(COMPOUND_DECIMALS);
+    .dp(decimals);
 
   const apyPercentage = dailyDistributedTokens
     .plus(1)
     .pow(DAYS_PER_YEAR - 1)
     .minus(1)
-    .dp(COMPOUND_DECIMALS)
+    .dp(decimals)
     // Convert to percentage
     .multipliedBy(100);
 


### PR DESCRIPTION
## Jira ticket(s)

VEN-1708

## Changes

- Takes the underlying token decimals into account when calculating the distributions, instead of always using `COMPOUND_DECIMALS`, which is a constant with value 18
