### PR TITLE
[VEN-1739] List assets enabled as collateral in Account page

### DIFF
--- a/src/pages/Account/PoolsBreakdown/Tables/index.tsx
+++ b/src/pages/Account/PoolsBreakdown/Tables/index.tsx
@@ -34,7 +34,9 @@ export const Tables: React.FC<TablesProps> = ({ pool }) => {
         pools: [
           {
             ...pool,
-            assets: pool.assets.filter(asset => asset.userSupplyBalanceTokens.isGreaterThan(0)),
+            assets: pool.assets.filter(
+              asset => asset.userSupplyBalanceTokens.isGreaterThan(0) || asset.isCollateralOfUser,
+            ),
           },
         ],
         marketType: 'supply',

--- a/src/pages/Account/index.tsx
+++ b/src/pages/Account/index.tsx
@@ -33,7 +33,8 @@ export const AccountUi: React.FC<AccountUiProps> = ({ isFetching, vaults, pools 
     [vaults],
   );
 
-  // Filter out pools user has not supplied in or borrowed from
+  // Filter out pools user has not supplied in or borrowed from, unless they have assets enabled as
+  // collateral in that pool
   const filteredPools = useMemo(
     () =>
       pools.filter(
@@ -41,7 +42,8 @@ export const AccountUi: React.FC<AccountUiProps> = ({ isFetching, vaults, pools 
           !!pool.assets.find(
             asset =>
               asset.userSupplyBalanceTokens.isGreaterThan(0) ||
-              asset.userBorrowBalanceTokens.isGreaterThan(0),
+              asset.userBorrowBalanceTokens.isGreaterThan(0) ||
+              asset.isCollateralOfUser,
           ),
       ),
     [pools],


### PR DESCRIPTION
## Changes

- always list assets enabled as collateral in Account page, even if user has no supply or borrow balance with them
