### PR TITLE
Lock Storybook version

### DIFF
--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "reg-suit": "^0.12.2",
     "rimraf": "^5.0.1",
     "semantic-release": "^21.0.9",
-    "storybook": "^7.4.0",
+    "storybook": "7.2.1",
     "stylelint": "^15.10.3",
     "stylelint-config-prettier": "^9.0.3",
     "stylelint-config-standard": "^18.3.0",


### PR DESCRIPTION
## Changes

- lock Storybook version to 7.2.1. I mistakingly merged a PR from dependabot that updated it to the latest available version, but that can only be done in conjonction with updating all other Storybook dependencies
