### PR TITLE
fix: update VenusLens address for mainnet

### DIFF
--- a/src/packages/contracts/contractInfos/uniqueContractInfos.ts
+++ b/src/packages/contracts/contractInfos/uniqueContractInfos.ts
@@ -48,7 +48,8 @@ const venusLens: UniqueContractInfo = {
   abi: venusLensAbi,
   address: {
     [ChainId.BSC_TESTNET]: venusProtocolTestnetDeployments.Contracts.VenusLens,
-    [ChainId.BSC_MAINNET]: venusProtocolMainnetDeployments.Contracts.VenusLens,
+    // TODO: get address from package once it gets updated
+    [ChainId.BSC_MAINNET]: '0x892D8E61B5151a1E200A64bd5F766784771D7355',
   },
 };
 


### PR DESCRIPTION
## Changes

- Updated `VenusLens` contract address with the latest mainnet deployment
