### PR TITLE
fix: use MAX_UINT256 as default value when approving token spending

### DIFF
--- a/src/clients/api/mutations/approveToken/index.ts
+++ b/src/clients/api/mutations/approveToken/index.ts
@@ -1,7 +1,7 @@
 import { ContractReceipt } from 'ethers';
 import { Bep20, Vai, Vrt, Xvs } from 'packages/contracts';
 
-import ALLOWANCE_AMOUNT_WEI from 'constants/allowanceAmountWei';
+import MAX_UINT256 from 'constants/maxUint256';
 
 export interface ApproveTokenInput {
   tokenContract: Vai | Bep20 | Vrt | Xvs;
@@ -14,7 +14,7 @@ export type ApproveTokenOutput = ContractReceipt;
 const approveToken = async ({
   tokenContract,
   spenderAddress,
-  allowance = ALLOWANCE_AMOUNT_WEI,
+  allowance = MAX_UINT256.toFixed(),
 }: ApproveTokenInput): Promise<ApproveTokenOutput> => {
   const transaction = await tokenContract.approve(spenderAddress, allowance);
   return transaction.wait(1);

--- a/src/constants/allowanceAmountWei.ts
+++ b/src/constants/allowanceAmountWei.ts
@@ -1,5 +1,0 @@
-import BigNumber from 'bignumber.js';
-
-// Default allowance set when approving a token to be used from an account
-const ALLOWANCE_AMOUNT_WEI = new BigNumber(2 ** 256).minus(1).toFixed();
-export default ALLOWANCE_AMOUNT_WEI;


### PR DESCRIPTION
## Changes

- use `MAX_UINT256` as default value when approving token spending
- remove `allowanceAmountWei.ts` file in favor of `MAX_UINT256` constant
