### PR TITLE
refactor: optimize request refetches

### DIFF
--- a/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
+++ b/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
@@ -1,11 +1,10 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
-import { callOrThrow } from 'utilities';
+import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getIsolatedPools, {
   GetIsolatedPoolsInput,
   GetIsolatedPoolsOutput,
 } from 'clients/api/queries/getIsolatedPools';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
 import useGetTokens from 'hooks/useGetTokens';
@@ -28,6 +27,8 @@ type Options = QueryObserverOptions<
   GetIsolatedPoolsOutput,
   [FunctionKey.GET_ISOLATED_POOLS, TrimmedInput]
 >;
+
+const refetchInterval = generatePseudoRandomRefetchInterval();
 
 const useGetIsolatedPools = (input: TrimmedInput, options?: Options) => {
   const { provider } = useAuth();
@@ -59,7 +60,7 @@ const useGetIsolatedPools = (input: TrimmedInput, options?: Options) => {
           }),
       ),
     {
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+      refetchInterval,
       ...options,
     },
   );

--- a/src/clients/api/queries/getMainMarkets/useGetMainMarkets.ts
+++ b/src/clients/api/queries/getMainMarkets/useGetMainMarkets.ts
@@ -1,7 +1,6 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
 
 import getMainMarkets, { GetMainMarketsOutput } from 'clients/api/queries/getMainMarkets';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 
 type Options = QueryObserverOptions<
@@ -13,9 +12,6 @@ type Options = QueryObserverOptions<
 >;
 
 const useGetMainMarkets = (options?: Options) =>
-  useQuery(FunctionKey.GET_MAIN_MARKETS, getMainMarkets, {
-    refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
-    ...options,
-  });
+  useQuery(FunctionKey.GET_MAIN_MARKETS, getMainMarkets, options);
 
 export default useGetMainMarkets;

--- a/src/clients/api/queries/getMainPool/useGetMainPool.ts
+++ b/src/clients/api/queries/getMainPool/useGetMainPool.ts
@@ -1,9 +1,8 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { useTranslation } from 'translation';
-import { callOrThrow } from 'utilities';
+import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getMainPool, { GetMainPoolInput, GetMainPoolOutput } from 'clients/api/queries/getMainPool';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 import useGetToken from 'hooks/useGetToken';
 import useGetTokens from 'hooks/useGetTokens';
@@ -30,6 +29,8 @@ type Options = QueryObserverOptions<
   GetMainPoolOutput,
   [FunctionKey.GET_MAIN_POOL, TrimmedInput]
 >;
+
+const refetchInterval = generatePseudoRandomRefetchInterval();
 
 const useGetMainPool = (input: TrimmedInput, options?: Options) => {
   const { t } = useTranslation();
@@ -76,7 +77,7 @@ const useGetMainPool = (input: TrimmedInput, options?: Options) => {
           }),
       ),
     {
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+      refetchInterval,
       ...options,
     },
   );

--- a/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
+++ b/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
@@ -1,8 +1,7 @@
 import { useMemo } from 'react';
 import { QueryObserverOptions, useQuery } from 'react-query';
-import { callOrThrow } from 'utilities';
+import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 import useGetTokens from 'hooks/useGetTokens';
 import useGetUniqueContract from 'hooks/useGetUniqueContract';
@@ -34,6 +33,8 @@ type Options = QueryObserverOptions<
   GetPendingRewardsOutput,
   [FunctionKey.GET_PENDING_REWARDS, TrimmedGetPendingRewardsInput]
 >;
+
+const refetchInterval = generatePseudoRandomRefetchInterval();
 
 const useGetPendingRewards = (input: TrimmedGetPendingRewardsInput, options?: Options) => {
   const mainPoolComptrollerContractAddress = useGetUniqueContractAddress({
@@ -107,7 +108,7 @@ const useGetPendingRewards = (input: TrimmedGetPendingRewardsInput, options?: Op
           }),
       ),
     {
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+      refetchInterval,
       ...options,
       enabled:
         (!options || options.enabled) && !isGetPoolsLoading && !isGetXvsVaultPoolCountLoading,

--- a/src/clients/api/queries/getProposals/useGetProposal.ts
+++ b/src/clients/api/queries/getProposals/useGetProposal.ts
@@ -17,14 +17,16 @@ type Options = QueryObserverOptions<
 
 const refetchStates = ['Pending', 'Active', 'Succeeded', 'Queued'];
 
-// refetchInterval is set automatically with onSucess so it is excluded from being set manually
+// refetchInterval is set automatically with onSuccess so it is excluded from being set manually
 const useGetProposal = (params: GetProposalInput, options?: Omit<Options, 'refetchInterval'>) =>
   useQuery([FunctionKey.GET_PROPOSAL, params], () => getProposal(params), {
     onSuccess: (data: Proposal) => {
-      const refetchInterval = refetchStates.includes(data.state) ? BLOCK_TIME_MS : 0;
-      queryClient.setQueryDefaults([FunctionKey.GET_PROPOSAL, params], {
-        refetchInterval,
-      });
+      if (refetchStates.includes(data.state)) {
+        queryClient.setQueryDefaults([FunctionKey.GET_PROPOSAL, params], {
+          refetchInterval: BLOCK_TIME_MS,
+        });
+      }
+
       if (options?.onSuccess) {
         options.onSuccess(data);
       }

--- a/src/clients/api/queries/getTransactions/useGetTransactions.ts
+++ b/src/clients/api/queries/getTransactions/useGetTransactions.ts
@@ -1,11 +1,11 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getTransactions, {
   GetTransactionsInput,
   GetTransactionsOutput,
 } from 'clients/api/queries/getTransactions';
 import useGetVTokens from 'clients/api/queries/getVTokens/useGetVTokens';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 import useGetToken from 'hooks/useGetToken';
 import useGetTokens from 'hooks/useGetTokens';
@@ -23,6 +23,8 @@ type Options = QueryObserverOptions<
   [FunctionKey.GET_TRANSACTIONS, TrimmedGetTransactionsInput]
 >;
 
+const refetchInterval = generatePseudoRandomRefetchInterval();
+
 const useGetTransactions = (params: TrimmedGetTransactionsInput, options?: Options) => {
   const { data: getVTokenData } = useGetVTokens();
   const vTokens = getVTokenData?.vTokens || [];
@@ -37,7 +39,7 @@ const useGetTransactions = (params: TrimmedGetTransactionsInput, options?: Optio
     () => getTransactions({ ...params, vTokens, tokens, defaultToken: xvs || tokens[0] }),
     {
       keepPreviousData: true,
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+      refetchInterval,
       ...options,
       enabled: vTokens.length > 0 && (!options || options.enabled),
     },

--- a/src/clients/api/queries/getVTokenBalancesAll/useGetVTokenBalancesAll.ts
+++ b/src/clients/api/queries/getVTokenBalancesAll/useGetVTokenBalancesAll.ts
@@ -5,7 +5,6 @@ import getVTokenBalancesAll, {
   GetVTokenBalancesAllInput,
   GetVTokenBalancesAllOutput,
 } from 'clients/api/queries/getVTokenBalancesAll';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 import useGetUniqueContract from 'hooks/useGetUniqueContract';
 
@@ -27,10 +26,7 @@ const useGetVTokenBalancesAll = (input: TrimmedGetVTokenBalancesAllInput, option
     [FunctionKey.GET_V_TOKEN_BALANCES_ALL, input],
     () =>
       callOrThrow({ venusLensContract }, params => getVTokenBalancesAll({ ...params, ...input })),
-    {
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
-      ...options,
-    },
+    options,
   );
 };
 

--- a/src/clients/api/queries/getVoterAccounts/useGetVoterAccounts.ts
+++ b/src/clients/api/queries/getVoterAccounts/useGetVoterAccounts.ts
@@ -1,6 +1,6 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { generatePseudoRandomRefetchInterval } from 'utilities';
 
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 
 import getVoterAccounts, { GetVoterAccountsInput, GetVoterAccountsOutput } from '.';
@@ -13,11 +13,13 @@ type Options = QueryObserverOptions<
   [FunctionKey.GET_VOTER_ACCOUNTS, GetVoterAccountsInput]
 >;
 
+const refetchInterval = generatePseudoRandomRefetchInterval();
+
 const useGetVoterAccounts = (params: GetVoterAccountsInput = {}, options?: Options) =>
   // This endpoint is paginated so we keep the previous responses by default to create a more seamless paginating experience
   useQuery([FunctionKey.GET_VOTER_ACCOUNTS, params], () => getVoterAccounts(params), {
     keepPreviousData: true,
-    refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+    refetchInterval,
     ...options,
   });
 

--- a/src/clients/api/queries/getVoterDetails/useGetVoterDetails.ts
+++ b/src/clients/api/queries/getVoterDetails/useGetVoterDetails.ts
@@ -4,7 +4,6 @@ import getVoterDetails, {
   GetVoterDetailsInput,
   GetVoterDetailsOutput,
 } from 'clients/api/queries/getVoterDetails';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 
 type Options = QueryObserverOptions<
@@ -16,10 +15,6 @@ type Options = QueryObserverOptions<
 >;
 
 const useGetVoterDetails = (params: GetVoterDetailsInput, options?: Options) =>
-  // This endpoint is paginated so we keep the previous responses by default to create a more seamless paginating experience
-  useQuery([FunctionKey.GET_VOTER_DETAILS, params], () => getVoterDetails(params), {
-    refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
-    ...options,
-  });
+  useQuery([FunctionKey.GET_VOTER_DETAILS, params], () => getVoterDetails(params), options);
 
 export default useGetVoterDetails;

--- a/src/clients/api/queries/getVoterHistory/useGetVoterHistory.ts
+++ b/src/clients/api/queries/getVoterHistory/useGetVoterHistory.ts
@@ -4,7 +4,6 @@ import getVoterHistory, {
   GetVoterHistoryInput,
   GetVoterHistoryOutput,
 } from 'clients/api/queries/getVoterHistory';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 
 type Options = QueryObserverOptions<
@@ -19,7 +18,6 @@ const useGetVoterHistory = (params: GetVoterHistoryInput, options?: Options) =>
   // This endpoint is paginated so we keep the previous responses by default to create a more seamless paginating experience
   useQuery([FunctionKey.GET_VOTER_HISTORY, params], () => getVoterHistory(params), {
     keepPreviousData: true,
-    refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
     ...options,
   });
 

--- a/src/clients/api/queries/getVoters/useGetVoters.ts
+++ b/src/clients/api/queries/getVoters/useGetVoters.ts
@@ -1,7 +1,7 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getVoters, { GetVotersInput, GetVotersOutput } from 'clients/api/queries/getVoters';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 
 type Options = QueryObserverOptions<
@@ -12,11 +12,13 @@ type Options = QueryObserverOptions<
   [FunctionKey.GET_VOTERS, GetVotersInput]
 >;
 
+const refetchInterval = generatePseudoRandomRefetchInterval();
+
 const useGetVoters = (params: GetVotersInput, options?: Options) =>
   // This endpoint is paginated so we keep the previous responses by default to create a more seamless paginating experience
   useQuery([FunctionKey.GET_VOTERS, params], () => getVoters(params), {
     keepPreviousData: true,
-    refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+    refetchInterval,
     ...options,
   });
 

--- a/src/clients/api/queries/getXvsWithdrawableAmount/useGetXvsWithdrawableAmount.ts
+++ b/src/clients/api/queries/getXvsWithdrawableAmount/useGetXvsWithdrawableAmount.ts
@@ -5,7 +5,6 @@ import getXvsWithdrawableAmount, {
   GetXvsWithdrawableAmountInput,
   GetXvsWithdrawableAmountOutput,
 } from 'clients/api/queries/getXvsWithdrawableAmount';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 import useGetUniqueContract from 'hooks/useGetUniqueContract';
 
@@ -36,10 +35,7 @@ const useGetXvsWithdrawableAmount = (
       callOrThrow({ xvsVestingContract }, params =>
         getXvsWithdrawableAmount({ ...params, ...input }),
       ),
-    {
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
-      ...options,
-    },
+    options,
   );
 };
 

--- a/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
@@ -9,7 +9,6 @@ import {
   useGetVenusVaiVaultDailyRate,
 } from 'clients/api';
 import { DAYS_PER_YEAR } from 'constants/daysPerYear';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import useGetToken from 'hooks/useGetToken';
 import useGetUniqueContractAddress from 'hooks/useGetUniqueContractAddress';
 
@@ -37,7 +36,6 @@ const useGetVaiVault = ({ accountAddress }: { accountAddress?: string }): UseGet
       token: vai!, // We ensure vai exists through the enabled option
     },
     {
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
       enabled: !!vaiVaultContractAddress && !!vai,
     },
   );

--- a/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPoolBalances.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPoolBalances.ts
@@ -1,7 +1,6 @@
 import { UseQueryOptions, UseQueryResult, useQueries } from 'react-query';
 
 import { GetBalanceOfOutput, getBalanceOf } from 'clients/api';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
 import useGetTokens from 'hooks/useGetTokens';
@@ -47,7 +46,6 @@ const useGetXvsVaultPoolBalances = ({
           },
         ],
         enabled: !!stakedToken && !!xvsVaultContractAddress,
-        refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
       };
     },
   );

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -31,6 +31,7 @@ const isOnTestnet =
   environment === 'testnet' || environment === 'storybook' || environment === 'ci';
 
 const isLocalServer = import.meta.env.DEV && environment !== 'ci' && environment !== 'storybook';
+
 const rpcUrls = isLocalServer
   ? {
       [ChainId.BSC_MAINNET]: {

--- a/src/constants/defaultRefetchInterval.ts
+++ b/src/constants/defaultRefetchInterval.ts
@@ -1,3 +1,0 @@
-import { BLOCK_TIME_MS } from './bsc';
-
-export const DEFAULT_REFETCH_INTERVAL_MS = BLOCK_TIME_MS * 3; // every 3 blocks (9 seconds)

--- a/src/context/AuthContext/index.tsx
+++ b/src/context/AuthContext/index.tsx
@@ -44,7 +44,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [isAuthModalOpen, setIsAuthModalOpen] = React.useState(false);
   const { connectors, connectAsync } = useConnect();
   const { disconnectAsync } = useDisconnect();
-  const { address, isConnected } = useAccount();
+  const { address } = useAccount();
   const { chain } = useNetwork();
 
   // TODO: get from chain instead of config
@@ -59,8 +59,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   // Set address as authorized by default
   const isAuthorizedAddress = !accountAuth || accountAuth.authorized;
-  const accountAddress =
-    isConnected && !!signer && address && isAuthorizedAddress ? address : undefined;
+  const accountAddress = !!address && isAuthorizedAddress ? address : undefined;
 
   const login = useCallback(async (connectorId: Connector) => {
     // If user is attempting to connect their Infinity wallet but the dApp

--- a/src/pages/Vai/MintVai/index.tsx
+++ b/src/pages/Vai/MintVai/index.tsx
@@ -13,7 +13,12 @@ import { ContractReceipt } from 'ethers';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
-import { convertTokensToWei, convertWeiToTokens, formatPercentageToReadableValue } from 'utilities';
+import {
+  convertTokensToWei,
+  convertWeiToTokens,
+  formatPercentageToReadableValue,
+  generatePseudoRandomRefetchInterval,
+} from 'utilities';
 
 import {
   useGetBalanceOf,
@@ -22,7 +27,6 @@ import {
   useGetVaiTreasuryPercentage,
   useMintVai,
 } from 'clients/api';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { AmountForm, AmountFormProps } from 'containers/AmountForm';
 import { useAuth } from 'context/AuthContext';
@@ -44,6 +48,8 @@ export interface MintVaiUiProps {
   mintFeePercentage?: number;
   vai: Token;
 }
+
+const userVaiRefetchInterval = generatePseudoRandomRefetchInterval();
 
 export const MintVaiUi: React.FC<MintVaiUiProps> = ({
   disabled,
@@ -215,7 +221,7 @@ const MintVai: React.FC = () => {
     },
     {
       enabled: !!accountAddress,
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+      refetchInterval: userVaiRefetchInterval,
     },
   );
 

--- a/src/pages/Vai/RepayVai/index.tsx
+++ b/src/pages/Vai/RepayVai/index.tsx
@@ -16,10 +16,13 @@ import { ContractReceipt } from 'ethers';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
-import { convertTokensToWei, convertWeiToTokens } from 'utilities';
+import {
+  convertTokensToWei,
+  convertWeiToTokens,
+  generatePseudoRandomRefetchInterval,
+} from 'utilities';
 
 import { useGetBalanceOf, useGetVaiRepayAmountWithInterests, useRepayVai } from 'clients/api';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import MAX_UINT256 from 'constants/maxUint256';
 import { AmountForm, AmountFormProps } from 'containers/AmountForm';
 import { useAuth } from 'context/AuthContext';
@@ -55,6 +58,8 @@ export interface IRepayVaiUiProps {
   userBalanceWei?: BigNumber;
   repayBalanceWei?: BigNumber;
 }
+
+const userVaiRefetchInterval = generatePseudoRandomRefetchInterval();
 
 export const RepayVaiUi: React.FC<IRepayVaiUiProps> = ({
   disabled,
@@ -267,7 +272,7 @@ const RepayVai: React.FC = () => {
     },
     {
       enabled: !!accountAddress,
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
+      refetchInterval: userVaiRefetchInterval,
     },
   );
 

--- a/src/pages/Xvs/Table/index.tsx
+++ b/src/pages/Xvs/Table/index.tsx
@@ -15,7 +15,6 @@ import {
 
 import { useGetBalanceOf, useGetMainPool, useGetVenusVaiVaultDailyRate } from 'clients/api';
 import { DAYS_PER_YEAR } from 'constants/daysPerYear';
-import { DEFAULT_REFETCH_INTERVAL_MS } from 'constants/defaultRefetchInterval';
 import { useAuth } from 'context/AuthContext';
 import useGetToken from 'hooks/useGetToken';
 import useGetUniqueContractAddress from 'hooks/useGetUniqueContractAddress';
@@ -137,7 +136,6 @@ const XvsTable: React.FC = () => {
       accountAddress: vaiVaultContractAddress || '',
     },
     {
-      refetchInterval: DEFAULT_REFETCH_INTERVAL_MS,
       enabled: !!vaiVaultContractAddress && !!vai,
     },
   );

--- a/src/utilities/generatePseudoRandomRefetchInterval/__tests__/index.spec.ts
+++ b/src/utilities/generatePseudoRandomRefetchInterval/__tests__/index.spec.ts
@@ -1,0 +1,16 @@
+import { generatePseudoRandomRefetchInterval } from '..';
+
+describe('generatePseudoRandomRefetchInterval', () => {
+  beforeEach(() => {
+    vi.spyOn(global.Math, 'random').mockReturnValue(0.123456789);
+  });
+
+  afterEach(() => {
+    vi.spyOn(global.Math, 'random').mockRestore();
+  });
+
+  it('returns a number from 9000 to 15000', () => {
+    const result = generatePseudoRandomRefetchInterval();
+    expect(result).toMatchInlineSnapshot('9741');
+  });
+});

--- a/src/utilities/generatePseudoRandomRefetchInterval/index.ts
+++ b/src/utilities/generatePseudoRandomRefetchInterval/index.ts
@@ -1,0 +1,3 @@
+export const generatePseudoRandomRefetchInterval = () =>
+  // Return a refetch interval from 9000 to 15000 milliseconds (approximately 3 to 5 blocks)
+  +(Math.random() * 6000 + 9000).toFixed(0);

--- a/src/utilities/index.ts
+++ b/src/utilities/index.ts
@@ -11,6 +11,7 @@ export { default as convertPercentageFromSmartContract } from './convertPercenta
 
 export * from './formatTokensToReadableValue';
 export * from './convertWeiToTokens';
+export * from './generatePseudoRandomRefetchInterval';
 export { default as encodeParameters } from './encodeParameters';
 export { default as shortenValueWithSuffix } from './shortenValueWithSuffix';
 export { default as formatCentsToReadableValue } from './formatCentsToReadableValue';


### PR DESCRIPTION
The goal of this PR is to reduce the overall amount of requests made and only reduce the refetch interval of requests for which that is really relevant.

## Changes
- remove refetch interval from queries that don't require to be refetched often
- replace the default refetch interval of 9 seconds, used on queries that need to be refetched often, with a pseudo random refetch interval of 9 to 15 seconds (3 to 5 blocks). The reason for using a pseudo random interval is to avoid the [thundering herd problem](https://en.wikipedia.org/wiki/Thundering_herd_problem#:~:text=In%20computer%20science%2C%20the%20thundering,but%20only%20one%20will%20win.)
- update auth context so the account address is returned even if the signer is `undefined` or the status of the wallet is not "connected". This means that for returning users the account address is instantly returned upon opening the dApp, reducing the amount of total requests made, as in the current implementation a query that uses the account address would be fired on mount, then fired again after the account address was returned
