### PR TITLE
fix: crash when transaction.tokenAddress is null

### DIFF
--- a/src/clients/api/queries/getTransactions/types.ts
+++ b/src/clients/api/queries/getTransactions/types.ts
@@ -8,5 +8,5 @@ export interface TransactionResponse {
   to: string;
   transactionHash: string;
   logIndex: string;
-  tokenAddress: string;
+  tokenAddress: string | null;
 }

--- a/src/utilities/getTokenByAddress.ts
+++ b/src/utilities/getTokenByAddress.ts
@@ -1,15 +1,18 @@
 import { Token } from 'types';
+import { areAddressesEqual } from 'utilities';
 
 import { TOKENS } from 'constants/tokens';
 
-const getTokenByAddress = (address: string) => {
+const getTokenByAddress = (address?: string | null) => {
   let token: Token | undefined;
 
   Object.keys(TOKENS)
     .filter(key => Object.prototype.hasOwnProperty.call(TOKENS, key))
     .forEach(tokenId => {
       const currentToken = TOKENS[tokenId as keyof typeof TOKENS];
-      if (currentToken?.address.toLowerCase() === address.toLowerCase()) {
+      if (!address) {
+        token = TOKENS.bnb;
+      } else if (areAddressesEqual(currentToken?.address, address)) {
         token = currentToken;
       }
     });

--- a/src/utilities/getVTokenByAddress.ts
+++ b/src/utilities/getVTokenByAddress.ts
@@ -2,8 +2,8 @@ import { VToken } from 'types';
 
 import { VBEP_TOKENS } from 'constants/tokens';
 
-const getVTokenByAddress = (address: string) =>
-  address.toLowerCase() in VBEP_TOKENS
+const getVTokenByAddress = (address?: string | null) =>
+  !!address && address.toLowerCase() in VBEP_TOKENS
     ? (VBEP_TOKENS[address.toLowerCase() as keyof typeof VBEP_TOKENS] as VToken)
     : undefined;
 


### PR DESCRIPTION
## Changes

- This attempts to fix a crash in the history page when listing transactions that have their tokenAddress as null
- It is expected that a transaction comes with a tokenAddress null from the API, so this has been ajusted in the corresponding type
- Added checks to avoid trying to lowercase a null address, thus avoiding the crash
- Defaults to BNB in `getTokenByAddress` if the address is null
