### PR TITLE
fix: replace mkdirSync usage with mkdir

### DIFF
--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAbis/__tests__/index.spec.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAbis/__tests__/index.spec.ts
@@ -8,8 +8,8 @@ import generateAbis from '..';
 vi.mock('utilities/writeFile');
 
 describe('generateAbis', () => {
-  it('calls writeFile with the right arguments', () => {
-    generateAbis({
+  it('calls writeFile with the right arguments', async () => {
+    await generateAbis({
       outputDirectoryPath: 'fake/output/director/path',
       contractConfigs: fakeContractConfigs,
     });

--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAbis/index.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAbis/index.ts
@@ -7,13 +7,15 @@ export interface GenerateTypesInput {
   outputDirectoryPath: string;
 }
 
-const generateAbis = ({ contractConfigs, outputDirectoryPath }: GenerateTypesInput) =>
+const generateAbis = async ({ contractConfigs, outputDirectoryPath }: GenerateTypesInput) =>
   // Go through config and extract ABIs into separate files
-  contractConfigs.forEach(contractConfig => {
-    writeFile({
-      outputPath: `${outputDirectoryPath}/${contractConfig.name}.json`,
-      content: JSON.stringify(contractConfig.abi),
-    });
-  });
+  Promise.all(
+    contractConfigs.map(contractConfig =>
+      writeFile({
+        outputPath: `${outputDirectoryPath}/${contractConfig.name}.json`,
+        content: JSON.stringify(contractConfig.abi),
+      }),
+    ),
+  );
 
 export default generateAbis;

--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAddressList/__tests__/index.spec.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAddressList/__tests__/index.spec.ts
@@ -8,8 +8,8 @@ import generateAddressList from '..';
 vi.mock('utilities/writeFile');
 
 describe('generateAddressList', () => {
-  it('calls writeFile with the right arguments', () => {
-    generateAddressList({
+  it('calls writeFile with the right arguments', async () => {
+    await generateAddressList({
       outputFilePath: 'fake/output/director/path',
       contractConfigs: fakeContractConfigs,
     });

--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAddressList/index.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateAddressList/index.ts
@@ -8,7 +8,10 @@ export interface GenerateAddressListInput {
   contractConfigs: ContractConfig[];
 }
 
-const generateAddressList = ({ outputFilePath, contractConfigs }: GenerateAddressListInput) => {
+const generateAddressList = async ({
+  outputFilePath,
+  contractConfigs,
+}: GenerateAddressListInput) => {
   // Open addresses output
   let addressesOutput = 'export default {';
 
@@ -44,7 +47,7 @@ const generateAddressList = ({ outputFilePath, contractConfigs }: GenerateAddres
   addressesOutput += '};';
 
   // Generate addresses file
-  writeFile({
+  await writeFile({
     outputPath: outputFilePath,
     content: addressesOutput,
   });

--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/index.spec.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/index.spec.ts
@@ -8,8 +8,8 @@ import generateGetters from '..';
 vi.mock('utilities/writeFile');
 
 describe('generateGetters', () => {
-  it('calls writeFile with the right arguments', () => {
-    generateGetters({
+  it('calls writeFile with the right arguments', async () => {
+    await generateGetters({
       outputDirectoryPath: 'fake/output/director/path',
       contractConfigs: fakeContractConfigs,
     });

--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateGetters/index.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateGetters/index.ts
@@ -51,27 +51,29 @@ export interface GenerateContractGettersInput {
   contractConfigs: ContractConfig[];
 }
 
-const generateGetters = ({
+const generateGetters = async ({
   outputDirectoryPath,
   contractConfigs,
 }: GenerateContractGettersInput) => {
-  const fileNames = contractConfigs.map(contractConfig => {
+  const writeGetterFile = async (contractConfig: ContractConfig) => {
     const content = getContent({ contractConfig });
     const fileName = `${contractConfig.name[0].toLowerCase()}${contractConfig.name.substring(1)}`;
     const outputPath = `${outputDirectoryPath}/${fileName}.ts`;
 
-    writeFile({
+    await writeFile({
       outputPath,
       content,
     });
 
     return fileName;
-  });
+  };
+
+  const fileNames = await Promise.all(contractConfigs.map(writeGetterFile));
 
   // Write index file exporting all getters
   const indexOutputPath = `${outputDirectoryPath}/index.ts`;
 
-  writeFile({
+  await writeFile({
     outputPath: indexOutputPath,
     content: indexTemplate({ fileNames }),
   });

--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateTypes/index.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/generateTypes/index.ts
@@ -60,7 +60,7 @@ const generateTypes = async ({
 
   const typesOutput = typesTemplate(contractNames);
 
-  writeFile({
+  await writeFile({
     outputPath: typesOutputDirectoryPath,
     content: typesOutput,
   });

--- a/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/index.ts
+++ b/src/packages/contractsNew/scripts/generateContractRecords/generateContracts/index.ts
@@ -31,7 +31,7 @@ export interface GenerateContractsInput {
 const generateContracts = async ({ contractConfigs }: GenerateContractsInput) => {
   // Generate address list
   console.log('Start generating contract address list...');
-  generateAddressList({
+  await generateAddressList({
     contractConfigs,
     outputFilePath: ADDRESSES_OUTPUT_FILE_PATH,
   });
@@ -39,7 +39,7 @@ const generateContracts = async ({ contractConfigs }: GenerateContractsInput) =>
 
   // Generate ABIs
   console.log('Generating contract ABIs...');
-  generateAbis({
+  await generateAbis({
     contractConfigs,
     outputDirectoryPath: ABIS_OUTPUT_DIRECTORY_PATH,
   });
@@ -57,7 +57,7 @@ const generateContracts = async ({ contractConfigs }: GenerateContractsInput) =>
 
   // Generate getter functions
   console.log('Generating contract getters...');
-  generateGetters({
+  await generateGetters({
     contractConfigs,
     outputDirectoryPath: GETTERS_OUTPUT_DIRECTORY_PATH,
   });

--- a/src/utilities/writeFile/index.ts
+++ b/src/utilities/writeFile/index.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { promises } from 'node:fs';
 
 import { AUTOMATICALLY_GENERATED_FILE_WARNING_MESSAGE } from 'constants/automaticallyGeneratedFileWarningMessage';
 
@@ -7,7 +7,7 @@ export interface WriteFileInput {
   content: string;
 }
 
-const writeFile = ({ outputPath, content }: WriteFileInput) => {
+const writeFile = async ({ outputPath, content }: WriteFileInput) => {
   const fileExtensionElements = outputPath.split('.');
   const fileExtension = fileExtensionElements[fileExtensionElements.length - 1];
 
@@ -24,10 +24,10 @@ const writeFile = ({ outputPath, content }: WriteFileInput) => {
   const directoryPathElements = outputPath.split('/');
   directoryPathElements.pop();
   const directoryPath = directoryPathElements.join('/');
-  mkdirSync(directoryPath, { recursive: true });
+  await promises.mkdir(directoryPath, { recursive: true });
 
   // Write file
-  writeFileSync(outputPath, formattedContent, 'utf8');
+  await promises.writeFile(outputPath, formattedContent, 'utf8');
 };
 
 export default writeFile;


### PR DESCRIPTION
## Changes

- `mkdirSync` is not exported by the fs module of Vite when building, so we use `mkdir` instead
