### PR TITLE
fix: issue with hook order in PrimePromotionalBanner

### DIFF
--- a/src/pages/Dashboard/PrimePromotionalBanner/index.tsx
+++ b/src/pages/Dashboard/PrimePromotionalBanner/index.tsx
@@ -97,7 +97,8 @@ export const PrimePromotionalBanner: React.FC = () => {
       accountAddress,
     });
   const isAccountPrime = !!getIsAddressPrimeData?.isPrime;
-  const shouldShow = !isGetIsAddressPrimeLoading && !isAccountPrime && store.use.shouldShowBanner();
+  const storeShouldShowBanner = store.use.shouldShowBanner();
+  const shouldShow = !isGetIsAddressPrimeLoading && !isAccountPrime && storeShouldShowBanner;
   const hideBanner = store.use.hideBanner();
 
   return <PrimePromotionalBannerUi shouldShow={shouldShow} onHide={hideBanner} />;


### PR DESCRIPTION
## Changes

- fix issue where hook would not always be rendered in `PrimePromotionalBanner`, causing the page to crash
