### PR TITLE
fix: await setValues when importing a VIP file

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "date-fns": "^2.30.0",
     "ethereum-multicall": "2.19.0",
     "ethers": "^5.7.2",
-    "formik": "^2.2.9",
+    "formik": "^2.4.3",
     "graphql": "16.7.1",
     "graphql-request": "^6.1.0",
     "graphql-tag": "2.12.6",

--- a/src/pages/Governance/ProposalList/CreateProposalModal/index.tsx
+++ b/src/pages/Governance/ProposalList/CreateProposalModal/index.tsx
@@ -62,9 +62,9 @@ export const CreateProposal: React.FC<CreateProposalProps> = ({
     if (file) {
       try {
         const values = await importJsonProposal(file);
-        setValues(values);
+        await setValues(values);
 
-        const errors = await validateForm();
+        const errors = await validateForm(values);
         checkImportErrors(errors);
 
         setProposalMode('file');

--- a/yarn.lock
+++ b/yarn.lock
@@ -12246,10 +12246,10 @@ formdata-polyfill@^4.0.10:
   dependencies:
     fetch-blob "^3.1.2"
 
-formik@^2.2.9:
-  version "2.2.9"
-  resolved "https://registry.yarnpkg.com/formik/-/formik-2.2.9.tgz#8594ba9c5e2e5cf1f42c5704128e119fc46232d0"
-  integrity sha512-LQLcISMmf1r5at4/gyJigGn0gOwFbeEAlji+N9InZF6LIMXnFNkO42sCI8Jt84YZggpD4cPWObAZaxpEFtSzNA==
+formik@^2.4.3:
+  version "2.4.3"
+  resolved "https://registry.yarnpkg.com/formik/-/formik-2.4.3.tgz#6020e85eb3e3e8415b3b19d6f4f65793ab754b24"
+  integrity sha512-2Dy79Szw3zlXmZiokUdKsn+n1ow4G8hRrC/n92cOWHNTWXCRpQXlyvz6HcjW7aSQZrldytvDOavYjhfmDnUq8Q==
   dependencies:
     deepmerge "^2.1.1"
     hoist-non-react-statics "^3.3.0"
@@ -12257,7 +12257,7 @@ formik@^2.2.9:
     lodash-es "^4.17.21"
     react-fast-compare "^2.0.1"
     tiny-warning "^1.0.2"
-    tslib "^1.10.0"
+    tslib "^2.0.0"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -21528,7 +21528,7 @@ tsconfig-paths@^3.14.1:
     minimist "^1.2.6"
     strip-bom "^3.0.0"
 
-tslib@1.14.1, tslib@^1.10.0, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@1.14.1, tslib@^1.11.1, tslib@^1.13.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==


### PR DESCRIPTION
## Changes

- Some imports were failing validation, surfacing that the async function `setValues` was missing an await
