### PR TITLE
fix: let users repay their entire VAI loan

### DIFF
--- a/src/clients/api/queries/getVaiRepayAmountWithInterests/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getVaiRepayAmountWithInterests/__snapshots__/index.spec.ts.snap
@@ -1045,6 +1045,6 @@ exports[`api/queries/getVaiRepayAmountWithInterests > returns the VAI fee with i
 
 exports[`api/queries/getVaiRepayAmountWithInterests > returns the VAI fee with interests 2`] = `
 {
-  "vaiRepayAmountWithInterests": "5.669568627692799723381666e+24",
+  "vaiRepayAmountWithInterestsWei": "5.669568627692799723381666e+24",
 }
 `;

--- a/src/clients/api/queries/getVaiRepayAmountWithInterests/formatToOutput.ts
+++ b/src/clients/api/queries/getVaiRepayAmountWithInterests/formatToOutput.ts
@@ -8,13 +8,13 @@ const formatToOutput = ({
 }: {
   contractCallResults: ContractCallResults;
 }): GetVaiRepayAmountWithInterestsOutput => {
-  const [vaiRepayAmountWithInterests] =
+  const [vaiRepayAmountWithInterestsWei] =
     contractCallResults.results.getVaiRepayTotalAmount.callsReturnContext[1].returnValues.map(
       unformattedBigNumber => new BigNumber(unformattedBigNumber.hex),
     );
 
   return {
-    vaiRepayAmountWithInterests,
+    vaiRepayAmountWithInterestsWei,
   };
 };
 

--- a/src/clients/api/queries/getVaiRepayAmountWithInterests/types.ts
+++ b/src/clients/api/queries/getVaiRepayAmountWithInterests/types.ts
@@ -7,5 +7,5 @@ export interface GetVaiRepayAmountWithInterestsInput {
 }
 
 export type GetVaiRepayAmountWithInterestsOutput = {
-  vaiRepayAmountWithInterests: BigNumber;
+  vaiRepayAmountWithInterestsWei: BigNumber;
 };

--- a/src/clients/api/queries/useGetMainAssets/index.spec.tsx
+++ b/src/clients/api/queries/useGetMainAssets/index.spec.tsx
@@ -29,7 +29,7 @@ describe('api/queries/useGetMainAssets', () => {
       tokenAddresses: assetsInAccount,
     }));
     (getVaiRepayAmountWithInterests as Vi.Mock).mockImplementation(() => ({
-      vaiRepayAmountWithInterests: fakeUserVaiRepayAmountWithInterestsWei,
+      vaiRepayAmountWithInterestsWei: fakeUserVaiRepayAmountWithInterestsWei,
     }));
 
     (useGetVTokenBalancesAll as Vi.Mock).mockImplementation(({ account }) => {

--- a/src/clients/api/queries/useGetMainAssets/index.ts
+++ b/src/clients/api/queries/useGetMainAssets/index.ts
@@ -266,9 +266,9 @@ const useGetMainAssets = ({
     let assetList = assets;
 
     const userTotalBorrowBalanceWithUserMintedVai = userTotalBorrowBalanceCents.plus(
-      userVaiRepayAmountWithInterests?.vaiRepayAmountWithInterests
+      userVaiRepayAmountWithInterests?.vaiRepayAmountWithInterestsWei
         ? convertWeiToTokens({
-            valueWei: userVaiRepayAmountWithInterests?.vaiRepayAmountWithInterests,
+            valueWei: userVaiRepayAmountWithInterests?.vaiRepayAmountWithInterestsWei,
             token: TOKENS.vai,
           })
             // Convert VAI to dollar cents (we assume 1 VAI = 1 dollar)
@@ -294,7 +294,7 @@ const useGetMainAssets = ({
       userTotalSupplyBalanceCents,
     };
   }, [
-    userVaiRepayAmountWithInterests?.vaiRepayAmountWithInterests,
+    userVaiRepayAmountWithInterests?.vaiRepayAmountWithInterestsWei,
     getMainMarketsData?.markets,
     assetsInAccount,
     vTokenBalances,

--- a/src/pages/Vai/RepayVai/__snapshots__/index.spec.tsx.snap
+++ b/src/pages/Vai/RepayVai/__snapshots__/index.spec.tsx.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`pages/Dashboard/MintRepayVai/RepayVai > displays the correct repay VAI balance and APY 1`] = `"MAXWallet balance-Repay VAI balance5.66M VAIRepay fee0.00031 VAI (0.000317%)Enter a valid amount to repay"`;
+exports[`pages/Dashboard/MintRepayVai/RepayVai > displays the correct repay VAI balance and APY 1`] = `"MAXWallet balance5.66M VAIRepay VAI balance5.66M VAIRepay fee0.00031 VAI (0.000317%)Enter a valid amount to repay"`;
 
 exports[`pages/Dashboard/MintRepayVai/RepayVai > displays the wallet spending limit correctly and lets user revoke it 1`] = `"Spending limit10.00 VAI"`;


### PR DESCRIPTION
## Changes

- rename `vaiRepayAmountWithInterests` property of result returned by `getVaiRepayAmountWithInterests` to `vaiRepayAmountWithInterestsWei`
- define repay limit using repay amount with interests instead of minted VAI only on Repay VAI. This effectively lets users repay their entire VAI loan, including interests
