### PR TITLE
feat: update PrimeStatusBanner to show amount of prime tokens left

### DIFF
--- a/src/components/Card/index.tsx
+++ b/src/components/Card/index.tsx
@@ -7,5 +7,5 @@ interface CardProps {
 }
 
 export const Card: React.FC<CardProps> = ({ children, className }) => (
-  <div className={cn('w-full rounded-2xl bg-cards p-4 md:p-6', className)}>{children}</div>
+  <div className={cn('w-full rounded-2xl bg-cards p-4 sm:p-6', className)}>{children}</div>
 );

--- a/src/containers/PrimeStatusBanner/PrimeTokensLeft/index.tsx
+++ b/src/containers/PrimeStatusBanner/PrimeTokensLeft/index.tsx
@@ -1,0 +1,26 @@
+import { useTranslation } from 'translation';
+
+interface PrimeTokensLeftProps {
+  tokensLeft: number;
+}
+
+const PrimeTokensLeft = ({ tokensLeft }: PrimeTokensLeftProps) => {
+  const { Trans } = useTranslation();
+  return (
+    <div className="flex flex-row rounded-full border border-yellow bg-[#2E2C2A] px-3 py-1 text-xs font-semibold uppercase lining-nums proportional-nums leading-[15px] tracking-[0.5px] text-yellow [font-variant:all-small-caps]">
+      <p>
+        <Trans
+          i18nKey="primeStatusBanner.tokensLeft"
+          components={{
+            WhiteText: <span className="text-offWhite" />,
+          }}
+          values={{
+            tokensLeft,
+          }}
+        />
+      </p>
+    </div>
+  );
+};
+
+export default PrimeTokensLeft;

--- a/src/containers/PrimeStatusBanner/index.tsx
+++ b/src/containers/PrimeStatusBanner/index.tsx
@@ -144,12 +144,12 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
       className={cn(
         'relative flex flex-col content-center md:flex-row md:justify-between',
         isUserXvsStakeHighEnoughForPrime && 'items-start md:items-center',
-        shouldShowPrimeTokensLeftIndicator && 'mt-[12.5px]',
+        shouldShowPrimeTokensLeftIndicator && 'mt-3',
         className,
       )}
     >
       {shouldShowPrimeTokensLeftIndicator && (
-        <div className="absolute top-0 -mt-3 max-sm:right-4 sm:left-18 md:left-20">
+        <div className="absolute top-0 -mt-3 right-4 sm:right-auto sm:left-18 md:left-20">
           <PrimeTokensLeft tokensLeft={primeTokensLeft} />
         </div>
       )}

--- a/src/containers/PrimeStatusBanner/index.tsx
+++ b/src/containers/PrimeStatusBanner/index.tsx
@@ -18,6 +18,8 @@ import useFormatPercentageToReadableValue from 'hooks/useFormatPercentageToReada
 import useConvertWeiToReadableTokenString from 'hooks/useFormatTokensToReadableValue';
 import useHandleTransactionMutation from 'hooks/useHandleTransactionMutation';
 
+import PrimeTokensLeft from './PrimeTokensLeft';
+
 export interface PrimeStatusBannerUiProps {
   xvs: Token;
   claimedPrimeTokenCount: number;
@@ -49,6 +51,9 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
 }) => {
   const { Trans, t } = useTranslation();
   const handleTransactionMutation = useHandleTransactionMutation();
+  const last5Percent = primeTokenLimit * 0.05;
+  const primeTokensLeft = primeTokenLimit - claimedPrimeTokenCount;
+  const shouldShowPrimeTokensLeftIndicator = primeTokensLeft > 0 && primeTokensLeft <= last5Percent;
 
   const handleClaimPrimeToken = () =>
     handleTransactionMutation({
@@ -137,11 +142,18 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
   return (
     <Card
       className={cn(
-        'flex flex-col content-center md:flex-row md:justify-between',
+        'relative flex flex-col content-center md:flex-row md:justify-between',
         isUserXvsStakeHighEnoughForPrime && 'items-start md:items-center',
+        shouldShowPrimeTokensLeftIndicator && 'mt-[12.5px]',
         className,
       )}
     >
+      {shouldShowPrimeTokensLeftIndicator && (
+        <div className="absolute top-0 -mt-3 max-sm:right-4 sm:left-18 md:left-20">
+          <PrimeTokensLeft tokensLeft={primeTokensLeft} />
+        </div>
+      )}
+
       <div
         className={cn(
           'w-full md:w-auto md:flex-1',
@@ -279,10 +291,10 @@ const PrimeStatusBanner: React.FC<PrimeStatusBannerProps> = props => {
   // TODO: wire up
   const isLoading = false;
   const primeClaimWaitingPeriodSeconds = 90 * 24 * 60 * 60; // 90 days in seconds
-  const userStakedXvsTokens = new BigNumber('1000');
+  const userStakedXvsTokens = new BigNumber('100');
   const minXvsToStakeForPrimeTokens = new BigNumber('1000');
   const highestPrimeSimulationApyBoostPercentage = new BigNumber('3.14');
-  const claimedPrimeTokenCount = 1000;
+  const claimedPrimeTokenCount = 975;
   const primeTokenLimit = 1000;
 
   const claimPrimeToken = async () => fakeContractReceipt;

--- a/src/context/AuthContext/index.tsx
+++ b/src/context/AuthContext/index.tsx
@@ -64,7 +64,7 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const accountAddress = !!address && isAuthorizedAddress && isConnected ? address : undefined;
 
   // TODO: fetch
-  const isPrime = !!accountAddress;
+  const isPrime = false;
 
   const login = useCallback(async (connectorId: Connector) => {
     // If user is attempting to connect their Infinity wallet but the dApp

--- a/src/translation/translations/en.json
+++ b/src/translation/translations/en.json
@@ -593,6 +593,7 @@
       "message": "You are now a Prime user. Visit the dashboard or the account page to see your earning boosts.",
       "title": "Prime token claimed"
     },
+    "tokensLeft": "<WhiteText>{{tokensLeft}}</WhiteText> prime tokens left",
     "waitForPrimeTitle": "{{claimWaitingPeriod}} until you can become a Prime user"
   },
   "select": {


### PR DESCRIPTION
## Jira ticket(s)

VEN-2058

## Changes

- Condionally displays the amount of prime tokens left above the PrimeStatusBanner, conditions are:
  - User is not prime
  - The amount of prime tokens left is above 0 and below 5% of the total amount
