### PR TITLE
fix: typo in BUSD warning link

### DIFF
--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -67,7 +67,7 @@ export const DashboardUi: React.FC<DashboardUiProps> = ({
             i18nKey="dashboard.banner.busdForceLiquidations"
             components={{
               Link: (
-                <Link href="https://app.venus.io/#/governance/proposal/1919" />
+                <Link href="https://app.venus.io/#/governance/proposal/191" />
               ),
             }}
           />


### PR DESCRIPTION
## Changes

- Fix typo in BUSD warning link
