### PR TITLE
refactor: move token-specific utilities to tokens package

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -105,6 +105,8 @@ module.exports = {
     'react/jsx-wrap-multilines': 0,
     'generator-star-spacing': 0,
     'consistent-return': 0,
+    // Disable import order checks as we automatically sort imports using Prettier
+    'import/order': 0,
   },
   settings: {
     'import/resolver': {

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,5 @@ storybook-static
 /src/clients/subgraph/gql/mainnet.ts
 /src/clients/subgraph/gql/testnet.ts
 
-
 # Version in package.json exposed to the dApp
 /src/constants/version.ts

--- a/src/clients/api/mutations/executeWithdrawalFromXvsVault/useExecuteWithdrawalFromXvsVault.ts
+++ b/src/clients/api/mutations/executeWithdrawalFromXvsVault/useExecuteWithdrawalFromXvsVault.ts
@@ -1,4 +1,5 @@
 import { useGetXvsVaultContract } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { MutationObserverOptions, useMutation } from 'react-query';
 import { Token } from 'types';
 import { callOrThrow } from 'utilities';
@@ -11,7 +12,6 @@ import {
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useAnalytics } from 'context/Analytics';
-import useGetToken from 'hooks/useGetToken';
 
 type TrimmedExecuteWithdrawalFromXvsVaultInput = Omit<
   ExecuteWithdrawalFromXvsVaultInput,

--- a/src/clients/api/mutations/repayVai/useRepayVai.ts
+++ b/src/clients/api/mutations/repayVai/useRepayVai.ts
@@ -1,10 +1,10 @@
 import { useGetVaiControllerContract } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { MutationObserverOptions, useMutation } from 'react-query';
 import { callOrThrow } from 'utilities';
 
 import { IRepayVaiOutput, RepayVaiInput, queryClient, repayVai } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
-import useGetToken from 'hooks/useGetToken';
 
 type TrimmedRepayVai = Omit<RepayVaiInput, 'vaiControllerContract'>;
 type Options = MutationObserverOptions<IRepayVaiOutput, Error, TrimmedRepayVai>;

--- a/src/clients/api/mutations/requestWithdrawalFromXvsVault/useRequestWithdrawalFromXvsVault.ts
+++ b/src/clients/api/mutations/requestWithdrawalFromXvsVault/useRequestWithdrawalFromXvsVault.ts
@@ -1,4 +1,5 @@
 import { useGetXvsVaultContract } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { MutationObserverOptions, useMutation } from 'react-query';
 import { callOrThrow, convertWeiToTokens } from 'utilities';
 
@@ -10,7 +11,6 @@ import {
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useAnalytics } from 'context/Analytics';
-import useGetToken from 'hooks/useGetToken';
 
 type TrimmedRequestWithdrawalFromXvsVaultInput = Omit<
   RequestWithdrawalFromXvsVaultInput,

--- a/src/clients/api/mutations/stakeInVaiVault/useStakeInVaiVault.ts
+++ b/src/clients/api/mutations/stakeInVaiVault/useStakeInVaiVault.ts
@@ -1,4 +1,5 @@
 import { useGetVaiVaultContract } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { MutationObserverOptions, useMutation } from 'react-query';
 import { callOrThrow, convertWeiToTokens } from 'utilities';
 
@@ -10,7 +11,6 @@ import {
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useAnalytics } from 'context/Analytics';
-import useGetToken from 'hooks/useGetToken';
 
 type TrimmedStakeInVaiVaultInput = Omit<StakeInVaiVaultInput, 'vaiVaultContract'>;
 type Options = MutationObserverOptions<StakeInVaiVaultOutput, Error, TrimmedStakeInVaiVaultInput>;

--- a/src/clients/api/mutations/useStakeInVault/index.ts
+++ b/src/clients/api/mutations/useStakeInVault/index.ts
@@ -1,10 +1,10 @@
 import BigNumber from 'bignumber.js';
 import { VError } from 'errors';
+import { useGetToken } from 'packages/tokens';
 import { Token } from 'types';
 import { areTokensEqual } from 'utilities';
 
 import { useStakeInVaiVault, useStakeInXvsVault } from 'clients/api';
-import useGetToken from 'hooks/useGetToken';
 
 export interface UseStakeInVaultInput {
   stakedToken: Token;

--- a/src/clients/api/mutations/withdrawFromVaiVault/useWithdrawFromVaiVault.ts
+++ b/src/clients/api/mutations/withdrawFromVaiVault/useWithdrawFromVaiVault.ts
@@ -1,4 +1,5 @@
 import { useGetVaiVaultContract } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { MutationObserverOptions, useMutation } from 'react-query';
 import { callOrThrow, convertWeiToTokens } from 'utilities';
 
@@ -10,7 +11,6 @@ import {
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useAnalytics } from 'context/Analytics';
-import useGetToken from 'hooks/useGetToken';
 
 type TrimmedWithdrawFromVaiVaultInput = Omit<WithdrawFromVaiVaultInput, 'vaiVaultContract'>;
 type Options = MutationObserverOptions<

--- a/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
+++ b/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
@@ -3,6 +3,7 @@ import {
   useGetPoolRegistryContractAddress,
   useGetResilientOracleContract,
 } from 'packages/contractsNew';
+import { useGetTokens } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
@@ -12,7 +13,6 @@ import getIsolatedPools, {
 } from 'clients/api/queries/getIsolatedPools';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
-import useGetTokens from 'hooks/useGetTokens';
 
 type TrimmedInput = Omit<
   GetIsolatedPoolsInput,

--- a/src/clients/api/queries/getMainPool/useGetMainPool.ts
+++ b/src/clients/api/queries/getMainPool/useGetMainPool.ts
@@ -4,14 +4,13 @@ import {
   useGetVaiControllerContract,
   useGetVenusLensContract,
 } from 'packages/contractsNew';
+import { useGetToken, useGetTokens } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { useTranslation } from 'translation';
 import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getMainPool, { GetMainPoolInput, GetMainPoolOutput } from 'clients/api/queries/getMainPool';
 import FunctionKey from 'constants/functionKey';
-import useGetToken from 'hooks/useGetToken';
-import useGetTokens from 'hooks/useGetTokens';
 
 type TrimmedInput = Omit<
   GetMainPoolInput,

--- a/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
+++ b/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
@@ -6,12 +6,12 @@ import {
   useGetVenusLensContract,
   useGetXvsVaultContract,
 } from 'packages/contractsNew';
+import { useGetTokens } from 'packages/tokens';
 import { useMemo } from 'react';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import FunctionKey from 'constants/functionKey';
-import useGetTokens from 'hooks/useGetTokens';
 
 import getPendingRewardGroups from '.';
 import useGetXvsVaultPoolCount from '../getXvsVaultPoolCount/useGetXvsVaultPoolCount';

--- a/src/clients/api/queries/getTransactions/useGetTransactions.ts
+++ b/src/clients/api/queries/getTransactions/useGetTransactions.ts
@@ -1,3 +1,4 @@
+import { useGetToken, useGetTokens } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { generatePseudoRandomRefetchInterval } from 'utilities';
 
@@ -7,8 +8,6 @@ import getTransactions, {
 } from 'clients/api/queries/getTransactions';
 import useGetVTokens from 'clients/api/queries/getVTokens/useGetVTokens';
 import FunctionKey from 'constants/functionKey';
-import useGetToken from 'hooks/useGetToken';
-import useGetTokens from 'hooks/useGetTokens';
 
 type TrimmedGetTransactionsInput = Omit<
   GetTransactionsInput,

--- a/src/clients/api/queries/getVTokens/useGetVTokens.ts
+++ b/src/clients/api/queries/getVTokens/useGetVTokens.ts
@@ -4,6 +4,7 @@ import {
   useGetPoolRegistryContractAddress,
   useGetVenusLensContract,
 } from 'packages/contractsNew';
+import { useGetTokens } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
@@ -11,7 +12,6 @@ import { callOrThrow } from 'utilities';
 import getVTokens, { GetVTokensOutput } from 'clients/api/queries/getVTokens';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
-import useGetTokens from 'hooks/useGetTokens';
 
 export type UseGetVTokensQueryKey = [
   FunctionKey.GET_VTOKENS,

--- a/src/clients/api/queries/getXvsVaultPoolCount/useGetXvsVaultPoolCount.ts
+++ b/src/clients/api/queries/getXvsVaultPoolCount/useGetXvsVaultPoolCount.ts
@@ -1,4 +1,5 @@
 import { useGetXvsVaultContract } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { callOrThrow } from 'utilities';
 
@@ -6,7 +7,6 @@ import getXvsVaultPoolCount, {
   GetXvsVaultPoolCountOutput,
 } from 'clients/api/queries/getXvsVaultPoolCount';
 import FunctionKey from 'constants/functionKey';
-import useGetToken from 'hooks/useGetToken';
 
 type Options = QueryObserverOptions<
   GetXvsVaultPoolCountOutput,

--- a/src/clients/api/queries/useGetMainPoolTotalXvsDistributed/index.tsx
+++ b/src/clients/api/queries/useGetMainPoolTotalXvsDistributed/index.tsx
@@ -1,9 +1,9 @@
 import BigNumber from 'bignumber.js';
+import { useGetToken } from 'packages/tokens';
 import { useMemo } from 'react';
 import { convertTokensToWei } from 'utilities';
 
 import { useGetMainMarkets } from 'clients/api';
-import useGetToken from 'hooks/useGetToken';
 
 export interface UseGetMainPoolTotalXvsDistributedOutput {
   isLoading: boolean;

--- a/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
@@ -1,4 +1,5 @@
 import { useGetVaiVaultContractAddress } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { useMemo } from 'react';
 import { Vault } from 'types';
 import { areTokensEqual, convertWeiToTokens } from 'utilities';
@@ -10,7 +11,6 @@ import {
   useGetVenusVaiVaultDailyRate,
 } from 'clients/api';
 import { DAYS_PER_YEAR } from 'constants/daysPerYear';
-import useGetToken from 'hooks/useGetToken';
 
 export interface UseGetVaiVaultOutput {
   isLoading: boolean;

--- a/src/clients/api/queries/useGetVaults/useGetVestingVaults/index.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVestingVaults/index.ts
@@ -1,3 +1,4 @@
+import { useGetToken, useGetTokens } from 'packages/tokens';
 import { useMemo } from 'react';
 import { UseQueryResult } from 'react-query';
 import { Vault } from 'types';
@@ -13,8 +14,6 @@ import {
 } from 'clients/api';
 import { BLOCKS_PER_DAY } from 'constants/bsc';
 import { DAYS_PER_YEAR } from 'constants/daysPerYear';
-import useGetToken from 'hooks/useGetToken';
-import useGetTokens from 'hooks/useGetTokens';
 import findTokenByAddress from 'utilities/findTokenByAddress';
 
 import useGetXvsVaultPoolBalances from './useGetXvsVaultPoolBalances';

--- a/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPoolBalances.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPoolBalances.ts
@@ -1,10 +1,10 @@
 import { useGetXvsVaultContractAddress } from 'packages/contractsNew';
+import { useGetTokens } from 'packages/tokens';
 import { UseQueryOptions, UseQueryResult, useQueries } from 'react-query';
 
 import { GetBalanceOfOutput, getBalanceOf } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
-import useGetTokens from 'hooks/useGetTokens';
 import findTokenByAddress from 'utilities/findTokenByAddress';
 
 export interface UseGetXvsVaultPoolBalancesInput {

--- a/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPools.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPools.ts
@@ -1,4 +1,5 @@
 import { useGetXvsVaultContract } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import { UseQueryOptions, UseQueryResult, useQueries } from 'react-query';
 import { callOrThrow } from 'utilities';
 
@@ -11,7 +12,6 @@ import {
   getXvsVaultUserInfo,
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
-import useGetToken from 'hooks/useGetToken';
 
 export interface UseGetXvsVaultPoolsInput {
   poolsCount: number;

--- a/src/components/ActiveVotingProgress/index.tsx
+++ b/src/components/ActiveVotingProgress/index.tsx
@@ -1,11 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import { BigNumber } from 'bignumber.js';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
 import { convertWeiToTokens } from 'utilities';
 
-import useGetToken from 'hooks/useGetToken';
 import { PALETTE } from 'theme/MuiThemeProvider/muiTheme';
 
 import { LabeledProgressBar } from '../ProgressBar/LabeledProgressBar';

--- a/src/components/Layout/ClaimRewardButton/useGetGroups.ts
+++ b/src/components/Layout/ClaimRewardButton/useGetGroups.ts
@@ -1,9 +1,9 @@
+import { useGetToken } from 'packages/tokens';
 import { useMemo } from 'react';
 import { useTranslation } from 'translation';
 
 import { Claim, useGetPendingRewards, useGetPools } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import { Group } from './types';
 

--- a/src/components/Layout/Footer/index.tsx
+++ b/src/components/Layout/Footer/index.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource @emotion/react */
 import Typography from '@mui/material/Typography';
+import { useGetToken } from 'packages/tokens';
 import React from 'react';
 import { useTranslation } from 'translation';
 import { generateBscScanUrl } from 'utilities';
@@ -8,7 +9,6 @@ import { useGetBlockNumber } from 'clients/api';
 import { Icon } from 'components/Icon';
 import { EXPLORER_URLS } from 'constants/bsc';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import {
   VENUS_DISCORD_URL,

--- a/src/components/ReadableActionSignature/index.tsx
+++ b/src/components/ReadableActionSignature/index.tsx
@@ -1,12 +1,12 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
+import { useGetTokens } from 'packages/tokens';
 import React from 'react';
 import { ChainId, ProposalAction, Token, VToken } from 'types';
 import { generateBscScanUrl } from 'utilities';
 
 import { useGetVTokens } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetTokens from 'hooks/useGetTokens';
 import { FormValues } from 'pages/Governance/ProposalList/CreateProposalModal/proposalSchema';
 
 import formatSignature from './formatSignature';

--- a/src/components/SelectTokenTextField/TokenList/index.tsx
+++ b/src/components/SelectTokenTextField/TokenList/index.tsx
@@ -1,11 +1,10 @@
 /** @jsxImportSource @emotion/react */
 import { Typography } from '@mui/material';
+import { useGetTokens } from 'packages/tokens';
 import React, { InputHTMLAttributes, useMemo, useState } from 'react';
 import { useTranslation } from 'translation';
 import { Token, TokenBalance } from 'types';
 import { convertWeiToTokens } from 'utilities';
-
-import useGetTokens from 'hooks/useGetTokens';
 
 import { SenaryButton } from '../../Button';
 import { TextField } from '../../TextField';

--- a/src/containers/PrimeStatusBanner/index.tsx
+++ b/src/containers/PrimeStatusBanner/index.tsx
@@ -4,6 +4,7 @@ import Paper from '@mui/material/Paper';
 import BigNumber from 'bignumber.js';
 import formatDistanceStrict from 'date-fns/formatDistanceStrict';
 import { ContractReceipt } from 'ethers';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import { useTranslation } from 'translation';
@@ -18,7 +19,6 @@ import { Tooltip } from 'components/Tooltip';
 import { routes } from 'constants/routing';
 import useFormatPercentageToReadableValue from 'hooks/useFormatPercentageToReadableValue';
 import useConvertWeiToReadableTokenString from 'hooks/useFormatTokensToReadableValue';
-import useGetToken from 'hooks/useGetToken';
 import useHandleTransactionMutation from 'hooks/useHandleTransactionMutation';
 
 import { useStyles } from './styles';

--- a/src/hooks/useGetSwapInfo/index.ts
+++ b/src/hooks/useGetSwapInfo/index.ts
@@ -6,13 +6,13 @@ import {
   TradeType as PSTradeType,
 } from '@pancakeswap/sdk/dist/index.js';
 import BigNumber from 'bignumber.js';
+import { useGetToken } from 'packages/tokens';
 import { useMemo } from 'react';
 import { SwapError } from 'types';
 import { areTokensEqual, convertTokensToWei } from 'utilities';
 
 import { useGetPancakeSwapPairs } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import formatToSwap from './formatToSwap';
 import { UseGetSwapInfoInput, UseGetSwapInfoOutput } from './types';

--- a/src/hooks/useGetSwapInfo/useGetTokenCombinations.ts
+++ b/src/hooks/useGetSwapInfo/useGetTokenCombinations.ts
@@ -1,11 +1,11 @@
 import { Token as PSToken } from '@pancakeswap/sdk/dist/index.js';
 import flatMap from 'lodash/flatMap';
+import { useGetToken } from 'packages/tokens';
 import { useMemo } from 'react';
 import { ChainId, PSTokenCombination, Token } from 'types';
 
 import { useAuth } from 'context/AuthContext';
 import useGetPancakeSwapTokens from 'hooks/useGetPancakeSwapTokens';
-import useGetToken from 'hooks/useGetToken';
 
 import wrapToken from './wrapToken';
 

--- a/src/packages/tokens/__mocks__/index.ts
+++ b/src/packages/tokens/__mocks__/index.ts
@@ -1,6 +1,9 @@
 import tokens from '__mocks__/models/tokens';
 
-export * from '../tokenInfos';
-export const getTokens = vi.fn(() => tokens);
+export * from 'packages/tokens/hooks/useGetToken';
+export * from 'packages/tokens/hooks/useGetTokens';
+export * from 'packages/tokens/tokenInfos';
+
 export const getPancakeSwapTokens = vi.fn(() => tokens);
 export const isTokenActionEnabled = vi.fn(() => true);
+export const getTokens = vi.fn(() => tokens);

--- a/src/packages/tokens/hooks/useGetToken/__tests__/index.spec.ts
+++ b/src/packages/tokens/hooks/useGetToken/__tests__/index.spec.ts
@@ -1,0 +1,35 @@
+import { renderHook } from '@testing-library/react-hooks';
+import Vi from 'vitest';
+
+import tokens, { xvs } from '__mocks__/models/tokens';
+import { useGetTokens } from 'packages/tokens/hooks/useGetTokens';
+
+import { useGetToken } from '..';
+
+vi.mock('packages/tokens/hooks/useGetTokens');
+
+describe('useGetToken', () => {
+  beforeEach(() => {
+    (useGetTokens as Vi.Mock).mockImplementation(() => tokens);
+  });
+
+  it('returns token when a corresponding symbol is found', () => {
+    const { result } = renderHook(() =>
+      useGetToken({
+        symbol: 'XVS',
+      }),
+    );
+
+    expect(result.current).toBe(xvs);
+  });
+
+  it('returns undefined when no corresponding token is found', () => {
+    const { result } = renderHook(() =>
+      useGetToken({
+        symbol: 'INVALID-TOKEN-SYMBOL',
+      }),
+    );
+
+    expect(result.current).toBe(undefined);
+  });
+});

--- a/src/packages/tokens/hooks/useGetToken/index.ts
+++ b/src/packages/tokens/hooks/useGetToken/index.ts
@@ -1,15 +1,12 @@
 import { useMemo } from 'react';
 
-import useGetTokens from './useGetTokens';
+import { useGetTokens } from '../useGetTokens';
 
 export interface UseGetTokenInput {
   symbol: string;
 }
 
-// TODO: move to tokens package
-function useGetToken({ symbol }: UseGetTokenInput) {
+export const useGetToken = ({ symbol }: UseGetTokenInput) => {
   const tokens = useGetTokens();
   return useMemo(() => tokens.find(token => token.symbol === symbol), [tokens]);
-}
-
-export default useGetToken;
+};

--- a/src/packages/tokens/hooks/useGetTokens/__tests__/index.spec.ts
+++ b/src/packages/tokens/hooks/useGetTokens/__tests__/index.spec.ts
@@ -1,0 +1,30 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { ChainId } from 'types';
+import Vi from 'vitest';
+
+import tokens from '__mocks__/models/tokens';
+import { useAuth } from 'context/AuthContext';
+import { getTokens } from 'packages/tokens/utilities/getTokens';
+
+import { useGetTokens } from '..';
+
+vi.mock('context/AuthContext');
+vi.mock('packages/tokens/utilities/getTokens');
+
+describe('useGetTokens', () => {
+  beforeEach(() => {
+    (useAuth as Vi.Mock).mockImplementation(() => ({
+      chainId: ChainId.BSC_TESTNET,
+    }));
+    (getTokens as Vi.Mock).mockImplementation(() => tokens);
+  });
+
+  it('returns tokens', () => {
+    const { result } = renderHook(() => useGetTokens());
+
+    expect(result.current).toBe(tokens);
+    expect(getTokens).toHaveBeenCalledWith({
+      chainId: ChainId.BSC_TESTNET,
+    });
+  });
+});

--- a/src/packages/tokens/hooks/useGetTokens/index.ts
+++ b/src/packages/tokens/hooks/useGetTokens/index.ts
@@ -1,10 +1,9 @@
-import { getTokens } from 'packages/tokens';
 import { useMemo } from 'react';
 
+import { getTokens } from '../../utilities/getTokens';
 import { useAuth } from 'context/AuthContext';
 
-// TODO: move to tokens package
-function useGetTokens() {
+export const useGetTokens = () => {
   const { chainId } = useAuth();
 
   return useMemo(
@@ -14,6 +13,4 @@ function useGetTokens() {
       }),
     [chainId],
   );
-}
-
-export default useGetTokens;
+};

--- a/src/packages/tokens/index.ts
+++ b/src/packages/tokens/index.ts
@@ -2,3 +2,5 @@ export * from './tokenInfos';
 export * from './utilities/getTokens';
 export * from './utilities/getPancakeSwapTokens';
 export * from './utilities/isTokenActionEnabled';
+export * from './hooks/useGetToken';
+export * from './hooks/useGetTokens';

--- a/src/packages/tokens/index.ts
+++ b/src/packages/tokens/index.ts
@@ -1,4 +1,4 @@
 export * from './tokenInfos';
-export * from './getTokens';
-export * from './getPancakeSwapTokens';
-export * from './isTokenActionEnabled';
+export * from './utilities/getTokens';
+export * from './utilities/getPancakeSwapTokens';
+export * from './utilities/isTokenActionEnabled';

--- a/src/packages/tokens/utilities/getPancakeSwapTokens/__tests__/index.spec.ts
+++ b/src/packages/tokens/utilities/getPancakeSwapTokens/__tests__/index.spec.ts
@@ -1,5 +1,6 @@
+import pancakeSwapTokens from 'packages/tokens/tokenInfos/pancakeSwapTokens';
+
 import { getPancakeSwapTokens } from '..';
-import pancakeSwapTokens from '../../tokenInfos/pancakeSwapTokens';
 
 describe('getPancakeSwapTokens', () => {
   it('returns all the tokens relevant to the passed chain ID', () => {

--- a/src/packages/tokens/utilities/getPancakeSwapTokens/index.ts
+++ b/src/packages/tokens/utilities/getPancakeSwapTokens/index.ts
@@ -1,5 +1,6 @@
-import pancakeSwapTokens from 'packages/tokens/tokenInfos/pancakeSwapTokens';
 import { ChainId } from 'types';
+
+import pancakeSwapTokens from '../../tokenInfos/pancakeSwapTokens';
 
 export interface GetPancakeSwapTokensInput {
   chainId: ChainId;

--- a/src/packages/tokens/utilities/getPancakeSwapTokens/index.ts
+++ b/src/packages/tokens/utilities/getPancakeSwapTokens/index.ts
@@ -1,6 +1,5 @@
+import pancakeSwapTokens from 'packages/tokens/tokenInfos/pancakeSwapTokens';
 import { ChainId } from 'types';
-
-import pancakeSwapTokens from '../tokenInfos/pancakeSwapTokens';
 
 export interface GetPancakeSwapTokensInput {
   chainId: ChainId;

--- a/src/packages/tokens/utilities/getTokens/__tests__/index.spec.ts
+++ b/src/packages/tokens/utilities/getTokens/__tests__/index.spec.ts
@@ -1,5 +1,6 @@
+import { tokens } from 'packages/tokens/tokenInfos/commonTokens';
+
 import { getTokens } from '..';
-import { tokens } from '../../tokenInfos/commonTokens';
 
 describe('getTokens', () => {
   it('returns all the tokens relevant to the passed chain ID', () => {

--- a/src/packages/tokens/utilities/getTokens/index.ts
+++ b/src/packages/tokens/utilities/getTokens/index.ts
@@ -1,5 +1,6 @@
-import { tokens } from 'packages/tokens/tokenInfos/commonTokens';
 import { ChainId } from 'types';
+
+import { tokens } from '../../tokenInfos/commonTokens';
 
 export interface GetTokensInput {
   chainId: ChainId;

--- a/src/packages/tokens/utilities/getTokens/index.ts
+++ b/src/packages/tokens/utilities/getTokens/index.ts
@@ -1,6 +1,5 @@
+import { tokens } from 'packages/tokens/tokenInfos/commonTokens';
 import { ChainId } from 'types';
-
-import { tokens } from '../tokenInfos/commonTokens';
 
 export interface GetTokensInput {
   chainId: ChainId;

--- a/src/packages/tokens/utilities/isTokenActionEnabled/index.tsx
+++ b/src/packages/tokens/utilities/isTokenActionEnabled/index.tsx
@@ -1,8 +1,7 @@
+import disabledTokenActions from 'packages/tokens/tokenInfos/disabledTokenActions';
 import { ChainId, TokenAction } from 'types';
 
 import areAddressesEqual from 'utilities/areAddressesEqual';
-
-import disabledTokenActions from '../tokenInfos/disabledTokenActions';
 
 export interface IsTokenActionEnabledInput {
   tokenAddress: string;

--- a/src/packages/tokens/utilities/isTokenActionEnabled/index.tsx
+++ b/src/packages/tokens/utilities/isTokenActionEnabled/index.tsx
@@ -1,7 +1,8 @@
-import disabledTokenActions from 'packages/tokens/tokenInfos/disabledTokenActions';
 import { ChainId, TokenAction } from 'types';
 
 import areAddressesEqual from 'utilities/areAddressesEqual';
+
+import disabledTokenActions from '../../tokenInfos/disabledTokenActions';
 
 export interface IsTokenActionEnabledInput {
   tokenAddress: string;

--- a/src/pages/Account/AccountBreakdown/index.tsx
+++ b/src/pages/Account/AccountBreakdown/index.tsx
@@ -1,13 +1,13 @@
 /** @jsxImportSource @emotion/react */
 import BigNumber from 'bignumber.js';
 import { Spinner } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { Pool, Vault } from 'types';
 import { areTokensEqual } from 'utilities';
 
 import { useGetPools, useGetVaults } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from '../styles';
 import AccountPlaceholder from './AccountPlaceholder';

--- a/src/pages/ConvertVrt/Withdraw/index.tsx
+++ b/src/pages/ConvertVrt/Withdraw/index.tsx
@@ -3,12 +3,12 @@ import { Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
 import { ConnectWallet, PrimaryButton, TokenIcon } from 'components';
 import { ContractReceipt } from 'ethers';
+import { useGetToken } from 'packages/tokens';
 import React, { useContext } from 'react';
 import { useTranslation } from 'translation';
 
 import { DisableLunaUstWarningContext } from 'context/DisableLunaUstWarning';
 import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTokenString';
-import useGetToken from 'hooks/useGetToken';
 import useHandleTransactionMutation from 'hooks/useHandleTransactionMutation';
 
 import { useStyles } from '../styles';

--- a/src/pages/ConvertVrt/index.tsx
+++ b/src/pages/ConvertVrt/index.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import Paper from '@mui/material/Paper';
 import { Spinner, Tabs } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { convertWeiToTokens } from 'utilities';
@@ -12,7 +13,6 @@ import {
   useWithdrawXvs,
 } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import Convert from './Convert';
 import Withdraw, { WithdrawProps } from './Withdraw';

--- a/src/pages/Governance/ProposalList/CreateProposalModal/ProposalPreview/index.tsx
+++ b/src/pages/Governance/ProposalList/CreateProposalModal/ProposalPreview/index.tsx
@@ -2,11 +2,10 @@
 import { Typography } from '@mui/material';
 import { MarkdownViewer, ReadableActionSignature } from 'components';
 import { useFormikContext } from 'formik';
+import { useGetTokens } from 'packages/tokens';
 import React from 'react';
 import { useTranslation } from 'translation';
 import { ProposalType } from 'types';
-
-import useGetTokens from 'hooks/useGetTokens';
 
 import { FormValues } from '../proposalSchema';
 import { useStyles } from './styles';

--- a/src/pages/Governance/VotingWallet/index.tsx
+++ b/src/pages/Governance/VotingWallet/index.tsx
@@ -11,6 +11,7 @@ import {
   TokenIcon,
 } from 'components';
 import { ContractReceipt } from 'ethers';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'translation';
@@ -26,7 +27,6 @@ import {
 import { routes } from 'constants/routing';
 import { XVS_SNAPSHOT_URL } from 'constants/xvsSnapshotUrl';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 
 import DelegateModal from './DelegateModal';

--- a/src/pages/Proposal/VoteModal/index.tsx
+++ b/src/pages/Proposal/VoteModal/index.tsx
@@ -2,10 +2,10 @@
 import { FormikSubmitButton, FormikTextField, Modal, TextField } from 'components';
 import { ContractReceipt } from 'ethers';
 import { Form, Formik } from 'formik';
+import { useGetToken } from 'packages/tokens';
 import React from 'react';
 import { useTranslation } from 'translation';
 
-import useGetToken from 'hooks/useGetToken';
 import useHandleTransactionMutation from 'hooks/useHandleTransactionMutation';
 
 import { useStyles } from './styles';

--- a/src/pages/Proposal/VoteSummary/index.tsx
+++ b/src/pages/Proposal/VoteSummary/index.tsx
@@ -3,6 +3,7 @@ import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
 import { BigNumber } from 'bignumber.js';
 import { Button, EllipseAddress, Icon, LabeledProgressBar, Tooltip } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React, { useCallback } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'translation';
@@ -10,7 +11,6 @@ import { VotersDetails } from 'types';
 import { convertWeiToTokens } from 'utilities';
 
 import { routes } from 'constants/routing';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from './styles';
 

--- a/src/pages/Proposal/index.tsx
+++ b/src/pages/Proposal/index.tsx
@@ -2,6 +2,7 @@
 import { BigNumber } from 'bignumber.js';
 import { Spinner } from 'components';
 import { ContractReceipt } from 'ethers';
+import { useGetToken, useGetTokens } from 'packages/tokens';
 import React, { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useTranslation } from 'translation';
@@ -10,8 +11,6 @@ import { convertWeiToTokens } from 'utilities';
 
 import { useGetCurrentVotes, useGetProposal, useGetVoteReceipt, useGetVoters } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
-import useGetTokens from 'hooks/useGetTokens';
 import useVote, { UseVoteParams } from 'hooks/useVote';
 
 import { Description } from './Description';

--- a/src/pages/Swap/index.tsx
+++ b/src/pages/Swap/index.tsx
@@ -17,6 +17,7 @@ import {
   useGetMainPoolComptrollerContractAddress,
   useGetSwapRouterContractAddress,
 } from 'packages/contractsNew';
+import { useGetToken, useGetTokens } from 'packages/tokens';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'translation';
 import { Swap, SwapError, TokenBalance } from 'types';
@@ -27,8 +28,6 @@ import { useAuth } from 'context/AuthContext';
 import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTokenString';
 import useGetSwapInfo from 'hooks/useGetSwapInfo';
 import useGetSwapTokenUserBalances from 'hooks/useGetSwapTokenUserBalances';
-import useGetToken from 'hooks/useGetToken';
-import useGetTokens from 'hooks/useGetTokens';
 import useSuccessfulTransactionModal from 'hooks/useSuccessfulTransactionModal';
 import useTokenApproval from 'hooks/useTokenApproval';
 

--- a/src/pages/Vai/MintVai/index.tsx
+++ b/src/pages/Vai/MintVai/index.tsx
@@ -10,6 +10,7 @@ import {
 } from 'components';
 import { VError } from 'errors';
 import { ContractReceipt } from 'ethers';
+import { useGetToken } from 'packages/tokens';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
@@ -31,7 +32,6 @@ import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { AmountForm, AmountFormProps } from 'containers/AmountForm';
 import { useAuth } from 'context/AuthContext';
 import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTokenString';
-import useGetToken from 'hooks/useGetToken';
 import useHandleTransactionMutation from 'hooks/useHandleTransactionMutation';
 
 import { useStyles } from '../styles';

--- a/src/pages/Vai/RepayVai/RepayFee.tsx
+++ b/src/pages/Vai/RepayVai/RepayFee.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import BigNumber from 'bignumber.js';
 import { LabeledInlineContent } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React, { useContext, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { convertTokensToWei, convertWeiToTokens } from 'utilities';
@@ -8,7 +9,6 @@ import { convertTokensToWei, convertWeiToTokens } from 'utilities';
 import { useGetVaiCalculateRepayAmount } from 'clients/api';
 import { AuthContext } from 'context/AuthContext';
 import useDebounceValue from 'hooks/useDebounceValue';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from '../styles';
 

--- a/src/pages/Vai/RepayVai/index.tsx
+++ b/src/pages/Vai/RepayVai/index.tsx
@@ -14,6 +14,7 @@ import {
 } from 'components';
 import { ContractReceipt } from 'ethers';
 import { useGetVaiControllerContractAddress } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import React, { useCallback, useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
@@ -28,7 +29,6 @@ import MAX_UINT256 from 'constants/maxUint256';
 import { AmountForm, AmountFormProps } from 'containers/AmountForm';
 import { useAuth } from 'context/AuthContext';
 import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTokenString';
-import useGetToken from 'hooks/useGetToken';
 import useHandleTransactionMutation from 'hooks/useHandleTransactionMutation';
 import useTokenApproval from 'hooks/useTokenApproval';
 

--- a/src/pages/Vault/modals/WithdrawFromVaiVaultModal/index.tsx
+++ b/src/pages/Vault/modals/WithdrawFromVaiVaultModal/index.tsx
@@ -1,11 +1,11 @@
 /** @jsxImportSource @emotion/react */
 import BigNumber from 'bignumber.js';
+import { useGetToken } from 'packages/tokens';
 import React from 'react';
 import { useTranslation } from 'translation';
 
 import { useGetVaiVaultUserInfo, useWithdrawFromVaiVault } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import ActionModal, { ActionModalProps } from '../ActionModal';
 

--- a/src/pages/Vault/modals/WithdrawFromVestingVaultModal/RequestWithdrawal/index.tsx
+++ b/src/pages/Vault/modals/WithdrawFromVestingVaultModal/RequestWithdrawal/index.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import BigNumber from 'bignumber.js';
 import { ConnectWallet, Spinner, TextButton } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
@@ -12,7 +13,6 @@ import {
   useRequestWithdrawalFromXvsVault,
 } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import TransactionForm, { TransactionFormProps } from '../../../TransactionForm';
 import { useStyles as useSharedStyles } from '../styles';

--- a/src/pages/Vault/modals/WithdrawFromVestingVaultModal/Withdraw/index.tsx
+++ b/src/pages/Vault/modals/WithdrawFromVestingVaultModal/Withdraw/index.tsx
@@ -2,6 +2,7 @@
 import BigNumber from 'bignumber.js';
 import { ConnectWallet, LabeledInlineContent, PrimaryButton, Spinner } from 'components';
 import isBefore from 'date-fns/isBefore';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { Token } from 'types';
@@ -9,7 +10,6 @@ import { Token } from 'types';
 import { useExecuteWithdrawalFromXvsVault, useGetXvsVaultLockedDeposits } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
 import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTokenString';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from './styles';
 import TEST_IDS from './testIds';

--- a/src/pages/Vault/modals/WithdrawFromVestingVaultModal/WithdrawalRequestList/index.tsx
+++ b/src/pages/Vault/modals/WithdrawFromVestingVaultModal/WithdrawalRequestList/index.tsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import Typography from '@mui/material/Typography';
 import { ConnectWallet, LabeledInlineContent, Spinner } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React from 'react';
 import { useTranslation } from 'translation';
 import { LockedDeposit, Token } from 'types';
@@ -8,7 +9,6 @@ import { convertWeiToTokens } from 'utilities';
 
 import { useGetXvsVaultLockedDeposits } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from './styles';
 import TEST_IDS from './testIds';

--- a/src/pages/Voter/Holding/index.tsx
+++ b/src/pages/Voter/Holding/index.tsx
@@ -2,12 +2,12 @@
 import { Paper, Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
 import { Delimiter, Icon } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React from 'react';
 import { useTranslation } from 'translation';
 
 import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import useConvertWeiToReadableTokenString from 'hooks/useConvertWeiToReadableTokenString';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from './styles';
 

--- a/src/pages/Voter/Transactions/index.tsx
+++ b/src/pages/Voter/Transactions/index.tsx
@@ -2,6 +2,7 @@
 import { Paper, Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
 import { AnchorButton, Icon, Spinner, Table, TableColumn } from 'components';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { VoteDetailTransaction } from 'types';
@@ -9,7 +10,6 @@ import { convertWeiToTokens, generateBscScanUrl } from 'utilities';
 
 import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from './styles';
 

--- a/src/pages/VoterLeaderboard/LeaderboardTable/index.tsx
+++ b/src/pages/VoterLeaderboard/LeaderboardTable/index.tsx
@@ -2,6 +2,7 @@
 import { Typography } from '@mui/material';
 import { EllipseAddress, Table, TableColumn } from 'components';
 import _cloneDeep from 'lodash/cloneDeep';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'translation';
@@ -9,7 +10,6 @@ import { VoterAccount } from 'types';
 import { convertWeiToTokens, formatPercentageToReadableValue } from 'utilities';
 
 import { routes } from 'constants/routing';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from './styles';
 

--- a/src/pages/Xvs/Header/index.tsx
+++ b/src/pages/Xvs/Header/index.tsx
@@ -3,6 +3,7 @@ import { Paper, Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
 import { EllipseAddress, Icon, LabeledProgressBar, TokenIcon } from 'components';
 import { useGetMainPoolComptrollerContractAddress } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { RewardDistributorDistribution, Token } from 'types';
@@ -16,7 +17,6 @@ import {
 } from 'clients/api';
 import { useAuth } from 'context/AuthContext';
 import useCopyToClipboard from 'hooks/useCopyToClipboard';
-import useGetToken from 'hooks/useGetToken';
 
 import { MINTED_XVS_WEI } from '../constants';
 import { useStyles } from '../styles';

--- a/src/pages/Xvs/Table/index.tsx
+++ b/src/pages/Xvs/Table/index.tsx
@@ -3,6 +3,7 @@ import { Typography } from '@mui/material';
 import BigNumber from 'bignumber.js';
 import { Table, TableColumn, TokenIconWithSymbol } from 'components';
 import { useGetVaiControllerContractAddress } from 'packages/contractsNew';
+import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
 import { useTranslation } from 'translation';
 import { RewardDistributorDistribution, Token } from 'types';
@@ -17,7 +18,6 @@ import {
 import { useGetBalanceOf, useGetMainPool, useGetVenusVaiVaultDailyRate } from 'clients/api';
 import { DAYS_PER_YEAR } from 'constants/daysPerYear';
 import { useAuth } from 'context/AuthContext';
-import useGetToken from 'hooks/useGetToken';
 
 import { useStyles } from '../styles';
 


### PR DESCRIPTION
## Changes

- move `useGetToken` and `useGetTokens` hooks to tokens packages
- move token utilities into a utilities directory in the tokens package 
