### PR TITLE
fix: removed NODE env vars from dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,6 @@ FROM node:18.16.1-alpine as builder
 ARG VERSION
 ARG TAR_FILE_PREFIX
 
-ENV NODE_ENV development
-ENV NODE_PATH=src/
-
 RUN apk add --update --no-cache python3 git openssh
 
 WORKDIR /usr/app

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,9 +1,5 @@
 FROM node:12.19.0-alpine3.12
 
-# must use development so that "npm run build" works
-ENV NODE_ENV development
-ENV NODE_PATH=src/
-
 RUN apk add --update --no-cache python3 git openssh
 
 WORKDIR /usr/app


### PR DESCRIPTION
## Changes

- Fixed env var causing Vite to use a dev build in prod