### PR TITLE
feat: update default error thrown by callOrThrow

### DIFF
--- a/src/errors/unexpectedErrorPhrases.ts
+++ b/src/errors/unexpectedErrorPhrases.ts
@@ -6,6 +6,7 @@ export const unexpectedErrorPhrases = {
   somethingWentWrongRetrievingVoterAccounts: t('errors.somethingWentWrongRetrievingVoterAccounts'),
   somethingWentWrongRetrievingVoterDetails: t('errors.somethingWentWrongRetrievingVoterDetails'),
   somethingWentWrongRetrievingVoterHistory: t('errors.somethingWentWrongRetrievingVoterHistory'),
+  couldNotRetrieveSigner: t('errors.couldNotRetrieveSigner'),
   walletNotConnected: t('errors.walletNotConnected'),
   undefinedAccountErrorMessage: t('errors.undefinedAccountErrorMessage'),
   internalErrorXvsToVrtConversionRatioUndefined: t(

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -210,10 +210,11 @@
     "noTargetsKey": "File does not contain the list of targets",
     "noTypeKey": "File does not indicate the proposal's type",
     "somethingWentWrong": "Something went wrong",
+    "couldNotRetrieveSigner": "Signer could not be retrieved, please make sure your wallet is unlocked",
     "somethingWentWrongRetrievingTransactions": "Something went wrong retrieving transactions",
     "somethingWentWrongRetrievingVoterAccounts": "Something went wrong retrieving voter accounts",
     "somethingWentWrongRetrievingVoterDetails": "Something went wrong retrieving voter details",
-    "somethingWentWrongRetrievingVoterHistory": "Something went wrong retrieving voter history  ",
+    "somethingWentWrongRetrievingVoterHistory": "Something went wrong retrieving voter history",
     "undefinedAccountErrorMessage": "Account undefined",
     "validationError": "Validation failed for imported proposal:",
     "walletNotConnected": "Wallet not connected"

--- a/src/utilities/callOrThrow/__tests__/index.spec.ts
+++ b/src/utilities/callOrThrow/__tests__/index.spec.ts
@@ -15,7 +15,7 @@ describe('utilities/callOrThrow', () => {
 
       throw new Error('callOrThrow should have thrown an error but did not');
     } catch (error) {
-      expect(error).toMatchInlineSnapshot('[Error: somethingWentWrong]');
+      expect(error).toMatchInlineSnapshot('[Error: couldNotRetrieveSigner]');
     }
   });
 

--- a/src/utilities/callOrThrow/index.ts
+++ b/src/utilities/callOrThrow/index.ts
@@ -1,4 +1,4 @@
-import { VError } from 'errors';
+import { VError, VErrorPhraseMap } from 'errors';
 import { NonNullableFields } from 'types';
 
 import { logError } from 'context/ErrorLogger';
@@ -6,12 +6,13 @@ import { logError } from 'context/ErrorLogger';
 function callOrThrow<TParams extends Record<string, unknown>, TReturn>(
   params: TParams,
   callback: (sanitizedParams: NonNullableFields<TParams>) => TReturn,
+  errorCodeOnThrow: VErrorPhraseMap['unexpected'] = 'couldNotRetrieveSigner',
 ): TReturn {
   // Throw if a param is undefined or null
   Object.entries(params).forEach(([key, value]) => {
     if (value === undefined || value === null) {
       logError(`Required parameter ${key} cannot be null or undefined`);
-      throw new VError({ type: 'unexpected', code: 'somethingWentWrong' });
+      throw new VError({ type: 'unexpected', code: errorCodeOnThrow });
     }
   });
 


### PR DESCRIPTION
## Changes

- update `callOrThrow` so it takes a third optional parameter representing the code of the error when throwing
- update default error thrown by `callOrThrow` to one that asks users to unlock their wallet. `callOrThrow` is currently exclusively used to ensure the needed contracts are defined when sending transactions. The most likely scenario for a contract not to be defined when sending a transaction is that a signer could not be retrieved despite an account address being set in the auth context. The most likely reason for this case to happen is that a user kept the dApp opened up until their wallet locked itself, therefore we now display a more suiting default error message.
