### PR TITLE
[VEN-1878] Fallback to dashboard if the nested switch does not match any routes

### DIFF
--- a/src/App/Switch/index.tsx
+++ b/src/App/Switch/index.tsx
@@ -76,9 +76,9 @@ const Switch = () => {
       <RRSwitch>
         <Route exact path={routes.governanceProposal.path} component={Proposal} />
         <Route path={`${routes.governance.path}/:newProposalStep`} component={Vote} />
-      </RRSwitch>
 
-      <Redirect to={routes.dashboard.path} />
+        <Redirect to={routes.dashboard.path} />
+      </RRSwitch>
     </RRSwitch>
   );
 };


### PR DESCRIPTION
## Jira ticket(s)

VEN-1878

## Changes

- The `Switch` component from React Router v5 tries to render the first `Route` or `Redirect` child that matches the URL. The problem with this is that if we nest another `Switch`, it will always render it if no previous `Route` component is a match. This means that:
    - The nested `Switch` has to come after all of the other routes
    - The `Redirect` component has to be nested inside the child `Switch`, so that it serves as a fallback, or else the child `Switch` will render and won't match any of its routes, displaying an empty page

An alternative solution is to migrate to React Router v6, that drops the `Switch` component in favor of the `Routes` component, which has a more robust route matching: https://reactrouter.com/en/main/upgrading/v5#upgrade-all-switch-elements-to-routes