### PR TITLE
feat: add Prime contract record on testnet

### DIFF
--- a/src/containers/ReadableActionSignature/getContractName.ts
+++ b/src/containers/ReadableActionSignature/getContractName.ts
@@ -35,7 +35,15 @@ const getContractName = ({ target, vTokens, tokens, chainId }: GetContractNameIn
   // Search within contracts
   const matchingUniqueContractInfo = Object.entries(addresses).find(
     ([_uniqueContractName, address]) => {
-      const contractAddress = address[chainId];
+      let contractAddress;
+
+      if (Object.prototype.hasOwnProperty.call(address, chainId)) {
+        contractAddress = address[chainId as keyof typeof address];
+      }
+
+      if (!contractAddress) {
+        return false;
+      }
 
       if (typeof contractAddress === 'string') {
         // Handle unique contracts

--- a/src/packages/contracts/config/externalAbis/Prime.json
+++ b/src/packages/contracts/config/externalAbis/Prime.json
@@ -1,0 +1,767 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_wbnb", "type": "address" },
+      { "internalType": "address", "name": "_vbnb", "type": "address" },
+      { "internalType": "uint256", "name": "_blocksPerYear", "type": "uint256" },
+      { "internalType": "uint256", "name": "_stakingPeriod", "type": "uint256" },
+      { "internalType": "uint256", "name": "_minimumStakedXVS", "type": "uint256" },
+      { "internalType": "uint256", "name": "_maximumXVSCap", "type": "uint256" }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  { "inputs": [], "name": "AssetAlreadyExists", "type": "error" },
+  {
+    "inputs": [{ "internalType": "int256", "name": "x", "type": "int256" }],
+    "name": "ExpTooLarge",
+    "type": "error"
+  },
+  { "inputs": [], "name": "IneligibleToClaim", "type": "error" },
+  { "inputs": [], "name": "InvalidAddress", "type": "error" },
+  { "inputs": [], "name": "InvalidAlphaArguments", "type": "error" },
+  { "inputs": [], "name": "InvalidBlocksPerYear", "type": "error" },
+  { "inputs": [], "name": "InvalidCaller", "type": "error" },
+  { "inputs": [], "name": "InvalidComptroller", "type": "error" },
+  { "inputs": [], "name": "InvalidFixedPoint", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "n", "type": "uint256" },
+      { "internalType": "uint256", "name": "d", "type": "uint256" }
+    ],
+    "name": "InvalidFraction",
+    "type": "error"
+  },
+  { "inputs": [], "name": "InvalidLimit", "type": "error" },
+  { "inputs": [], "name": "InvalidVToken", "type": "error" },
+  {
+    "inputs": [{ "internalType": "int256", "name": "x", "type": "int256" }],
+    "name": "LnNonRealResult",
+    "type": "error"
+  },
+  {
+    "inputs": [{ "internalType": "int256", "name": "x", "type": "int256" }],
+    "name": "LnTooLarge",
+    "type": "error"
+  },
+  { "inputs": [], "name": "MarketAlreadyExists", "type": "error" },
+  { "inputs": [], "name": "MarketNotSupported", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "loopsLimit", "type": "uint256" },
+      { "internalType": "uint256", "name": "requiredLoops", "type": "uint256" }
+    ],
+    "name": "MaxLoopsLimitExceeded",
+    "type": "error"
+  },
+  { "inputs": [], "name": "NoScoreUpdatesRequired", "type": "error" },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "sender", "type": "address" },
+      { "internalType": "address", "name": "calledContract", "type": "address" },
+      { "internalType": "string", "name": "methodSignature", "type": "string" }
+    ],
+    "name": "Unauthorized",
+    "type": "error"
+  },
+  { "inputs": [], "name": "UserHasNoPrimeToken", "type": "error" },
+  { "inputs": [], "name": "WaitMoreTime", "type": "error" },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "uint128", "name": "oldNumerator", "type": "uint128" },
+      { "indexed": true, "internalType": "uint128", "name": "oldDenominator", "type": "uint128" },
+      { "indexed": true, "internalType": "uint128", "name": "newNumerator", "type": "uint128" },
+      { "indexed": false, "internalType": "uint128", "name": "newDenominator", "type": "uint128" }
+    ],
+    "name": "AlphaUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "user", "type": "address" }],
+    "name": "Burn",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": false, "internalType": "uint8", "name": "version", "type": "uint8" }],
+    "name": "Initialized",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "market", "type": "address" },
+      { "indexed": false, "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "InterestClaimed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "market", "type": "address" },
+      { "indexed": true, "internalType": "uint256", "name": "supplyMultiplier", "type": "uint256" },
+      { "indexed": true, "internalType": "uint256", "name": "borrowMultiplier", "type": "uint256" }
+    ],
+    "name": "MarketAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldMaxLoopsLimit",
+        "type": "uint256"
+      },
+      { "indexed": false, "internalType": "uint256", "name": "newmaxLoopsLimit", "type": "uint256" }
+    ],
+    "name": "MaxLoopsLimitUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "user", "type": "address" },
+      { "indexed": false, "internalType": "bool", "name": "isIrrevocable", "type": "bool" }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "oldIrrevocableLimit",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "oldRevocableLimit",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "newIrrevocableLimit",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newRevocableLimit",
+        "type": "uint256"
+      }
+    ],
+    "name": "MintLimitsUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "market", "type": "address" },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "oldSupplyMultiplier",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "oldBorrowMultiplier",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newSupplyMultiplier",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newBorrowMultiplier",
+        "type": "uint256"
+      }
+    ],
+    "name": "MultiplierUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldAccessControlManager",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newAccessControlManager",
+        "type": "address"
+      }
+    ],
+    "name": "NewAccessControlManager",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferStarted",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "previousOwner", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "newOwner", "type": "address" }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "Paused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "user", "type": "address" }],
+    "name": "TokenUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": false, "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "Unpaused",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      { "indexed": true, "internalType": "address", "name": "comptroller", "type": "address" },
+      { "indexed": true, "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "UpdatedAssetsState",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [{ "indexed": true, "internalType": "address", "name": "user", "type": "address" }],
+    "name": "UserScoreUpdated",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "BLOCKS_PER_YEAR",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MAXIMUM_XVS_CAP",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "MINIMUM_STAKED_XVS",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "STAKING_PERIOD",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "VBNB",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "WBNB",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accessControlManager",
+    "outputs": [
+      { "internalType": "contract IAccessControlManagerV8", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "vToken", "type": "address" }],
+    "name": "accrueInterest",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "address", "name": "market", "type": "address" }
+    ],
+    "name": "accrueInterestAndUpdateScore",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "market", "type": "address" },
+      { "internalType": "uint256", "name": "supplyMultiplier", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowMultiplier", "type": "uint256" }
+    ],
+    "name": "addMarket",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "alphaDenominator",
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "alphaNumerator",
+    "outputs": [{ "internalType": "uint128", "name": "", "type": "uint128" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "burn",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "market", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "calculateAPR",
+    "outputs": [
+      { "internalType": "uint256", "name": "supplyAPR", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowAPR", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "vToken", "type": "address" }],
+    "name": "claimInterest",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "claimInterest",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "claimTimeRemaining",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "market", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" },
+      { "internalType": "uint256", "name": "borrow", "type": "uint256" },
+      { "internalType": "uint256", "name": "supply", "type": "uint256" },
+      { "internalType": "uint256", "name": "xvsStaked", "type": "uint256" }
+    ],
+    "name": "estimateAPR",
+    "outputs": [
+      { "internalType": "uint256", "name": "supplyAPR", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowAPR", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getAllMarkets",
+    "outputs": [{ "internalType": "address[]", "name": "", "type": "address[]" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "vToken", "type": "address" },
+      { "internalType": "address", "name": "user", "type": "address" }
+    ],
+    "name": "getInterestAccrued",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "getPendingInterests",
+    "outputs": [
+      {
+        "components": [
+          { "internalType": "address", "name": "market", "type": "address" },
+          { "internalType": "uint256", "name": "amount", "type": "uint256" }
+        ],
+        "internalType": "struct PrimeStorageV1.PendingInterest[]",
+        "name": "pendingInterests",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_xvsVault", "type": "address" },
+      { "internalType": "address", "name": "_xvsVaultRewardToken", "type": "address" },
+      { "internalType": "uint256", "name": "_xvsVaultPoolId", "type": "uint256" },
+      { "internalType": "uint128", "name": "_alphaNumerator", "type": "uint128" },
+      { "internalType": "uint128", "name": "_alphaDenominator", "type": "uint128" },
+      { "internalType": "address", "name": "_accessControlManager", "type": "address" },
+      { "internalType": "address", "name": "_protocolShareReserve", "type": "address" },
+      { "internalType": "address", "name": "_primeLiquidityProvider", "type": "address" },
+      { "internalType": "address", "name": "_comptroller", "type": "address" },
+      { "internalType": "address", "name": "_oracle", "type": "address" },
+      { "internalType": "uint256", "name": "_loopsLimit", "type": "uint256" }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "", "type": "address" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "interests",
+    "outputs": [
+      { "internalType": "uint256", "name": "accrued", "type": "uint256" },
+      { "internalType": "uint256", "name": "score", "type": "uint256" },
+      { "internalType": "uint256", "name": "rewardIndex", "type": "uint256" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "irrevocableLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "", "type": "uint256" },
+      { "internalType": "address", "name": "", "type": "address" }
+    ],
+    "name": "isScoreUpdated",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "bool", "name": "isIrrevocable", "type": "bool" },
+      { "internalType": "address[]", "name": "users", "type": "address[]" }
+    ],
+    "name": "issue",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "markets",
+    "outputs": [
+      { "internalType": "uint256", "name": "supplyMultiplier", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowMultiplier", "type": "uint256" },
+      { "internalType": "uint256", "name": "rewardIndex", "type": "uint256" },
+      { "internalType": "uint256", "name": "sumOfMembersScore", "type": "uint256" },
+      { "internalType": "bool", "name": "exists", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "maxLoopsLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nextScoreUpdateRoundId",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "oracle",
+    "outputs": [
+      { "internalType": "contract ResilientOracleInterface", "name": "", "type": "address" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "pendingScoreUpdates",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "primeLiquidityProvider",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "protocolShareReserve",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "renounceOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "revocableLimit",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "accessControlManager_", "type": "address" }],
+    "name": "setAccessControlManager",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint256", "name": "_irrevocableLimit", "type": "uint256" },
+      { "internalType": "uint256", "name": "_revocableLimit", "type": "uint256" }
+    ],
+    "name": "setLimit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "stakedAt",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "togglePause",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "tokens",
+    "outputs": [
+      { "internalType": "bool", "name": "exists", "type": "bool" },
+      { "internalType": "bool", "name": "isIrrevocable", "type": "bool" }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalIrrevocable",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalRevocable",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalScoreUpdatesRequired",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "newOwner", "type": "address" }],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "unreleasedPLPIncome",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "unreleasedPSRIncome",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "uint128", "name": "_alphaNumerator", "type": "uint128" },
+      { "internalType": "uint128", "name": "_alphaDenominator", "type": "uint128" }
+    ],
+    "name": "updateAlpha",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_comptroller", "type": "address" },
+      { "internalType": "address", "name": "asset", "type": "address" }
+    ],
+    "name": "updateAssetsState",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "market", "type": "address" },
+      { "internalType": "uint256", "name": "supplyMultiplier", "type": "uint256" },
+      { "internalType": "uint256", "name": "borrowMultiplier", "type": "uint256" }
+    ],
+    "name": "updateMultipliers",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address[]", "name": "users", "type": "address[]" }],
+    "name": "updateScores",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "vTokenForAsset",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{ "internalType": "address", "name": "user", "type": "address" }],
+    "name": "xvsUpdated",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/packages/contracts/config/index.ts
+++ b/src/packages/contracts/config/index.ts
@@ -33,6 +33,8 @@ import { ChainId } from 'types';
 import MaximillionAbi from './externalAbis/Maximillion.json';
 import multicall3Abi from './externalAbis/Multicall3.json';
 import pancakePairV2Abi from './externalAbis/PancakePairV2.json';
+// TODO: get ABI from package once it's been added
+import PrimeAbi from './externalAbis/Prime.json';
 import vBnbAbi from './externalAbis/VBnb.json';
 import XsequenceMulticall from './externalAbis/XsequenceMulticall.json';
 
@@ -184,6 +186,14 @@ export const contracts: ContractConfig[] = [
     address: {
       [ChainId.BSC_TESTNET]: resilientOracleTestnetDeployments.address,
       [ChainId.BSC_MAINNET]: resilientOracleMainnetDeployments.address,
+    },
+  },
+  {
+    name: 'Prime',
+    abi: PrimeAbi,
+    address: {
+      // TODO: get addresses from package once they've been added
+      [ChainId.BSC_TESTNET]: '0xDe0c98BeecA94bf9d5B87D025442F80c076A78D8',
     },
   },
   // Generic Contracts

--- a/src/packages/contracts/utilities/getUniqueContractAddress/index.ts
+++ b/src/packages/contracts/utilities/getUniqueContractAddress/index.ts
@@ -7,5 +7,10 @@ export type GetUniqueContractAddressInput = {
   chainId: ChainId;
 };
 
-export const getUniqueContractAddress = ({ name, chainId }: GetUniqueContractAddressInput) =>
-  addresses[name][chainId];
+export const getUniqueContractAddress = ({ name, chainId }: GetUniqueContractAddressInput) => {
+  const contractAddresses = addresses[name];
+
+  return Object.prototype.hasOwnProperty.call(contractAddresses, chainId)
+    ? contractAddresses[chainId as keyof typeof contractAddresses]
+    : undefined;
+};


### PR DESCRIPTION
## Changes

- add Prime contract record on testnet
- fix issue with `getUniqueContractAddress` where all contracts where assumed to be present on all chains
- fix issue with `getContractName` where all contracts where assumed to be present on all chains
