### PR TITLE
fix: keep Prime status up-to-date

### DIFF
--- a/src/clients/api/mutations/stakeInXvsVault/useStakeInXvsVault.ts
+++ b/src/clients/api/mutations/stakeInXvsVault/useStakeInXvsVault.ts
@@ -93,6 +93,21 @@ const useStakeInXvsVault = (
           { rewardTokenAddress: rewardToken.address, poolIndex },
         ]);
 
+        // Invalidate cached Prime data
+        queryClient.invalidateQueries([
+          FunctionKey.GET_PRIME_STATUS,
+          {
+            accountAddress,
+          },
+        ]);
+
+        queryClient.invalidateQueries([
+          FunctionKey.GET_PRIME_TOKEN,
+          {
+            accountAddress,
+          },
+        ]);
+
         if (options?.onSuccess) {
           options.onSuccess(...onSuccessParams);
         }

--- a/src/clients/api/mutations/withdrawXvs/useWithdrawXvs.ts
+++ b/src/clients/api/mutations/withdrawXvs/useWithdrawXvs.ts
@@ -15,8 +15,25 @@ const useWithdrawXvs = (options?: MutationObserverOptions<WithdrawXvsOutput, Err
     () => callOrThrow({ xvsVestingContract }, withdrawXvs),
     {
       ...options,
-      onSuccess: (...onSuccessParams) => {
+      onSuccess: async (...onSuccessParams) => {
+        const accountAddress = await xvsVestingContract?.signer.getAddress();
+
         queryClient.invalidateQueries(FunctionKey.GET_XVS_WITHDRAWABLE_AMOUNT);
+
+        // Invalidate cached Prime data
+        queryClient.invalidateQueries([
+          FunctionKey.GET_PRIME_STATUS,
+          {
+            accountAddress,
+          },
+        ]);
+
+        queryClient.invalidateQueries([
+          FunctionKey.GET_PRIME_TOKEN,
+          {
+            accountAddress,
+          },
+        ]);
 
         if (options?.onSuccess) {
           options.onSuccess(...onSuccessParams);

--- a/src/containers/PrimeStatusBanner/formatWaitingPeriod.ts
+++ b/src/containers/PrimeStatusBanner/formatWaitingPeriod.ts
@@ -1,0 +1,8 @@
+import { formatDistanceStrict } from 'date-fns';
+
+const ONE_MONTH_IN_SECONDS = 30 * 24 * 60 * 60;
+
+export const formatWaitingPeriod = ({ waitingPeriodSeconds }: { waitingPeriodSeconds: number }) =>
+  formatDistanceStrict(new Date(), new Date().getTime() + waitingPeriodSeconds * 1000, {
+    unit: waitingPeriodSeconds >= ONE_MONTH_IN_SECONDS ? 'day' : undefined,
+  });

--- a/src/containers/PrimeStatusBanner/index.tsx
+++ b/src/containers/PrimeStatusBanner/index.tsx
@@ -1,6 +1,5 @@
 import BigNumber from 'bignumber.js';
 import { Card, Icon, Link, PrimaryButton, ProgressBar, Tooltip } from 'components';
-import formatDistanceStrict from 'date-fns/formatDistanceStrict';
 import { ContractReceipt } from 'ethers';
 import { useGetToken } from 'packages/tokens';
 import React, { useMemo } from 'react';
@@ -25,6 +24,7 @@ import useConvertWeiToReadableTokenString from 'hooks/useFormatTokensToReadableV
 import useHandleTransactionMutation from 'hooks/useHandleTransactionMutation';
 
 import PrimeTokensLeft from './PrimeTokensLeft';
+import { formatWaitingPeriod } from './formatWaitingPeriod';
 import TEST_IDS from './testIds';
 
 export interface PrimeStatusBannerUiProps {
@@ -98,14 +98,8 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
 
   const [readableClaimWaitingPeriod, readableUserClaimWaitingPeriod] = useMemo(
     () => [
-      formatDistanceStrict(
-        new Date(),
-        new Date().getTime() + primeClaimWaitingPeriodSeconds * 1000,
-      ),
-      formatDistanceStrict(
-        new Date(),
-        new Date().getTime() + userPrimeClaimWaitingPeriodSeconds * 1000,
-      ),
+      formatWaitingPeriod({ waitingPeriodSeconds: primeClaimWaitingPeriodSeconds }),
+      formatWaitingPeriod({ waitingPeriodSeconds: userPrimeClaimWaitingPeriodSeconds }),
     ],
     [primeClaimWaitingPeriodSeconds, userPrimeClaimWaitingPeriodSeconds],
   );

--- a/src/containers/PrimeStatusBanner/index.tsx
+++ b/src/containers/PrimeStatusBanner/index.tsx
@@ -7,7 +7,7 @@ import React, { useMemo } from 'react';
 import { useNavigate } from 'react-router';
 import { useTranslation } from 'translation';
 import { AssetDistribution, Token } from 'types';
-import { cn, convertWeiToTokens } from 'utilities';
+import { cn, convertWeiToTokens, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import { ReactComponent as PrimeLogo } from 'assets/img/primeLogo.svg';
 import {
@@ -42,6 +42,8 @@ export interface PrimeStatusBannerUiProps {
   hidePromotionalTitle?: boolean;
   className?: string;
 }
+
+const refetchInterval = generatePseudoRandomRefetchInterval();
 
 export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
   className,
@@ -142,7 +144,13 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
         />
       );
     }
-  }, [hidePromotionalTitle, readableApyBoostPercentage, isUserXvsStakeHighEnoughForPrime]);
+  }, [
+    hidePromotionalTitle,
+    readableApyBoostPercentage,
+    userPrimeClaimWaitingPeriodSeconds,
+    readableUserClaimWaitingPeriod,
+    isUserXvsStakeHighEnoughForPrime,
+  ]);
 
   const displayProgress = !isUserXvsStakeHighEnoughForPrime;
   const displayWarning = haveAllPrimeTokensBeenClaimed;
@@ -319,6 +327,7 @@ const PrimeStatusBanner: React.FC<PrimeStatusBannerProps> = props => {
     },
     {
       enabled: !isGetPrimeTokenLoading && !isAccountPrime,
+      refetchInterval,
     },
   );
 


### PR DESCRIPTION
## Changes

- refresh Prime status at an interval
- invalidate cache linked to Prime after interacting with XVS vault
- update formatting of waiting periods so the largest unit used is days