### PR TITLE
feat: add vankrBNB in DeFi for mainnet and testnet

### DIFF
--- a/src/constants/tokens/vBep/mainnet.ts
+++ b/src/constants/tokens/vBep/mainnet.ts
@@ -317,4 +317,10 @@ export const MAINNET_VBEP_TOKENS = {
     symbol: 'vstkBNB',
     underlyingToken: MAINNET_TOKENS.stkbnb,
   } as VToken,
+  '0x53728fd51060a85ac41974c6c3eb1dae42776723': {
+    address: '0x53728FD51060a85ac41974C6C3Eb1DaE42776723',
+    decimals: 8,
+    symbol: 'vankrBNB',
+    underlyingToken: MAINNET_TOKENS.ankrbnb,
+  } as VToken,
 };

--- a/src/constants/tokens/vBep/testnet.ts
+++ b/src/constants/tokens/vBep/testnet.ts
@@ -281,4 +281,10 @@ export const TESTNET_VBEP_TOKENS = {
     symbol: 'vstkBNB',
     underlyingToken: TESTNET_TOKENS.stkbnb,
   } as VToken,
+  '0xe507b30c41e9e375bce05197c1e09fc9ee40c0f6': {
+    address: '0xe507B30C41E9e375BCe05197c1e09fc9ee40c0f6',
+    decimals: 8,
+    symbol: 'vankrBNB',
+    underlyingToken: TESTNET_TOKENS.ankrbnb,
+  } as VToken,
 };


### PR DESCRIPTION
## Changes

- Added VToken addresses for the new ankrBNB market in the DeFi pool
