### PR TITLE
refactor: removed venusRate references

### DIFF
--- a/src/__mocks__/api/governance.json
+++ b/src/__mocks__/api/governance.json
@@ -1,7 +1,6 @@
 {
   "status": true,
   "data": {
-    "venusRate": "224000000000000000",
     "dailyVenus": "6473179999999993766400",
     "markets": [
       {

--- a/src/clients/api/queries/getMainMarkets/index.ts
+++ b/src/clients/api/queries/getMainMarkets/index.ts
@@ -13,7 +13,6 @@ export interface GetMainMarketsResponse {
   dailyVenus: number;
   markets: ApiMarket[];
   request: { addresses: string[] };
-  venusRate: string;
 }
 
 export interface GetMainMarketsOutput {


### PR DESCRIPTION
## Changes

- Removed `venusRate` references as it is getting removed from the comptroller and API