### PR TITLE
Add update_strategy option to dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,8 @@
 version: 2
 
 updates:
-  # Enable version updates for npm
   - package-ecosystem: 'npm'
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: '/'
+    update_strategy: 'widen'
     schedule:
       interval: 'daily'


### PR DESCRIPTION
## Changes

- add "widen" `update_strategy` option to dependabot config so the bot only proposes non-breaking version updates
