### PR TITLE
refactor: use .hasOwnProperty of object instead of .hasOwn

### DIFF
--- a/src/constants/routing.ts
+++ b/src/constants/routing.ts
@@ -63,7 +63,7 @@ type Routes = {
 
 export const routes = Object.keys(routeSubdirectories).reduce<Routes>(
   (obj, key) =>
-    Object.hasOwn(routeSubdirectories, key)
+    Object.prototype.hasOwnProperty.call(routeSubdirectories, key)
       ? {
           ...obj,
           [key]: {

--- a/src/containers/ReadableActionSignature/getContractName.ts
+++ b/src/containers/ReadableActionSignature/getContractName.ts
@@ -37,7 +37,7 @@ const getContractName = ({ target, vTokens, tokens, chainId }: GetContractNameIn
     ([_uniqueContractName, address]) => {
       let contractAddress;
 
-      if (Object.hasOwn(address, chainId)) {
+      if (Object.prototype.hasOwnProperty.call(address, chainId)) {
         contractAddress = address[chainId as keyof typeof address];
       }
 

--- a/src/packages/contracts/utilities/getUniqueContractAddress/index.ts
+++ b/src/packages/contracts/utilities/getUniqueContractAddress/index.ts
@@ -10,7 +10,7 @@ export type GetUniqueContractAddressInput = {
 export const getUniqueContractAddress = ({ name, chainId }: GetUniqueContractAddressInput) => {
   const contractAddresses = addresses[name];
 
-  return Object.hasOwn(contractAddresses, chainId)
+  return Object.prototype.hasOwnProperty.call(contractAddresses, chainId)
     ? contractAddresses[chainId as keyof typeof contractAddresses]
     : undefined;
 };

--- a/src/pages/Market/index.tsx
+++ b/src/pages/Market/index.tsx
@@ -191,7 +191,7 @@ export const MarketUi: React.FC<MarketUiProps> = ({
 
       const accCopy = { ...accDistributionMapping };
 
-      if (!Object.hasOwn(accCopy, distribution.token.address)) {
+      if (!Object.prototype.hasOwnProperty.call(accCopy, distribution.token.address)) {
         accCopy[distribution.token.address] = {
           rewardToken: distribution.token,
           dailyDistributedTokens: new BigNumber(0),


### PR DESCRIPTION
## Changes

- use `hasOwnProperty` method of Object instead of `hasOwn` as the former offers better browser compatibility
