### PR TITLE
fix: disable swap and supply for tokens that do not support it

### DIFF
--- a/src/containers/AssetAccessor/DisabledActionNotice/index.tsx
+++ b/src/containers/AssetAccessor/DisabledActionNotice/index.tsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import { NoticeWarning, TokenAnnouncement } from 'components';
-import React from 'react';
+import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token, TokenAction } from 'types';
 
@@ -15,7 +15,7 @@ const DisabledActionNotice: React.FC<DisabledActionNoticeProps> = ({ token, acti
   const { t } = useTranslation();
   const { chainId } = useAuth();
 
-  const getDescription = () => {
+  const description: string | undefined = useMemo(() => {
     if (action === 'supply') {
       return t('operationModal.disabledActionNotice.supply');
     }
@@ -28,15 +28,17 @@ const DisabledActionNotice: React.FC<DisabledActionNoticeProps> = ({ token, acti
       return t('operationModal.disabledActionNotice.borrow');
     }
 
-    return t('operationModal.disabledActionNotice.repay');
-  };
+    if (action === 'repay') {
+      return t('operationModal.disabledActionNotice.repay');
+    }
+  }, [action]);
 
   const tokenAnnouncementDom = TokenAnnouncement({
     token,
     chainId,
   });
 
-  return tokenAnnouncementDom || <NoticeWarning description={getDescription()} />;
+  return tokenAnnouncementDom || (!!description && <NoticeWarning description={description} />);
 };
 
 export default DisabledActionNotice;

--- a/src/containers/AssetAccessor/index.spec.tsx
+++ b/src/containers/AssetAccessor/index.spec.tsx
@@ -58,9 +58,7 @@ describe('containers/AssetAccessor', () => {
     );
 
     await waitFor(() =>
-      expect(
-        getByText(en.operationModal.disabledActionNotice[fakeProps.action]),
-      ).toBeInTheDocument(),
+      expect(getByText(en.operationModal.disabledActionNotice.borrow)).toBeInTheDocument(),
     );
 
     expect(queryByText(fakeProps.connectWalletMessage)).toBeNull();

--- a/src/hooks/useIsTokenActionEnabled.ts
+++ b/src/hooks/useIsTokenActionEnabled.ts
@@ -19,7 +19,7 @@ const useIsTokenActionEnabled = ({ tokenAddress, action }: UseIsTokenActionEnabl
         chainId,
         action,
       }),
-    [chainId],
+    [chainId, tokenAddress, action],
   );
 };
 

--- a/src/hooks/useOperationModal/Modal/SupplyForm/index.stories.tsx
+++ b/src/hooks/useOperationModal/Modal/SupplyForm/index.stories.tsx
@@ -1,6 +1,7 @@
 import { Meta } from '@storybook/react';
 import noop from 'noop-ts';
 import React from 'react';
+import { ChainId } from 'types';
 
 import { poolData } from '__mocks__/models/pools';
 import { xvs } from '__mocks__/models/tokens';
@@ -20,6 +21,7 @@ export default {
 export const Default = () => (
   <SupplyFormUi
     asset={fakeAsset}
+    chainId={ChainId.BSC_TESTNET}
     pool={fakePool}
     onSubmit={noop}
     onCloseModal={noop}

--- a/src/packages/tokens/isTokenActionEnabled/index.tsx
+++ b/src/packages/tokens/isTokenActionEnabled/index.tsx
@@ -4,15 +4,17 @@ import areAddressesEqual from 'utilities/areAddressesEqual';
 
 import disabledTokenActions from '../tokenInfos/disabledTokenActions';
 
+export interface IsTokenActionEnabledInput {
+  tokenAddress: string;
+  chainId: ChainId;
+  action: TokenAction;
+}
+
 export const isTokenActionEnabled = ({
   tokenAddress,
   chainId,
   action,
-}: {
-  tokenAddress: string;
-  chainId: ChainId;
-  action: TokenAction;
-}) => {
+}: IsTokenActionEnabledInput) => {
   const disabledToken = disabledTokenActions[chainId].find(item =>
     areAddressesEqual(item.address, tokenAddress),
   );

--- a/src/packages/tokens/tokenInfos/disabledTokenActions/bscMainnet.ts
+++ b/src/packages/tokens/tokenInfos/disabledTokenActions/bscMainnet.ts
@@ -36,4 +36,119 @@ export const disabledTokenActions: DisabledTokenAction[] = [
     address: '0x250632378E573c6Be1AC2f97Fcdf00515d0Aa91B',
     disabledActions: ['borrow'],
   },
+  // BNB
+  {
+    address: '0x0000000000000000000000000000000000000000',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vAAVE - Main pool
+  {
+    address: '0x26DA28954763B92139ED49283625ceCAf52C6f94',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vADA - Main pool
+  {
+    address: '0x9A0AF7FDb2065Ce470D72664DE73cAE409dA28Ec',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vBCH - Main pool
+  {
+    address: '0x5F0388EBc2B94FA8E123F404b79cCF5f40b29176',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vBETH - Main pool
+  {
+    address: '0x972207A639CC1B374B893cc33Fa251b55CEB7c07',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vCAKE - Main pool
+  {
+    address: '0x86aC3974e2BD0d60825230fa6F355fF11409df5c',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vCAN - Main pool
+  {
+    address: '0xeBD0070237a0713E8D94fEf1B728d3d993d290ef',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vDAI - Main pool
+  {
+    address: '0x334b3eCB4DCa3593BCCC3c7EBD1A1C1d1780FBF1',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vDOGE - Main pool
+  {
+    address: '0xec3422Ef92B2fb59e84c8B02Ba73F1fE84Ed8D71',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vDOT - Main pool
+  {
+    address: '0x1610bc33319e9398de5f57B33a5b184c806aD217',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vFIL - Main pool
+  {
+    address: '0xf91d58b5aE142DAcC749f58A49FCBac340Cb0343',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vLINK - Main pool
+  {
+    address: '0x650b940a1033B8A1b1873f78730FcFC73ec11f1f',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vLTC - Main pool
+  {
+    address: '0x57A5297F2cB2c0AaC9D554660acd6D385Ab50c6B',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vLUNA - Main pool
+  {
+    address: '0xb91A659E88B51474767CD97EF3196A3e7cEDD2c8',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vMATIC - Main pool
+  {
+    address: '0x5c9476FcD6a4F9a3654139721c949c2233bBbBc8',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vSXP - Main pool
+  {
+    address: '0x2fF3d0F6990a40261c66E1ff2017aCBc282EB6d0',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vTRX - Main pool
+  {
+    address: '0xC5D3466aA484B040eE977073fcF337f2c00071c1',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vTRXOLD - Main pool
+  {
+    address: '0x61eDcFe8Dd6bA3c891CB9bEc2dc7657B3B422E93',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vTUSD - Main pool
+  {
+    address: '0xBf762cd5991cA1DCdDaC9ae5C638F5B5Dc3Bee6E',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vTUSDOLD - Main pool
+  {
+    address: '0x08CEB3F4a7ed3500cA0982bcd0FC7816688084c3',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vUST - Main pool
+  {
+    address: '0x78366446547D062f45b4C0f320cDaa6d710D87bb',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vWBETH - Main pool
+  {
+    address: '0x6CFdEc747f37DAf3b87a35a1D9c8AD3063A1A8A0',
+    disabledActions: ['swapAndSupply'],
+  },
+  // vXRP - Main pool
+  {
+    address: '0xB248a295732e0225acd3337607cc01068e3b9c10',
+    disabledActions: ['swapAndSupply'],
+  },
 ];

--- a/src/packages/tokens/tokenInfos/disabledTokenActions/bscTestnet.ts
+++ b/src/packages/tokens/tokenInfos/disabledTokenActions/bscTestnet.ts
@@ -31,4 +31,9 @@ export const disabledTokenActions: DisabledTokenAction[] = [
     address: '0xFeC3A63401Eb9C1476200d7C32c4009Be0154169',
     disabledActions: ['borrow', 'supply'],
   },
+  // BNB
+  {
+    address: '0x0000000000000000000000000000000000000000',
+    disabledActions: ['swapAndSupply'],
+  },
 ];

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource @emotion/react */
-import { ButtonGroup, NoticeWarning, Tag, TagGroup, TextField } from 'components';
+import { ButtonGroup, Tag, TagGroup, TextField } from 'components';
 import React, { InputHTMLAttributes, useMemo, useState } from 'react';
 import { useTranslation } from 'translation';
 import { Pool } from 'types';
@@ -28,7 +28,7 @@ export const DashboardUi: React.FC<DashboardUiProps> = ({
   searchValue,
   onSearchInputChange,
 }) => {
-  const { t, Trans } = useTranslation();
+  const { t } = useTranslation();
   const styles = useStyles();
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const [selectedPoolTagIndex, setSelectedPoolTagIndex] = useState<number>(0);
@@ -92,24 +92,6 @@ export const DashboardUi: React.FC<DashboardUiProps> = ({
   return (
     <>
       <ConnectWalletBanner />
-
-      <NoticeWarning
-        css={styles.banner}
-        description={
-          <Trans
-            i18nKey="dashboard.banner.busdDelisting"
-            components={{
-              Link: (
-                // eslint-disable-next-line jsx-a11y/anchor-has-content
-                <a
-                  href="https://community.venus.io/t/chaos-labs-risk-parameter-updates-08-21-2023/3707"
-                  rel="noreferrer"
-                />
-              ),
-            }}
-          />
-        }
-      />
 
       <div css={styles.header}>
         <TextField

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -173,9 +173,6 @@
   },
   "dashboard": {
     "allTag": "All",
-    "banner": {
-      "busdDelisting": "Borrowing and supplying have been paused for the BUSD token. For more information see the <Link>Chaos Labs recommendations</Link>."
-    },
     "borrowMarketTableTitle": "Borrow market",
     "borrowTabTitle": "Borrow",
     "connectWalletBanner": {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,7 +25,7 @@ export interface VToken extends Omit<Token, 'isNative' | 'asset'> {
   underlyingToken: Token;
 }
 
-export type TokenAction = 'supply' | 'withdraw' | 'borrow' | 'repay';
+export type TokenAction = 'swapAndSupply' | 'supply' | 'withdraw' | 'borrow' | 'repay';
 
 export interface TokenBalance {
   token: Token;


### PR DESCRIPTION
## Changes

- remove dashboard warning about BUSD delisting
- add `swapAndSupply` to the list of actins that can be disabled
- disable swap and supply action for tokens that don't support the `mintBehalf` function
