### PR TITLE
feat: add chain ID to query hooks

### DIFF
--- a/src/clients/api/queries/getAllowance/useGetAllowance.ts
+++ b/src/clients/api/queries/getAllowance/useGetAllowance.ts
@@ -10,13 +10,13 @@ import getAllowance, {
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
 
+type TrimmedGetAllowanceInput = Omit<GetAllowanceInput, 'tokenContract'> & { token: Token };
+
 export type UseGetAllowanceQueryKey = [
   FunctionKey.GET_TOKEN_ALLOWANCE,
-  {
+  Omit<TrimmedGetAllowanceInput, 'token'> & {
     chainId: ChainId;
-    accountAddress: string;
     tokenAddress: string;
-    spenderAddress: string;
   },
 ];
 
@@ -27,8 +27,6 @@ type Options = QueryObserverOptions<
   GetAllowanceOutput,
   UseGetAllowanceQueryKey
 >;
-
-type TrimmedGetAllowanceInput = Omit<GetAllowanceInput, 'tokenContract'> & { token: Token };
 
 const useGetAllowance = (
   { token, spenderAddress, accountAddress }: TrimmedGetAllowanceInput,

--- a/src/clients/api/queries/getAllowance/useGetAllowance.ts
+++ b/src/clients/api/queries/getAllowance/useGetAllowance.ts
@@ -1,6 +1,6 @@
 import { useGetTokenContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
-import { Token } from 'types';
+import { ChainId, Token } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getAllowance, {
@@ -8,13 +8,15 @@ import getAllowance, {
   GetAllowanceOutput,
 } from 'clients/api/queries/getAllowance';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 export type UseGetAllowanceQueryKey = [
   FunctionKey.GET_TOKEN_ALLOWANCE,
   {
+    chainId: ChainId;
+    accountAddress: string;
     tokenAddress: string;
     spenderAddress: string;
-    accountAddress: string;
   },
 ];
 
@@ -32,13 +34,16 @@ const useGetAllowance = (
   { token, spenderAddress, accountAddress }: TrimmedGetAllowanceInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const tokenContract = useGetTokenContract({ token });
+
   const queryKey: UseGetAllowanceQueryKey = [
     FunctionKey.GET_TOKEN_ALLOWANCE,
     {
+      chainId,
+      accountAddress,
       tokenAddress: token.address,
       spenderAddress,
-      accountAddress,
     },
   ];
 

--- a/src/clients/api/queries/getBalanceOf/useGetBalanceOf.ts
+++ b/src/clients/api/queries/getBalanceOf/useGetBalanceOf.ts
@@ -5,12 +5,13 @@ import { GetBalanceOfInput, GetBalanceOfOutput, getBalanceOf } from 'clients/api
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
 
+type TrimmedGetBalanceOfInput = Omit<GetBalanceOfInput, 'signer' | 'provider'>;
+
 export type UseGetBalanceOfQueryKey = [
   FunctionKey.GET_BALANCE_OF,
-  {
-    chainId: ChainId;
-    accountAddress: string;
+  Omit<TrimmedGetBalanceOfInput, 'token'> & {
     tokenAddress: string;
+    chainId: ChainId;
   },
 ];
 
@@ -23,7 +24,7 @@ type Options = QueryObserverOptions<
 >;
 
 const useGetBalanceOf = (
-  { accountAddress, token }: Omit<GetBalanceOfInput, 'signer' | 'provider'>,
+  { accountAddress, token }: TrimmedGetBalanceOfInput,
   options?: Options,
 ) => {
   const { provider, chainId } = useAuth();

--- a/src/clients/api/queries/getBalanceOf/useGetBalanceOf.ts
+++ b/src/clients/api/queries/getBalanceOf/useGetBalanceOf.ts
@@ -1,33 +1,38 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 
 import { GetBalanceOfInput, GetBalanceOfOutput, getBalanceOf } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
+
+export type UseGetBalanceOfQueryKey = [
+  FunctionKey.GET_BALANCE_OF,
+  {
+    chainId: ChainId;
+    accountAddress: string;
+    tokenAddress: string;
+  },
+];
 
 type Options = QueryObserverOptions<
   GetBalanceOfOutput,
   Error,
   GetBalanceOfOutput,
   GetBalanceOfOutput,
-  [
-    FunctionKey.GET_BALANCE_OF,
-    {
-      accountAddress: string;
-      tokenAddress: string;
-    },
-  ]
+  UseGetBalanceOfQueryKey
 >;
 
 const useGetBalanceOf = (
   { accountAddress, token }: Omit<GetBalanceOfInput, 'signer' | 'provider'>,
   options?: Options,
 ) => {
-  const { provider } = useAuth();
+  const { provider, chainId } = useAuth();
 
   return useQuery(
     [
       FunctionKey.GET_BALANCE_OF,
       {
+        chainId,
         accountAddress,
         tokenAddress: token.address,
       },

--- a/src/clients/api/queries/getBlockNumber/useGetBlockNumber.ts
+++ b/src/clients/api/queries/getBlockNumber/useGetBlockNumber.ts
@@ -6,7 +6,7 @@ import { BLOCK_TIME_MS } from 'constants/bsc';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
 
-export type UseGetBlockNumber = [FunctionKey.GET_BLOCK_NUMBER, { chainId: ChainId }];
+export type UseGetBlockNumberQueryKey = [FunctionKey.GET_BLOCK_NUMBER, { chainId: ChainId }];
 
 interface GetBlockNumberOutput {
   blockNumber: number;
@@ -17,7 +17,7 @@ type Options = QueryObserverOptions<
   Error,
   GetBlockNumberOutput,
   GetBlockNumberOutput,
-  UseGetBlockNumber
+  UseGetBlockNumberQueryKey
 >;
 
 const useGetBlockNumber = (options?: Options) => {

--- a/src/clients/api/queries/getBlockNumber/useGetBlockNumber.ts
+++ b/src/clients/api/queries/getBlockNumber/useGetBlockNumber.ts
@@ -1,9 +1,12 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 
 import { getBlockNumber } from 'clients/api/';
 import { BLOCK_TIME_MS } from 'constants/bsc';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
+
+export type UseGetBlockNumber = [FunctionKey.GET_BLOCK_NUMBER, { chainId: ChainId }];
 
 interface GetBlockNumberOutput {
   blockNumber: number;
@@ -14,13 +17,13 @@ type Options = QueryObserverOptions<
   Error,
   GetBlockNumberOutput,
   GetBlockNumberOutput,
-  FunctionKey.GET_BLOCK_NUMBER
+  UseGetBlockNumber
 >;
 
 const useGetBlockNumber = (options?: Options) => {
-  const { provider } = useAuth();
+  const { provider, chainId } = useAuth();
 
-  return useQuery(FunctionKey.GET_BLOCK_NUMBER, () => getBlockNumber({ provider }), {
+  return useQuery([FunctionKey.GET_BLOCK_NUMBER, { chainId }], () => getBlockNumber({ provider }), {
     refetchInterval: BLOCK_TIME_MS,
     ...options,
   });

--- a/src/clients/api/queries/getCurrentVotes/useGetCurrentVotes.ts
+++ b/src/clients/api/queries/getCurrentVotes/useGetCurrentVotes.ts
@@ -6,6 +6,7 @@ import getCurrentVotes, {
   GetCurrentVotesInput,
   GetCurrentVotesOutput,
 } from 'clients/api/queries/getCurrentVotes';
+import { governanceChain } from 'clients/web3';
 import FunctionKey from 'constants/functionKey';
 
 type TrimmedGetCurrentVotesInput = Omit<GetCurrentVotesInput, 'xvsVaultContract'>;
@@ -18,7 +19,9 @@ type Options = QueryObserverOptions<
 >;
 
 const useGetCurrentVotes = (input: TrimmedGetCurrentVotesInput, options?: Options) => {
-  const xvsVaultContract = useGetXvsVaultContract();
+  const xvsVaultContract = useGetXvsVaultContract({
+    chainId: governanceChain.id,
+  });
 
   return useQuery(
     [FunctionKey.GET_CURRENT_VOTES, input],

--- a/src/clients/api/queries/getCurrentVotes/useGetCurrentVotes.ts
+++ b/src/clients/api/queries/getCurrentVotes/useGetCurrentVotes.ts
@@ -10,12 +10,18 @@ import { governanceChain } from 'clients/web3';
 import FunctionKey from 'constants/functionKey';
 
 type TrimmedGetCurrentVotesInput = Omit<GetCurrentVotesInput, 'xvsVaultContract'>;
+
+export type UseGetCurrentVotesQueryKey = [
+  FunctionKey.GET_CURRENT_VOTES,
+  TrimmedGetCurrentVotesInput,
+];
+
 type Options = QueryObserverOptions<
   GetCurrentVotesOutput,
   Error,
   GetCurrentVotesOutput,
   GetCurrentVotesOutput,
-  [FunctionKey.GET_CURRENT_VOTES, TrimmedGetCurrentVotesInput]
+  UseGetCurrentVotesQueryKey
 >;
 
 const useGetCurrentVotes = (input: TrimmedGetCurrentVotesInput, options?: Options) => {

--- a/src/clients/api/queries/getHypotheticalPrimeApys/useGetHypotheticalPrimeApys.ts
+++ b/src/clients/api/queries/getHypotheticalPrimeApys/useGetHypotheticalPrimeApys.ts
@@ -1,5 +1,6 @@
 import { useGetPrimeContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import {
@@ -8,6 +9,7 @@ import {
   getHypotheticalPrimeApys,
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 interface UseGetPrimeTokenInput
@@ -15,20 +17,28 @@ interface UseGetPrimeTokenInput
   accountAddress?: string;
 }
 
+export type UseGetHypotheticalPrimeApysQueryKey = [
+  FunctionKey.GET_HYPOTHETICAL_PRIME_APYS,
+  UseGetPrimeTokenInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetHypotheticalPrimeApysOutput,
   Error,
   GetHypotheticalPrimeApysOutput,
   GetHypotheticalPrimeApysOutput,
-  [FunctionKey.GET_HYPOTHETICAL_PRIME_APYS, UseGetPrimeTokenInput]
+  UseGetHypotheticalPrimeApysQueryKey
 >;
 
 const useGetHypotheticalPrimeApys = (input: UseGetPrimeTokenInput, options?: Options) => {
+  const { chainId } = useAuth();
   const isPrimeEnabled = useIsFeatureEnabled({ name: 'prime' });
   const primeContract = useGetPrimeContract();
 
   return useQuery(
-    [FunctionKey.GET_HYPOTHETICAL_PRIME_APYS, input],
+    [FunctionKey.GET_HYPOTHETICAL_PRIME_APYS, { ...input, chainId }],
     () =>
       callOrThrow({ primeContract, accountAddress: input.accountAddress }, params =>
         getHypotheticalPrimeApys({

--- a/src/clients/api/queries/getIsAddressAuthorized/useGetIsAddressAuthorized.ts
+++ b/src/clients/api/queries/getIsAddressAuthorized/useGetIsAddressAuthorized.ts
@@ -5,12 +5,17 @@ import getIsAddressAuthorized, {
 } from 'clients/api/queries/getIsAddressAuthorized';
 import FunctionKey from 'constants/functionKey';
 
+export type UseGetIsAddressAuthorizedQueryKey = [
+  FunctionKey.GET_IS_ADDRESS_AUTHORIZED,
+  { accountAddress: string },
+];
+
 type Options = QueryObserverOptions<
   GetIsAddressAuthorizedOutput,
   Error,
   GetIsAddressAuthorizedOutput,
   GetIsAddressAuthorizedOutput,
-  [FunctionKey.GET_IS_ADDRESS_AUTHORIZED, { accountAddress: string }]
+  UseGetIsAddressAuthorizedQueryKey
 >;
 
 const ONE_HOUR_MS = 60 * 60 * 1000;
@@ -23,7 +28,9 @@ const useGetIsAddressAuthorized = (accountAddress: string, options?: Options) =>
       refetchOnMount: false,
       refetchOnReconnect: false,
       refetchOnWindowFocus: false,
-      staleTime: ONE_HOUR_MS,
+      refetchInterval: ONE_HOUR_MS,
+      staleTime: Infinity,
+      cacheTime: Infinity,
       ...options,
     },
   );

--- a/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
+++ b/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
@@ -5,6 +5,7 @@ import {
 } from 'packages/contracts';
 import { useGetTokens } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getIsolatedPools, {
@@ -23,18 +24,25 @@ type TrimmedInput = Omit<
   | 'tokens'
 >;
 
+export type UseGetIsolatedPoolsQueryKey = [
+  FunctionKey.GET_ISOLATED_POOLS,
+  TrimmedInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetIsolatedPoolsOutput,
   Error,
   GetIsolatedPoolsOutput,
   GetIsolatedPoolsOutput,
-  [FunctionKey.GET_ISOLATED_POOLS, TrimmedInput]
+  UseGetIsolatedPoolsQueryKey
 >;
 
 const refetchInterval = generatePseudoRandomRefetchInterval();
 
 const useGetIsolatedPools = (input: TrimmedInput, options?: Options) => {
-  const { provider } = useAuth();
+  const { provider, chainId } = useAuth();
   const tokens = useGetTokens();
 
   const poolLensContract = useGetPoolLensContract();
@@ -42,7 +50,7 @@ const useGetIsolatedPools = (input: TrimmedInput, options?: Options) => {
   const poolRegistryContractAddress = useGetPoolRegistryContractAddress();
 
   return useQuery(
-    [FunctionKey.GET_ISOLATED_POOLS, input],
+    [FunctionKey.GET_ISOLATED_POOLS, { ...input, chainId }],
     () =>
       callOrThrow(
         { poolLensContract, poolRegistryContractAddress, resilientOracleContract },

--- a/src/clients/api/queries/getLatestProposalIdByProposer/useGetLatestProposalIdByProposer.ts
+++ b/src/clients/api/queries/getLatestProposalIdByProposer/useGetLatestProposalIdByProposer.ts
@@ -6,6 +6,7 @@ import getLatestProposalIdByProposer, {
   GetLatestProposalIdByProposerInput,
   GetLatestProposalIdByProposerOutput,
 } from 'clients/api/queries/getLatestProposalIdByProposer';
+import { governanceChain } from 'clients/web3';
 import { BLOCK_TIME_MS } from 'constants/bsc';
 import FunctionKey from 'constants/functionKey';
 
@@ -21,7 +22,9 @@ const useGetLatestProposalIdByProposer = (
   { accountAddress }: Omit<GetLatestProposalIdByProposerInput, 'governorBravoDelegateContract'>,
   options?: Options,
 ) => {
-  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract();
+  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract({
+    chainId: governanceChain.id,
+  });
 
   return useQuery(
     [FunctionKey.GET_LATEST_PROPOSAL_ID_BY_PROPOSER, accountAddress],

--- a/src/clients/api/queries/getMainPool/useGetMainPool.ts
+++ b/src/clients/api/queries/getMainPool/useGetMainPool.ts
@@ -8,10 +8,12 @@ import {
 import { useGetToken, useGetTokens } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { useTranslation } from 'translation';
+import { ChainId } from 'types';
 import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getMainPool, { GetMainPoolInput, GetMainPoolOutput } from 'clients/api/queries/getMainPool';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 type TrimmedInput = Omit<
@@ -28,17 +30,23 @@ type TrimmedInput = Omit<
   | 'tokens'
 >;
 
+export type UseGetMainPoolQueryKey = [
+  FunctionKey.GET_MAIN_POOL,
+  TrimmedInput & { chainId: ChainId },
+];
+
 type Options = QueryObserverOptions<
   GetMainPoolOutput,
   Error,
   GetMainPoolOutput,
   GetMainPoolOutput,
-  [FunctionKey.GET_MAIN_POOL, TrimmedInput]
+  UseGetMainPoolQueryKey
 >;
 
 const refetchInterval = generatePseudoRandomRefetchInterval();
 
 const useGetMainPool = (input: TrimmedInput, options?: Options) => {
+  const { chainId } = useAuth();
   const { t } = useTranslation();
 
   const xvs = useGetToken({ symbol: 'XVS' });
@@ -55,7 +63,7 @@ const useGetMainPool = (input: TrimmedInput, options?: Options) => {
   const primeContract = useGetPrimeContract();
 
   return useQuery(
-    [FunctionKey.GET_MAIN_POOL, input],
+    [FunctionKey.GET_MAIN_POOL, { ...input, chainId }],
     () =>
       callOrThrow(
         {

--- a/src/clients/api/queries/getMintableVai/useGetMintableVai.ts
+++ b/src/clients/api/queries/getMintableVai/useGetMintableVai.ts
@@ -1,5 +1,6 @@
 import { useGetVaiControllerContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getMintableVai, {
@@ -7,21 +8,29 @@ import getMintableVai, {
   GetMintableVaiOutput,
 } from 'clients/api/queries/getMintableVai';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetMintableVaiInput = Omit<GetMintableVaiInput, 'vaiControllerContract'>;
+
+export type UseGetMintableVaiQueryKey = [
+  FunctionKey.GET_MINTABLE_VAI,
+  TrimmedGetMintableVaiInput & { chainId: ChainId },
+];
+
 type Options = QueryObserverOptions<
   GetMintableVaiOutput | undefined,
   Error,
   GetMintableVaiOutput | undefined,
   GetMintableVaiOutput | undefined,
-  [FunctionKey.GET_MINTABLE_VAI, TrimmedGetMintableVaiInput]
+  UseGetMintableVaiQueryKey
 >;
 
 const useGetMintableVai = (input: TrimmedGetMintableVaiInput, options?: Options) => {
+  const { chainId } = useAuth();
   const vaiControllerContract = useGetVaiControllerContract();
 
   return useQuery(
-    [FunctionKey.GET_MINTABLE_VAI, input],
+    [FunctionKey.GET_MINTABLE_VAI, { ...input, chainId }],
     () =>
       callOrThrow({ vaiControllerContract }, params =>
         getMintableVai({

--- a/src/clients/api/queries/getMintedVai/useGetMintedVai.ts
+++ b/src/clients/api/queries/getMintedVai/useGetMintedVai.ts
@@ -1,5 +1,6 @@
 import { useGetMainPoolComptrollerContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getMintedVai, {
@@ -7,21 +8,31 @@ import getMintedVai, {
   GetMintedVaiOutput,
 } from 'clients/api/queries/getMintedVai';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetMintedVaiOutput = Omit<GetMintedVaiInput, 'mainPoolComptrollerContract'>;
+
+export type UseGetMintedVaiQueryKey = [
+  FunctionKey.GET_MINTED_VAI,
+  TrimmedGetMintedVaiOutput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetMintedVaiOutput,
   Error,
   GetMintedVaiOutput,
   GetMintedVaiOutput,
-  [FunctionKey.GET_MINTED_VAI, TrimmedGetMintedVaiOutput]
+  UseGetMintedVaiQueryKey
 >;
 
 const useGetMintedVai = (input: TrimmedGetMintedVaiOutput, options?: Options) => {
+  const { chainId } = useAuth();
   const mainPoolComptrollerContract = useGetMainPoolComptrollerContract();
 
   return useQuery(
-    [FunctionKey.GET_MINTED_VAI, input],
+    [FunctionKey.GET_MINTED_VAI, { ...input, chainId }],
     () =>
       callOrThrow({ mainPoolComptrollerContract }, params =>
         getMintedVai({

--- a/src/clients/api/queries/getPancakeSwapPairs/useGetPancakeSwapPairs.ts
+++ b/src/clients/api/queries/getPancakeSwapPairs/useGetPancakeSwapPairs.ts
@@ -1,4 +1,5 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 
 import getPancakeSwapPairs, {
   GetPancakeSwapPairsInput,
@@ -10,25 +11,31 @@ import { useAuth } from 'context/AuthContext';
 
 import generateTokenCombinationIds from './generateTokenCombinationIds';
 
+export type UseGetPancakeSwapPairsQueryKey = [
+  FunctionKey.GET_PANCAKE_SWAP_PAIRS,
+  { chainId: ChainId },
+  ...string[],
+];
+
 type Options = QueryObserverOptions<
   GetPancakeSwapPairsOutput,
   Error,
   GetPancakeSwapPairsOutput,
   GetPancakeSwapPairsOutput,
-  [FunctionKey.GET_PANCAKE_SWAP_PAIRS, ...string[]]
+  UseGetPancakeSwapPairsQueryKey
 >;
 
 const useGetPancakeSwapPairs = (
   input: Omit<GetPancakeSwapPairsInput, 'provider' | 'chainId'>,
   options?: Options,
 ) => {
-  const { provider } = useAuth();
+  const { provider, chainId } = useAuth();
 
   // Generate query key based on token combinations
   const tokenCombinationIds = generateTokenCombinationIds(input.tokenCombinations);
 
   return useQuery(
-    [FunctionKey.GET_PANCAKE_SWAP_PAIRS, ...tokenCombinationIds],
+    [FunctionKey.GET_PANCAKE_SWAP_PAIRS, { chainId }, ...tokenCombinationIds],
     () => getPancakeSwapPairs({ ...input, provider }),
     {
       // Refresh request on every new block

--- a/src/clients/api/queries/getPrimeStatus/useGetPrimeStatus.ts
+++ b/src/clients/api/queries/getPrimeStatus/useGetPrimeStatus.ts
@@ -1,29 +1,39 @@
 import { useGetPrimeContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import { GetPrimeStatusOutput, getPrimeStatus } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 interface UseGetPrimeStatusInput {
   accountAddress?: string;
 }
 
+export type UseGetPrimeStatusQueryKey = [
+  FunctionKey.GET_PRIME_STATUS,
+  UseGetPrimeStatusInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetPrimeStatusOutput,
   Error,
   GetPrimeStatusOutput,
   GetPrimeStatusOutput,
-  [FunctionKey.GET_PRIME_STATUS, UseGetPrimeStatusInput]
+  UseGetPrimeStatusQueryKey
 >;
 
 const useGetPrimeStatus = ({ accountAddress }: UseGetPrimeStatusInput, options?: Options) => {
+  const { chainId } = useAuth();
   const isPrimeEnabled = useIsFeatureEnabled({ name: 'prime' });
   const primeContract = useGetPrimeContract();
 
   return useQuery(
-    [FunctionKey.GET_PRIME_STATUS, { accountAddress }],
+    [FunctionKey.GET_PRIME_STATUS, { accountAddress, chainId }],
     () => callOrThrow({ accountAddress, primeContract }, params => getPrimeStatus(params)),
     {
       ...options,

--- a/src/clients/api/queries/getPrimeToken/useGetPrimeToken.ts
+++ b/src/clients/api/queries/getPrimeToken/useGetPrimeToken.ts
@@ -1,29 +1,39 @@
 import { useGetPrimeContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import { GetPrimeTokenOutput, getPrimeToken } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 type UseGetPrimeTokenInput = {
   accountAddress?: string;
 };
 
+export type UseGetPrimeStatusQueryKey = [
+  FunctionKey.GET_PRIME_TOKEN,
+  UseGetPrimeTokenInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetPrimeTokenOutput,
   Error,
   GetPrimeTokenOutput,
   GetPrimeTokenOutput,
-  [FunctionKey.GET_PRIME_TOKEN, UseGetPrimeTokenInput]
+  UseGetPrimeStatusQueryKey
 >;
 
 const useGetPrimeToken = (input: UseGetPrimeTokenInput, options?: Options) => {
+  const { chainId } = useAuth();
   const isPrimeEnabled = useIsFeatureEnabled({ name: 'prime' });
   const primeContract = useGetPrimeContract();
 
   return useQuery(
-    [FunctionKey.GET_PRIME_TOKEN, input],
+    [FunctionKey.GET_PRIME_TOKEN, { ...input, chainId }],
     () =>
       callOrThrow({ primeContract, accountAddress: input.accountAddress }, params =>
         getPrimeToken(params),

--- a/src/clients/api/queries/getProposalEta/useGetProposalEta.ts
+++ b/src/clients/api/queries/getProposalEta/useGetProposalEta.ts
@@ -6,6 +6,7 @@ import getProposalEta, {
   GetProposalEtaInput,
   GetProposalEtaOutput,
 } from 'clients/api/queries/getProposalEta';
+import { governanceChain } from 'clients/web3';
 import FunctionKey from 'constants/functionKey';
 
 type TrimmedGetProposalEtaInput = Omit<GetProposalEtaInput, 'governorBravoDelegateContract'>;
@@ -19,7 +20,9 @@ type Options = QueryObserverOptions<
 >;
 
 const useGetProposalEta = (input: TrimmedGetProposalEtaInput, options?: Options) => {
-  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract();
+  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract({
+    chainId: governanceChain.id,
+  });
 
   return useQuery(
     [FunctionKey.GET_PROPOSAL_ETA, input],

--- a/src/clients/api/queries/getProposalState/useGetProposalState.ts
+++ b/src/clients/api/queries/getProposalState/useGetProposalState.ts
@@ -6,6 +6,7 @@ import getProposalState, {
   GetProposalStateInput,
   GetProposalStateOutput,
 } from 'clients/api/queries/getProposalState';
+import { governanceChain } from 'clients/web3';
 import { BLOCK_TIME_MS } from 'constants/bsc';
 import FunctionKey from 'constants/functionKey';
 
@@ -20,7 +21,9 @@ type Options = QueryObserverOptions<
 >;
 
 const useGetProposalState = (input: TrimmedGetProposalStateInput, options?: Options) => {
-  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract();
+  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract({
+    chainId: governanceChain.id,
+  });
 
   return useQuery(
     [FunctionKey.GET_PROPOSAL_STATE, input],

--- a/src/clients/api/queries/getProposalThreshold/useGetProposalThreshold.ts
+++ b/src/clients/api/queries/getProposalThreshold/useGetProposalThreshold.ts
@@ -5,6 +5,7 @@ import { callOrThrow } from 'utilities';
 import getProposalThreshold, {
   GetProposalThresholdOutput,
 } from 'clients/api/queries/getProposalThreshold';
+import { governanceChain } from 'clients/web3';
 import FunctionKey from 'constants/functionKey';
 
 type Options = QueryObserverOptions<
@@ -16,7 +17,9 @@ type Options = QueryObserverOptions<
 >;
 
 const useGetProposalThreshold = (options?: Options) => {
-  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract();
+  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract({
+    chainId: governanceChain.id,
+  });
 
   return useQuery(
     FunctionKey.GET_PROPOSAL_THRESHOLD,

--- a/src/clients/api/queries/getTokenBalances/useGetTokenBalances.ts
+++ b/src/clients/api/queries/getTokenBalances/useGetTokenBalances.ts
@@ -1,28 +1,32 @@
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 
 import { GetTokenBalancesInput, GetTokenBalancesOutput, getTokenBalances } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
+
+export type UseGetTokenBalancesQueryKey = [
+  FunctionKey.GET_TOKEN_BALANCES,
+  {
+    accountAddress: string;
+    chainId: ChainId;
+  },
+  ...string[],
+];
 
 export type Options = QueryObserverOptions<
   GetTokenBalancesOutput,
   Error,
   GetTokenBalancesOutput,
   GetTokenBalancesOutput,
-  [
-    FunctionKey.GET_TOKEN_BALANCES,
-    {
-      accountAddress: string;
-    },
-    ...string[],
-  ]
+  UseGetTokenBalancesQueryKey
 >;
 
 const useGetTokenBalances = (
   { accountAddress, tokens }: Omit<GetTokenBalancesInput, 'multicall3' | 'provider'>,
   options?: Options,
 ) => {
-  const { provider } = useAuth();
+  const { provider, chainId } = useAuth();
 
   // Sort addresses alphabetically to prevent unnecessary re-renders
   const sortedTokenAddresses = [...tokens].map(token => token.address).sort();
@@ -32,6 +36,7 @@ const useGetTokenBalances = (
       FunctionKey.GET_TOKEN_BALANCES,
       {
         accountAddress,
+        chainId,
       },
       ...sortedTokenAddresses,
     ],

--- a/src/clients/api/queries/getVTokenApySimulations/useGetVTokenApySimulations.ts
+++ b/src/clients/api/queries/getVTokenApySimulations/useGetVTokenApySimulations.ts
@@ -1,7 +1,7 @@
 import { getJumpRateModelContract, getJumpRateModelV2Contract } from 'packages/contracts';
 import { useMemo } from 'react';
 import { QueryObserverOptions, useQuery } from 'react-query';
-import { Asset, VToken } from 'types';
+import { Asset, ChainId, VToken } from 'types';
 
 import getVTokenApySimulations, {
   GetVTokenApySimulationsOutput,
@@ -10,12 +10,17 @@ import useGetVTokenInterestRateModel from 'clients/api/queries/getVTokenInterest
 import FunctionKey from 'constants/functionKey';
 import { useAuth } from 'context/AuthContext';
 
+export type UseGetVTokenApySimulationsQueryKey = [
+  FunctionKey.GET_V_TOKEN_APY_SIMULATIONS,
+  { vTokenAddress: string; chainId: ChainId },
+];
+
 type Options = QueryObserverOptions<
   GetVTokenApySimulationsOutput,
   Error,
   GetVTokenApySimulationsOutput,
   GetVTokenApySimulationsOutput,
-  [FunctionKey.GET_V_TOKEN_APY_SIMULATIONS, { vTokenAddress: string }]
+  UseGetVTokenApySimulationsQueryKey
 >;
 
 const useGetVTokenApySimulations = (
@@ -30,7 +35,7 @@ const useGetVTokenApySimulations = (
   },
   options?: Options,
 ) => {
-  const { provider } = useAuth();
+  const { provider, chainId } = useAuth();
   const { data: interestRateModelData } = useGetVTokenInterestRateModel({ vToken });
 
   const interestRateModelContract = useMemo(() => {
@@ -49,7 +54,7 @@ const useGetVTokenApySimulations = (
   }, [interestRateModelData?.contractAddress, isIsolatedPoolMarket, provider]);
 
   return useQuery(
-    [FunctionKey.GET_V_TOKEN_APY_SIMULATIONS, { vTokenAddress: vToken.address }],
+    [FunctionKey.GET_V_TOKEN_APY_SIMULATIONS, { vTokenAddress: vToken.address, chainId }],
     () =>
       getVTokenApySimulations({
         interestRateModelContract: interestRateModelContract!, // Checked through enabled option

--- a/src/clients/api/queries/getVTokenBalanceOf/useGetVTokenBalanceOf.ts
+++ b/src/clients/api/queries/getVTokenBalanceOf/useGetVTokenBalanceOf.ts
@@ -1,6 +1,6 @@
 import { useGetVTokenContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
-import { VToken } from 'types';
+import { ChainId, VToken } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getVTokenBalanceOf, {
@@ -8,27 +8,37 @@ import getVTokenBalanceOf, {
   GetVTokenBalanceOfOutput,
 } from 'clients/api/queries/getVTokenBalanceOf';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 interface TrimmedGetVTokenBalanceOfInput extends Omit<GetVTokenBalanceOfInput, 'vTokenContract'> {
   vToken: VToken;
 }
+
+export type UseGetVTokenBalanceOfQueryKey = [
+  FunctionKey.GET_V_TOKEN_BALANCE,
+  Omit<TrimmedGetVTokenBalanceOfInput, 'vToken'> & {
+    vTokenAddress: string;
+    chainId: ChainId;
+  },
+];
 
 type Options = QueryObserverOptions<
   GetVTokenBalanceOfOutput,
   Error,
   GetVTokenBalanceOfOutput,
   GetVTokenBalanceOfOutput,
-  [FunctionKey.GET_V_TOKEN_BALANCE, { accountAddress: string; vTokenAddress: string }]
+  UseGetVTokenBalanceOfQueryKey
 >;
 
 const useGetVTokenBalanceOf = (
   { accountAddress, vToken }: TrimmedGetVTokenBalanceOfInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const vTokenContract = useGetVTokenContract({ vToken });
 
   return useQuery(
-    [FunctionKey.GET_V_TOKEN_BALANCE, { accountAddress, vTokenAddress: vToken.address }],
+    [FunctionKey.GET_V_TOKEN_BALANCE, { accountAddress, vTokenAddress: vToken.address, chainId }],
     () =>
       callOrThrow({ vTokenContract }, params =>
         getVTokenBalanceOf({

--- a/src/clients/api/queries/getVTokenBalancesAll/useGetVTokenBalancesAll.ts
+++ b/src/clients/api/queries/getVTokenBalancesAll/useGetVTokenBalancesAll.ts
@@ -1,5 +1,6 @@
 import { useGetVenusLensContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getVTokenBalancesAll, {
@@ -7,21 +8,31 @@ import getVTokenBalancesAll, {
   GetVTokenBalancesAllOutput,
 } from 'clients/api/queries/getVTokenBalancesAll';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetVTokenBalancesAllInput = Omit<GetVTokenBalancesAllInput, 'venusLensContract'>;
+
+export type UseGetVTokenBalancesAllQueryKey = [
+  FunctionKey.GET_V_TOKEN_BALANCES_ALL,
+  TrimmedGetVTokenBalancesAllInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetVTokenBalancesAllOutput,
   Error,
   GetVTokenBalancesAllOutput,
   GetVTokenBalancesAllOutput,
-  [FunctionKey.GET_V_TOKEN_BALANCES_ALL, TrimmedGetVTokenBalancesAllInput]
+  UseGetVTokenBalancesAllQueryKey
 >;
 
 const useGetVTokenBalancesAll = (input: TrimmedGetVTokenBalancesAllInput, options?: Options) => {
+  const { chainId } = useAuth();
   const venusLensContract = useGetVenusLensContract();
 
   return useQuery(
-    [FunctionKey.GET_V_TOKEN_BALANCES_ALL, input],
+    [FunctionKey.GET_V_TOKEN_BALANCES_ALL, { ...input, chainId }],
     () =>
       callOrThrow({ venusLensContract }, params => getVTokenBalancesAll({ ...params, ...input })),
     options,

--- a/src/clients/api/queries/getVTokenInterestRateModel/useGetVTokenInterestRateModel.ts
+++ b/src/clients/api/queries/getVTokenInterestRateModel/useGetVTokenInterestRateModel.ts
@@ -1,26 +1,33 @@
 import { useGetVTokenContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
-import { VToken } from 'types';
+import { ChainId, VToken } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getVTokenInterestRateModel, {
   GetVTokenInterestRateModelOutput,
 } from 'clients/api/queries/getVTokenInterestRateModel';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
+
+export type UseGetVTokenInterestRateModelQueryKey = [
+  FunctionKey.GET_V_TOKEN_INTEREST_RATE_MODEL,
+  { vTokenAddress: string; chainId: ChainId },
+];
 
 type Options = QueryObserverOptions<
   GetVTokenInterestRateModelOutput,
   Error,
   GetVTokenInterestRateModelOutput,
   GetVTokenInterestRateModelOutput,
-  [FunctionKey.GET_V_TOKEN_INTEREST_RATE_MODEL, { vTokenAddress: string }]
+  UseGetVTokenInterestRateModelQueryKey
 >;
 
 const useGetVTokenInterestRateModel = ({ vToken }: { vToken: VToken }, options?: Options) => {
+  const { chainId } = useAuth();
   const vTokenContract = useGetVTokenContract({ vToken });
 
   return useQuery(
-    [FunctionKey.GET_V_TOKEN_INTEREST_RATE_MODEL, { vTokenAddress: vToken.address }],
+    [FunctionKey.GET_V_TOKEN_INTEREST_RATE_MODEL, { vTokenAddress: vToken.address, chainId }],
     () => callOrThrow({ vTokenContract }, getVTokenInterestRateModel),
     options,
   );

--- a/src/clients/api/queries/getVaiCalculateRepayAmount/useGetVaiCalculateRepayAmount.ts
+++ b/src/clients/api/queries/getVaiCalculateRepayAmount/useGetVaiCalculateRepayAmount.ts
@@ -1,24 +1,29 @@
 import { useGetVaiControllerContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import { getVaiCalculateRepayAmount } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 import { GetVaiCalculateRepayAmountInput, GetVaiCalculateRepayAmountOutput } from './types';
+
+export type UseGetVaiCalculateRepayAmountQueryKey = [
+  FunctionKey.GET_VAI_CALCULATE_REPAY_AMOUNT,
+  {
+    accountAddress: string;
+    repayAmountWei: string;
+    chainId: ChainId;
+  },
+];
 
 type Options = QueryObserverOptions<
   GetVaiCalculateRepayAmountOutput | undefined,
   Error,
   GetVaiCalculateRepayAmountOutput | undefined,
   GetVaiCalculateRepayAmountOutput | undefined,
-  [
-    FunctionKey.GET_VAI_CALCULATE_REPAY_AMOUNT,
-    {
-      accountAddress: string;
-      repayAmountWei: string;
-    },
-  ]
+  UseGetVaiCalculateRepayAmountQueryKey
 >;
 
 const useGetVaiCalculateRepayAmount = (
@@ -28,6 +33,7 @@ const useGetVaiCalculateRepayAmount = (
   }: Omit<GetVaiCalculateRepayAmountInput, 'vaiControllerContract'>,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const vaiControllerContract = useGetVaiControllerContract();
 
   return useQuery(
@@ -35,6 +41,7 @@ const useGetVaiCalculateRepayAmount = (
       FunctionKey.GET_VAI_CALCULATE_REPAY_AMOUNT,
       {
         accountAddress,
+        chainId,
         repayAmountWei: repayAmountWei.toFixed(),
       },
     ],

--- a/src/clients/api/queries/getVaiRepayAmountWithInterests/useGetVaiRepayAmountWithInterests.ts
+++ b/src/clients/api/queries/getVaiRepayAmountWithInterests/useGetVaiRepayAmountWithInterests.ts
@@ -1,29 +1,39 @@
 import { useGetVaiControllerContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import { getVaiRepayAmountWithInterests } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 import { GetVaiRepayAmountWithInterestsInput, GetVaiRepayAmountWithInterestsOutput } from './types';
+
+type TrimmedGetVaiRepayAmountWithInterestsInput = Omit<
+  GetVaiRepayAmountWithInterestsInput,
+  'vaiControllerContract'
+>;
+
+export type UseGetVaiRepayAmountWithInterestsQueryKey = [
+  FunctionKey.GET_VAI_REPAY_AMOUNT_WITH_INTERESTS,
+  TrimmedGetVaiRepayAmountWithInterestsInput & {
+    chainId: ChainId;
+  },
+];
 
 type Options = QueryObserverOptions<
   GetVaiRepayAmountWithInterestsOutput | undefined,
   Error,
   GetVaiRepayAmountWithInterestsOutput | undefined,
   GetVaiRepayAmountWithInterestsOutput | undefined,
-  [
-    FunctionKey.GET_VAI_REPAY_AMOUNT_WITH_INTERESTS,
-    {
-      accountAddress: string;
-    },
-  ]
+  UseGetVaiRepayAmountWithInterestsQueryKey
 >;
 
 const useGetVaiRepayAmountWithInterests = (
-  { accountAddress }: Omit<GetVaiRepayAmountWithInterestsInput, 'vaiControllerContract'>,
+  { accountAddress }: TrimmedGetVaiRepayAmountWithInterestsInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const vaiControllerContract = useGetVaiControllerContract();
 
   return useQuery(
@@ -31,6 +41,7 @@ const useGetVaiRepayAmountWithInterests = (
       FunctionKey.GET_VAI_REPAY_AMOUNT_WITH_INTERESTS,
       {
         accountAddress,
+        chainId,
       },
     ],
     () =>

--- a/src/clients/api/queries/getVaiRepayApy/useGetVaiRepayApy.ts
+++ b/src/clients/api/queries/getVaiRepayApy/useGetVaiRepayApy.ts
@@ -1,23 +1,28 @@
 import { useGetVaiControllerContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getVaiRepayApy, { GetVaiRepayApyOutput } from 'clients/api/queries/getVaiRepayApy';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
+
+export type UseGetVaiRepayApyQueryKey = [FunctionKey.GET_VAI_REPAY_APY, { chainId: ChainId }];
 
 type Options = QueryObserverOptions<
   GetVaiRepayApyOutput | undefined,
   Error,
   GetVaiRepayApyOutput | undefined,
   GetVaiRepayApyOutput | undefined,
-  FunctionKey.GET_VAI_REPAY_APY
+  UseGetVaiRepayApyQueryKey
 >;
 
 const useGetVaiRepayApy = (options?: Options) => {
+  const { chainId } = useAuth();
   const vaiControllerContract = useGetVaiControllerContract();
 
   return useQuery(
-    FunctionKey.GET_VAI_REPAY_APY,
+    [FunctionKey.GET_VAI_REPAY_APY, { chainId }],
     () => callOrThrow({ vaiControllerContract }, getVaiRepayApy),
     options,
   );

--- a/src/clients/api/queries/getVaiTreasuryPercentage/useGetVaiTreasuryPercentage.ts
+++ b/src/clients/api/queries/getVaiTreasuryPercentage/useGetVaiTreasuryPercentage.ts
@@ -1,23 +1,31 @@
 import { useGetVaiControllerContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import { GetVaiTreasuryPercentageOutput, getVaiTreasuryPercentage } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
+
+export type UseGetVaiTreasuryPercentageQueryKey = [
+  FunctionKey.GET_VAI_TREASURY_PERCENTAGE,
+  { chainId: ChainId },
+];
 
 type Options = QueryObserverOptions<
   GetVaiTreasuryPercentageOutput | undefined,
   Error,
   GetVaiTreasuryPercentageOutput | undefined,
   GetVaiTreasuryPercentageOutput | undefined,
-  FunctionKey.GET_VAI_TREASURY_PERCENTAGE
+  UseGetVaiTreasuryPercentageQueryKey
 >;
 
 const useGetVaiTreasuryPercentage = (options?: Options) => {
+  const { chainId } = useAuth();
   const vaiControllerContract = useGetVaiControllerContract();
 
   return useQuery(
-    FunctionKey.GET_VAI_TREASURY_PERCENTAGE,
+    [FunctionKey.GET_VAI_TREASURY_PERCENTAGE, { chainId }],
     () => callOrThrow({ vaiControllerContract }, getVaiTreasuryPercentage),
     options,
   );

--- a/src/clients/api/queries/getVaiVaultUserInfo/useGetVaiVaultUserInfo.ts
+++ b/src/clients/api/queries/getVaiVaultUserInfo/useGetVaiVaultUserInfo.ts
@@ -1,5 +1,6 @@
 import { useGetVaiVaultContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import {
@@ -8,21 +9,31 @@ import {
   getVaiVaultUserInfo,
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetVaiVaultUserInfoInput = Omit<GetVaiVaultUserInfoInput, 'vaiVaultContract'>;
+
+export type UseGetVaiVaultUserInfoQueryKey = [
+  FunctionKey.GET_VAI_VAULT_USER_INFO,
+  TrimmedGetVaiVaultUserInfoInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetVaiVaultUserInfoOutput,
   Error,
   GetVaiVaultUserInfoOutput,
   GetVaiVaultUserInfoOutput,
-  [FunctionKey.GET_VAI_VAULT_USER_INFO, TrimmedGetVaiVaultUserInfoInput]
+  UseGetVaiVaultUserInfoQueryKey
 >;
 
 const useGetVaiVaultUserInfo = (input: TrimmedGetVaiVaultUserInfoInput, options?: Options) => {
+  const { chainId } = useAuth();
   const vaiVaultContract = useGetVaiVaultContract();
 
   return useQuery(
-    [FunctionKey.GET_VAI_VAULT_USER_INFO, input],
+    [FunctionKey.GET_VAI_VAULT_USER_INFO, { ...input, chainId }],
     () => callOrThrow({ vaiVaultContract }, params => getVaiVaultUserInfo({ ...params, ...input })),
     options,
   );

--- a/src/clients/api/queries/getVenusVaiVaultDailyRate/useGetVenusVaiVaultDailyRate.ts
+++ b/src/clients/api/queries/getVenusVaiVaultDailyRate/useGetVenusVaiVaultDailyRate.ts
@@ -1,23 +1,31 @@
 import { useGetMainPoolComptrollerContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import { GetVenusVaiVaultDailyRateOutput, getVenusVaiVaultDailyRate } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
+
+export type UseGetVenusVaiVaultDailyRateQueryKey = [
+  FunctionKey.GET_VENUS_VAI_VAULT_DAILY_RATE,
+  { chainId: ChainId },
+];
 
 type Options = QueryObserverOptions<
   GetVenusVaiVaultDailyRateOutput,
   Error,
   GetVenusVaiVaultDailyRateOutput,
   GetVenusVaiVaultDailyRateOutput,
-  FunctionKey.GET_VENUS_VAI_VAULT_DAILY_RATE
+  UseGetVenusVaiVaultDailyRateQueryKey
 >;
 
 const useGetVenusVaiVaultDailyRate = (options?: Options) => {
+  const { chainId } = useAuth();
   const mainPoolComptrollerContract = useGetMainPoolComptrollerContract();
 
   return useQuery(
-    FunctionKey.GET_VENUS_VAI_VAULT_DAILY_RATE,
+    [FunctionKey.GET_VENUS_VAI_VAULT_DAILY_RATE, { chainId }],
     () => callOrThrow({ mainPoolComptrollerContract }, getVenusVaiVaultDailyRate),
     options,
   );

--- a/src/clients/api/queries/getVoteDelegateAddress/useGetVoteDelegateAddress.ts
+++ b/src/clients/api/queries/getVoteDelegateAddress/useGetVoteDelegateAddress.ts
@@ -7,6 +7,7 @@ import {
   GetVoteDelegateAddressOutput,
   getVoteDelegateAddress,
 } from 'clients/api';
+import { governanceChain } from 'clients/web3';
 import FunctionKey from 'constants/functionKey';
 
 type TrimmedGetVoteDelegateAddressInput = Omit<GetVoteDelegateAddressInput, 'xvsVaultContract'>;
@@ -22,7 +23,9 @@ const useGetVoteDelegateAddress = (
   input: TrimmedGetVoteDelegateAddressInput,
   options?: Options,
 ) => {
-  const xvsVaultContract = useGetXvsVaultContract();
+  const xvsVaultContract = useGetXvsVaultContract({
+    chainId: governanceChain.id,
+  });
 
   return useQuery(
     [FunctionKey.GET_VOTE_DELEGATE_ADDRESS, input],

--- a/src/clients/api/queries/getVoteReceipt/useGetVoteReceipt.ts
+++ b/src/clients/api/queries/getVoteReceipt/useGetVoteReceipt.ts
@@ -2,6 +2,7 @@ import { useGetGovernorBravoDelegateContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
 import { callOrThrow } from 'utilities';
 
+import { governanceChain } from 'clients/web3';
 import FunctionKey from 'constants/functionKey';
 
 import getVoteReceipt, { GetVoteReceiptInput, GetVoteReceiptOutput } from '.';
@@ -18,7 +19,9 @@ type Options = QueryObserverOptions<
 
 const useGetVoteReceipt = (input: TrimmedGetVoteReceiptInput, options?: Options) => {
   const { accountAddress } = input;
-  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract();
+  const governorBravoDelegateContract = useGetGovernorBravoDelegateContract({
+    chainId: governanceChain.id,
+  });
 
   return useQuery(
     [FunctionKey.GET_VOTE_RECEIPT, input],

--- a/src/clients/api/queries/getVrtConversionEndTime/useGetVrtConversionEndTime.ts
+++ b/src/clients/api/queries/getVrtConversionEndTime/useGetVrtConversionEndTime.ts
@@ -1,25 +1,33 @@
 import { useGetVrtConverterContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getVrtConversionEndTime, {
   GetVrtConversionEndTimeOutput,
 } from 'clients/api/queries/getVrtConversionEndTime';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
+
+export type UseGetVrtConversionEndTimeIndexQueryIndex = [
+  FunctionKey.GET_VRT_CONVERSION_END_TIME,
+  { chainId: ChainId },
+];
 
 type Options = QueryObserverOptions<
   GetVrtConversionEndTimeOutput,
   Error,
   GetVrtConversionEndTimeOutput,
   GetVrtConversionEndTimeOutput,
-  FunctionKey.GET_VRT_CONVERSION_END_TIME
+  UseGetVrtConversionEndTimeIndexQueryIndex
 >;
 
 const useGetVrtConversionEndTimeIndex = (options?: Options) => {
+  const { chainId } = useAuth();
   const vrtConverterContract = useGetVrtConverterContract();
 
   return useQuery(
-    FunctionKey.GET_VRT_CONVERSION_END_TIME,
+    [FunctionKey.GET_VRT_CONVERSION_END_TIME, { chainId }],
     () => callOrThrow({ vrtConverterContract }, getVrtConversionEndTime),
     options,
   );

--- a/src/clients/api/queries/getVrtConversionRatio/useGetVrtConversionRatio.ts
+++ b/src/clients/api/queries/getVrtConversionRatio/useGetVrtConversionRatio.ts
@@ -1,25 +1,33 @@
 import { useGetVrtConverterContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getVrtConversionRatio, {
   GetVrtConversionRatioOutput,
 } from 'clients/api/queries/getVrtConversionRatio';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
+
+export type UseGetVrtConversionRatioQueryKey = [
+  FunctionKey.GET_VRT_CONVERSION_RATIO,
+  { chainId: ChainId },
+];
 
 type Options = QueryObserverOptions<
   GetVrtConversionRatioOutput,
   Error,
   GetVrtConversionRatioOutput,
   GetVrtConversionRatioOutput,
-  FunctionKey.GET_VRT_CONVERSION_RATIO
+  UseGetVrtConversionRatioQueryKey
 >;
 
 const useGetVrtConversionRatio = (options?: Options) => {
+  const { chainId } = useAuth();
   const vrtConverterContract = useGetVrtConverterContract();
 
   return useQuery(
-    FunctionKey.GET_VRT_CONVERSION_RATIO,
+    [FunctionKey.GET_VRT_CONVERSION_RATIO, { chainId }],
     () => callOrThrow({ vrtConverterContract }, getVrtConversionRatio),
     options,
   );

--- a/src/clients/api/queries/getXvsVaultLockedDeposits/useGetXvsVaultLockedDeposits.ts
+++ b/src/clients/api/queries/getXvsVaultLockedDeposits/useGetXvsVaultLockedDeposits.ts
@@ -1,5 +1,6 @@
 import { useGetXvsVaultContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsVaultLockedDeposits, {
@@ -7,27 +8,37 @@ import getXvsVaultLockedDeposits, {
   GetXvsVaultLockedDepositsOutput,
 } from 'clients/api/queries/getXvsVaultLockedDeposits';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetXvsVaultLockedDepositsInput = Omit<
   GetXvsVaultLockedDepositsInput,
   'xvsVaultContract'
 >;
+
+export type UseGetXvsVaultLockedDepositsQueryKey = [
+  FunctionKey.GET_XVS_VAULT_WITHDRAWAL_REQUESTS,
+  TrimmedGetXvsVaultLockedDepositsInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetXvsVaultLockedDepositsOutput,
   Error,
   GetXvsVaultLockedDepositsOutput,
   GetXvsVaultLockedDepositsOutput,
-  [FunctionKey.GET_XVS_VAULT_WITHDRAWAL_REQUESTS, TrimmedGetXvsVaultLockedDepositsInput]
+  UseGetXvsVaultLockedDepositsQueryKey
 >;
 
 const useGetXvsVaultLockedDeposits = (
   input: TrimmedGetXvsVaultLockedDepositsInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const xvsVaultContract = useGetXvsVaultContract();
 
   return useQuery(
-    [FunctionKey.GET_XVS_VAULT_WITHDRAWAL_REQUESTS, input],
+    [FunctionKey.GET_XVS_VAULT_WITHDRAWAL_REQUESTS, { ...input, chainId }],
     () =>
       callOrThrow({ xvsVaultContract }, params =>
         getXvsVaultLockedDeposits({ ...params, ...input }),

--- a/src/clients/api/queries/getXvsVaultPendingWithdrawalsFromBeforeUpgrade/useGetXvsVaultPendingWithdrawalsFromBeforeUpgrade.ts
+++ b/src/clients/api/queries/getXvsVaultPendingWithdrawalsFromBeforeUpgrade/useGetXvsVaultPendingWithdrawalsFromBeforeUpgrade.ts
@@ -1,5 +1,6 @@
 import { useGetXvsVaultContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsVaultPendingWithdrawalsFromBeforeUpgrade, {
@@ -7,30 +8,37 @@ import getXvsVaultPendingWithdrawalsFromBeforeUpgrade, {
   GetXvsVaultPendingWithdrawalsFromBeforeUpgradeOutput,
 } from 'clients/api/queries/getXvsVaultPendingWithdrawalsFromBeforeUpgrade';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetXvsVaultPendingWithdrawalsFromBeforeUpgradeInput = Omit<
   GetXvsVaultPendingWithdrawalsFromBeforeUpgradeInput,
   'xvsVaultContract'
 >;
+
+export type UseGetXvsVaultPendingWithdrawalsFromBeforeUpgradeQueryKey = [
+  FunctionKey.GET_XVS_VAULT_PENDING_WITHDRAWALS_FROM_BEFORE_UPGRADE,
+  TrimmedGetXvsVaultPendingWithdrawalsFromBeforeUpgradeInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetXvsVaultPendingWithdrawalsFromBeforeUpgradeOutput,
   Error,
   GetXvsVaultPendingWithdrawalsFromBeforeUpgradeOutput,
   GetXvsVaultPendingWithdrawalsFromBeforeUpgradeOutput,
-  [
-    FunctionKey.GET_XVS_VAULT_PENDING_WITHDRAWALS_FROM_BEFORE_UPGRADE,
-    TrimmedGetXvsVaultPendingWithdrawalsFromBeforeUpgradeInput,
-  ]
+  UseGetXvsVaultPendingWithdrawalsFromBeforeUpgradeQueryKey
 >;
 
 const useGetXvsVaultPendingWithdrawalsFromBeforeUpgrade = (
   input: TrimmedGetXvsVaultPendingWithdrawalsFromBeforeUpgradeInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const xvsVaultContract = useGetXvsVaultContract();
 
   return useQuery(
-    [FunctionKey.GET_XVS_VAULT_PENDING_WITHDRAWALS_FROM_BEFORE_UPGRADE, input],
+    [FunctionKey.GET_XVS_VAULT_PENDING_WITHDRAWALS_FROM_BEFORE_UPGRADE, { ...input, chainId }],
     () =>
       callOrThrow({ xvsVaultContract }, params =>
         getXvsVaultPendingWithdrawalsFromBeforeUpgrade({ ...params, ...input }),

--- a/src/clients/api/queries/getXvsVaultPoolCount/useGetXvsVaultPoolCount.ts
+++ b/src/clients/api/queries/getXvsVaultPoolCount/useGetXvsVaultPoolCount.ts
@@ -1,22 +1,30 @@
 import { useGetXvsVaultContract } from 'packages/contracts';
 import { useGetToken } from 'packages/tokens';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsVaultPoolCount, {
   GetXvsVaultPoolCountOutput,
 } from 'clients/api/queries/getXvsVaultPoolCount';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
+
+export type UseGetXvsVaultPoolCountQueryKey = [
+  FunctionKey.GET_XVS_VAULT_POOLS_COUNT,
+  { chainId: ChainId },
+];
 
 type Options = QueryObserverOptions<
   GetXvsVaultPoolCountOutput,
   Error,
   GetXvsVaultPoolCountOutput,
   GetXvsVaultPoolCountOutput,
-  FunctionKey.GET_XVS_VAULT_POOLS_COUNT
+  UseGetXvsVaultPoolCountQueryKey
 >;
 
 const useGetXvsVaultPoolCount = (options?: Options) => {
+  const { chainId } = useAuth();
   const xvsVaultContract = useGetXvsVaultContract();
 
   const xvs = useGetToken({
@@ -24,7 +32,7 @@ const useGetXvsVaultPoolCount = (options?: Options) => {
   });
 
   return useQuery(
-    FunctionKey.GET_XVS_VAULT_POOLS_COUNT,
+    [FunctionKey.GET_XVS_VAULT_POOLS_COUNT, { chainId }],
     () => callOrThrow({ xvsVaultContract, xvsTokenAddress: xvs?.address }, getXvsVaultPoolCount),
     options,
   );

--- a/src/clients/api/queries/getXvsVaultPoolInfo/useGetXvsVaultPoolInfo.ts
+++ b/src/clients/api/queries/getXvsVaultPoolInfo/useGetXvsVaultPoolInfo.ts
@@ -1,5 +1,6 @@
 import { useGetXvsVaultContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsVaultPoolInfo, {
@@ -7,21 +8,31 @@ import getXvsVaultPoolInfo, {
   GetXvsVaultPoolInfoOutput,
 } from 'clients/api/queries/getXvsVaultPoolInfo';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetXvsVaultPoolInfoInput = Omit<GetXvsVaultPoolInfoInput, 'xvsVaultContract'>;
+
+export type UseGetXvsVaultPoolInfoQueryKey = [
+  FunctionKey.GET_XVS_VAULT_POOL_INFOS,
+  TrimmedGetXvsVaultPoolInfoInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetXvsVaultPoolInfoOutput,
   Error,
   GetXvsVaultPoolInfoOutput,
   GetXvsVaultPoolInfoOutput,
-  [FunctionKey.GET_XVS_VAULT_POOL_INFOS, TrimmedGetXvsVaultPoolInfoInput]
+  UseGetXvsVaultPoolInfoQueryKey
 >;
 
 const useGetXvsVaultPoolInfo = (input: TrimmedGetXvsVaultPoolInfoInput, options?: Options) => {
+  const { chainId } = useAuth();
   const xvsVaultContract = useGetXvsVaultContract();
 
   return useQuery(
-    [FunctionKey.GET_XVS_VAULT_POOL_INFOS, input],
+    [FunctionKey.GET_XVS_VAULT_POOL_INFOS, { ...input, chainId }],
     () => callOrThrow({ xvsVaultContract }, params => getXvsVaultPoolInfo({ ...params, ...input })),
     options,
   );

--- a/src/clients/api/queries/getXvsVaultRewardPerBlock/useGetXvsVaultRewardPerBlock.ts
+++ b/src/clients/api/queries/getXvsVaultRewardPerBlock/useGetXvsVaultRewardPerBlock.ts
@@ -1,5 +1,6 @@
 import { useGetXvsVaultContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsVaultRewardPerBlock, {
@@ -7,27 +8,37 @@ import getXvsVaultRewardPerBlock, {
   GetXvsVaultRewardPerBlockOutput,
 } from 'clients/api/queries/getXvsVaultRewardPerBlock';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetXvsVaultRewardPerBlockInput = Omit<
   GetXvsVaultRewardPerBlockInput,
   'xvsVaultContract'
 >;
+
+export type UseGetXvsVaultRewardPerBlockQueryKey = [
+  FunctionKey.GET_XVS_VAULT_REWARD_PER_BLOCK,
+  TrimmedGetXvsVaultRewardPerBlockInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetXvsVaultRewardPerBlockOutput,
   Error,
   GetXvsVaultRewardPerBlockOutput,
   GetXvsVaultRewardPerBlockOutput,
-  [FunctionKey.GET_XVS_VAULT_REWARD_PER_BLOCK, TrimmedGetXvsVaultRewardPerBlockInput]
+  UseGetXvsVaultRewardPerBlockQueryKey
 >;
 
 const useGetXvsVaultRewardPerBlock = (
   input: TrimmedGetXvsVaultRewardPerBlockInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const xvsVaultContract = useGetXvsVaultContract();
 
   return useQuery(
-    [FunctionKey.GET_XVS_VAULT_REWARD_PER_BLOCK, input],
+    [FunctionKey.GET_XVS_VAULT_REWARD_PER_BLOCK, { ...input, chainId }],
     () =>
       callOrThrow({ xvsVaultContract }, params =>
         getXvsVaultRewardPerBlock({ ...params, ...input }),

--- a/src/clients/api/queries/getXvsVaultTotalAllocationPoints/useGetXvsVaultTotalAllocationPoints.ts
+++ b/src/clients/api/queries/getXvsVaultTotalAllocationPoints/useGetXvsVaultTotalAllocationPoints.ts
@@ -1,5 +1,6 @@
 import { useGetXvsVaultContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsVaultTotalAllocationPoints, {
@@ -7,27 +8,37 @@ import getXvsVaultTotalAllocationPoints, {
   GetXvsVaultTotalAllocPointsOutput,
 } from 'clients/api/queries/getXvsVaultTotalAllocationPoints';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetXvsVaultTotalAllocPointsInput = Omit<
   GetXvsVaultTotalAllocPointsInput,
   'xvsVaultContract'
 >;
+
+export type UseGetXvsVaultTotalAllocationPointsQueryKey = [
+  FunctionKey.GET_XVS_VAULT_TOTAL_ALLOCATION_POINTS,
+  TrimmedGetXvsVaultTotalAllocPointsInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetXvsVaultTotalAllocPointsOutput,
   Error,
   GetXvsVaultTotalAllocPointsOutput,
   GetXvsVaultTotalAllocPointsOutput,
-  [FunctionKey.GET_XVS_VAULT_TOTAL_ALLOCATION_POINTS, TrimmedGetXvsVaultTotalAllocPointsInput]
+  UseGetXvsVaultTotalAllocationPointsQueryKey
 >;
 
 const useGetXvsVaultTotalAllocationPoints = (
   input: TrimmedGetXvsVaultTotalAllocPointsInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const xvsVaultContract = useGetXvsVaultContract();
 
   return useQuery(
-    [FunctionKey.GET_XVS_VAULT_TOTAL_ALLOCATION_POINTS, input],
+    [FunctionKey.GET_XVS_VAULT_TOTAL_ALLOCATION_POINTS, { ...input, chainId }],
     () =>
       callOrThrow({ xvsVaultContract }, params =>
         getXvsVaultTotalAllocationPoints({ ...params, ...input }),

--- a/src/clients/api/queries/getXvsVaultUserInfo/useGetXvsVaultUserInfo.ts
+++ b/src/clients/api/queries/getXvsVaultUserInfo/useGetXvsVaultUserInfo.ts
@@ -1,5 +1,6 @@
 import { useGetXvsVaultContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsVaultUserInfo, {
@@ -7,21 +8,31 @@ import getXvsVaultUserInfo, {
   GetXvsVaultUserInfoOutput,
 } from 'clients/api/queries/getXvsVaultUserInfo';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetXvsVaultUserInfoInput = Omit<GetXvsVaultUserInfoInput, 'xvsVaultContract'>;
+
+export type UseGetXvsVaultUserInfoQueryKey = [
+  FunctionKey.GET_XVS_VAULT_USER_INFO,
+  TrimmedGetXvsVaultUserInfoInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetXvsVaultUserInfoOutput,
   Error,
   GetXvsVaultUserInfoOutput,
   GetXvsVaultUserInfoOutput,
-  [FunctionKey.GET_XVS_VAULT_USER_INFO, TrimmedGetXvsVaultUserInfoInput]
+  UseGetXvsVaultUserInfoQueryKey
 >;
 
 const useGetXvsVaultUserInfo = (input: TrimmedGetXvsVaultUserInfoInput, options?: Options) => {
+  const { chainId } = useAuth();
   const xvsVaultContract = useGetXvsVaultContract();
 
   return useQuery(
-    [FunctionKey.GET_XVS_VAULT_USER_INFO, input],
+    [FunctionKey.GET_XVS_VAULT_USER_INFO, { ...input, chainId }],
     () => callOrThrow({ xvsVaultContract }, params => getXvsVaultUserInfo({ ...params, ...input })),
     options,
   );

--- a/src/clients/api/queries/getXvsWithdrawableAmount/useGetXvsWithdrawableAmount.ts
+++ b/src/clients/api/queries/getXvsWithdrawableAmount/useGetXvsWithdrawableAmount.ts
@@ -1,5 +1,6 @@
 import { useGetXvsVestingContract } from 'packages/contracts';
 import { QueryObserverOptions, useQuery } from 'react-query';
+import { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
 import getXvsWithdrawableAmount, {
@@ -7,28 +8,37 @@ import getXvsWithdrawableAmount, {
   GetXvsWithdrawableAmountOutput,
 } from 'clients/api/queries/getXvsWithdrawableAmount';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 type TrimmedGetXvsWithdrawableAmountInput = Omit<
   GetXvsWithdrawableAmountInput,
   'xvsVestingContract'
 >;
 
+export type UseGetXvsWithdrawableAmountQueryKey = [
+  FunctionKey.GET_XVS_WITHDRAWABLE_AMOUNT,
+  TrimmedGetXvsWithdrawableAmountInput & {
+    chainId: ChainId;
+  },
+];
+
 type Options = QueryObserverOptions<
   GetXvsWithdrawableAmountOutput | undefined,
   Error,
   GetXvsWithdrawableAmountOutput | undefined,
   GetXvsWithdrawableAmountOutput | undefined,
-  [FunctionKey.GET_XVS_WITHDRAWABLE_AMOUNT, TrimmedGetXvsWithdrawableAmountInput]
+  UseGetXvsWithdrawableAmountQueryKey
 >;
 
 const useGetXvsWithdrawableAmount = (
   input: TrimmedGetXvsWithdrawableAmountInput,
   options?: Options,
 ) => {
+  const { chainId } = useAuth();
   const xvsVestingContract = useGetXvsVestingContract();
 
   return useQuery(
-    [FunctionKey.GET_XVS_WITHDRAWABLE_AMOUNT, input],
+    [FunctionKey.GET_XVS_WITHDRAWABLE_AMOUNT, { ...input, chainId }],
     () =>
       callOrThrow({ xvsVestingContract }, params =>
         getXvsWithdrawableAmount({ ...params, ...input }),

--- a/src/clients/api/queries/useGetVaults/index.spec.tsx
+++ b/src/clients/api/queries/useGetVaults/index.spec.tsx
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import BigNumber from 'bignumber.js';
 import React from 'react';
+import { ChainId } from 'types';
 import Vi from 'vitest';
 
 import compTrollerResponses from '__mocks__/contracts/mainPoolComptroller';
@@ -23,12 +24,19 @@ import {
 import formatToVaiVaultUserInfo from 'clients/api/queries/getVaiVaultUserInfo/formatToUserInfo';
 import formatToPoolInfo from 'clients/api/queries/getXvsVaultPoolInfo/formatToPoolInfo';
 import formatToXvsVaultUserInfo from 'clients/api/queries/getXvsVaultUserInfo/formatToUserInfo';
+import { useAuth } from 'context/AuthContext';
 import renderComponent from 'testUtils/renderComponent';
 
 import useGetVaults, { UseGetVaultsOutput } from '.';
 
+vi.mock('context/AuthContext');
+
 describe('api/queries/useGetVaults', () => {
   beforeEach(() => {
+    (useAuth as Vi.Mock).mockImplementation(() => ({
+      chainId: ChainId.BSC_TESTNET,
+    }));
+
     (getXvsVaultPoolCount as Vi.Mock).mockImplementation(() => ({
       poolCount: xvsVaultResponses.poolLength,
     }));

--- a/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPoolBalances.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPoolBalances.ts
@@ -16,7 +16,7 @@ export type UseGetXvsVaultPoolBalancesOutput = UseQueryResult<GetBalanceOfOutput
 const useGetXvsVaultPoolBalances = ({
   stakedTokenAddresses,
 }: UseGetXvsVaultPoolBalancesInput): UseGetXvsVaultPoolBalancesOutput => {
-  const { provider } = useAuth();
+  const { provider, chainId } = useAuth();
   const tokens = useGetTokens();
 
   const xvsVaultContractAddress = useGetXvsVaultContractAddress();
@@ -39,6 +39,7 @@ const useGetXvsVaultPoolBalances = ({
         queryKey: [
           FunctionKey.GET_BALANCE_OF,
           {
+            chainId,
             accountAddress: xvsVaultContractAddress,
             tokenAddress: stakedToken?.address,
           },

--- a/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPools.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVestingVaults/useGetXvsVaultPools.ts
@@ -12,6 +12,7 @@ import {
   getXvsVaultUserInfo,
 } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
+import { useAuth } from 'context/AuthContext';
 
 export interface UseGetXvsVaultPoolsInput {
   poolsCount: number;
@@ -28,6 +29,8 @@ const useGetXvsVaultPools = ({
   accountAddress,
   poolsCount,
 }: UseGetXvsVaultPoolsInput): UseGetXvsVaultPoolsOutput => {
+  const { chainId } = useAuth();
+
   const xvsVaultContract = useGetXvsVaultContract();
 
   const xvs = useGetToken({
@@ -54,7 +57,7 @@ const useGetXvsVaultPools = ({
         ),
       queryKey: [
         FunctionKey.GET_XVS_VAULT_POOL_INFOS,
-        { rewardTokenAddress: xvs?.address, poolIndex },
+        { chainId, rewardTokenAddress: xvs?.address, poolIndex },
       ],
     });
 
@@ -70,7 +73,7 @@ const useGetXvsVaultPools = ({
         ),
       queryKey: [
         FunctionKey.GET_XVS_VAULT_USER_INFO,
-        { accountAddress, rewardTokenAddress: xvs?.address, poolIndex },
+        { chainId, accountAddress, rewardTokenAddress: xvs?.address, poolIndex },
       ],
       enabled: !!accountAddress,
     });
@@ -87,7 +90,7 @@ const useGetXvsVaultPools = ({
         ),
       queryKey: [
         FunctionKey.GET_XVS_VAULT_PENDING_WITHDRAWALS_FROM_BEFORE_UPGRADE,
-        { accountAddress, rewardTokenAddress: xvs?.address, poolIndex },
+        { chainId, accountAddress, rewardTokenAddress: xvs?.address, poolIndex },
       ],
       enabled: !!accountAddress,
     });

--- a/src/clients/web3/chains.ts
+++ b/src/clients/web3/chains.ts
@@ -13,5 +13,7 @@ const getSupportedChains = (): Chain[] => {
   return [bsc];
 };
 
+export const governanceChain = localConfig.isOnTestnet ? bscTestnet : bsc;
+
 // Note: the first chain listed will be used as the default chain
 export const chains = getSupportedChains();

--- a/src/context/AuthContext/useProvider/__mocks__/index.ts
+++ b/src/context/AuthContext/useProvider/__mocks__/index.ts
@@ -1,0 +1,5 @@
+import { getDefaultProvider } from 'ethers';
+
+const defaultProvider = getDefaultProvider();
+const useProvider = () => defaultProvider;
+export default useProvider;

--- a/src/context/AuthContext/useProvider/index.ts
+++ b/src/context/AuthContext/useProvider/index.ts
@@ -1,10 +1,15 @@
 import { useMemo } from 'react';
+import { ChainId } from 'types';
 import { usePublicClient } from 'wagmi';
 
 import getProvider from './getProvider';
 
-const useProvider = () => {
-  const publicClient = usePublicClient();
+export interface UseProviderInput {
+  chainId?: ChainId;
+}
+
+const useProvider = (input?: UseProviderInput) => {
+  const publicClient = usePublicClient({ chainId: input?.chainId });
   return useMemo(() => getProvider({ publicClient }), [publicClient]);
 };
 

--- a/src/context/AuthContext/useSigner/__mocks__/index.ts
+++ b/src/context/AuthContext/useSigner/__mocks__/index.ts
@@ -1,0 +1,4 @@
+import fakeSigner from '__mocks__/models/signer';
+
+const useSigner = () => fakeSigner;
+export default useSigner;

--- a/src/context/AuthContext/useSigner/getSigner.ts
+++ b/src/context/AuthContext/useSigner/getSigner.ts
@@ -8,6 +8,7 @@ const getSigner = ({ walletClient }: { walletClient?: WalletClient } = {}) => {
   }
 
   const { account, chain, transport } = walletClient;
+
   const network = {
     chainId: chain.id,
     name: chain.name,

--- a/src/context/AuthContext/useSigner/index.ts
+++ b/src/context/AuthContext/useSigner/index.ts
@@ -1,10 +1,15 @@
 import { useMemo } from 'react';
+import { ChainId } from 'types';
 import { useWalletClient } from 'wagmi';
 
 import getSigner from './getSigner';
 
-const useSigner = () => {
-  const { data: walletClient } = useWalletClient();
+export interface UseSignerInput {
+  chainId?: ChainId;
+}
+
+const useSigner = (input?: UseSignerInput) => {
+  const { data: walletClient } = useWalletClient({ chainId: input?.chainId });
   return useMemo(() => getSigner({ walletClient: walletClient || undefined }), [walletClient]);
 };
 

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,8 @@
 exports[`generateGetters > calls writeFile with the right arguments 1`] = `
 [
   {
-    "content": "import type { Provider } from '@ethersproject/abstract-provider';
+    "content": "/* Automatically generated file, do not update manually */
+import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
 import abi from 'packages/contracts/generated/infos/abis/PoolLens.json';
 import { PoolLens } from 'packages/contracts/generated/infos/contractTypes';
@@ -11,15 +12,15 @@ import { useMemo } from 'react';
 import { ChainId } from 'types';
 
 import { useAuth } from 'context/AuthContext';
+import useProvider from 'context/AuthContext/useProvider';
+import useSigner from 'context/AuthContext/useSigner';
 import { getUniqueContractAddress } from 'packages/contracts/utilities/getUniqueContractAddress';
 
 interface GetPoolLensContractAddressInput {
   chainId: ChainId;
 }
 
-export const getPoolLensContractAddress = ({
-  chainId,
-}: GetPoolLensContractAddressInput) =>
+export const getPoolLensContractAddress = ({ chainId }: GetPoolLensContractAddressInput) =>
   getUniqueContractAddress({ name: 'PoolLens', chainId });
 
 export const useGetPoolLensContractAddress = () => {
@@ -39,24 +40,22 @@ interface GetPoolLensContractInput {
   signerOrProvider: Signer | Provider;
 }
 
-export const getPoolLensContract = ({
-  chainId,
-  signerOrProvider,
-}: GetPoolLensContractInput) => {
+export const getPoolLensContract = ({ chainId, signerOrProvider }: GetPoolLensContractInput) => {
   const address = getPoolLensContractAddress({ chainId });
-  return address
-    ? (new Contract(address, abi, signerOrProvider) as PoolLens)
-    : undefined;
+  return address ? (new Contract(address, abi, signerOrProvider) as PoolLens) : undefined;
 };
 
 interface UseGetPoolLensContractInput {
-  passSigner: boolean;
+  passSigner?: boolean;
+  chainId?: ChainId;
 }
 
-export const useGetPoolLensContract = (
-  input?: UseGetPoolLensContractInput,
-) => {
-  const { signer, provider, chainId } = useAuth();
+export const useGetPoolLensContract = (input?: UseGetPoolLensContractInput) => {
+  const { chainId: currentChainId } = useAuth();
+  const chainId = input?.chainId || currentChainId;
+
+  const provider = useProvider({ chainId: input?.chainId });
+  const signer = useSigner({ chainId: input?.chainId });
   const signerOrProvider = input?.passSigner ? signer : provider;
 
   return useMemo(
@@ -79,30 +78,40 @@ export const useGetPoolLensContract = (
 exports[`generateGetters > calls writeFile with the right arguments 2`] = `
 [
   {
-    "content": "/* Automatically generated file, do not update manually */
-import type { Provider } from '@ethersproject/abstract-provider';
+    "content": "import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
 import abi from 'packages/contracts/generated/infos/abis/IsolatedPoolComptroller.json';
 import { IsolatedPoolComptroller } from 'packages/contracts/generated/infos/contractTypes';
 import { useMemo } from 'react';
+import { ChainId } from 'types';
 
-import { useAuth } from 'context/AuthContext';
+import useProvider from 'context/AuthContext/useProvider';
+import useSigner from 'context/AuthContext/useSigner';
 
 interface GetIsolatedPoolComptrollerContractInput {
   address: string;
   signerOrProvider: Signer | Provider;
 }
 
-export const getIsolatedPoolComptrollerContract = ({ signerOrProvider, address }: GetIsolatedPoolComptrollerContractInput) =>
+export const getIsolatedPoolComptrollerContract = ({
+  signerOrProvider,
+  address,
+}: GetIsolatedPoolComptrollerContractInput) =>
   new Contract(address, abi, signerOrProvider) as IsolatedPoolComptroller;
 
 interface UseGetIsolatedPoolComptrollerContractInput {
   passSigner: boolean;
   address: string;
+  chainId?: ChainId;
 }
 
-export const useGetIsolatedPoolComptrollerContract = ({ passSigner = false, address }: UseGetIsolatedPoolComptrollerContractInput) => {
-  const { signer, provider } = useAuth();
+export const useGetIsolatedPoolComptrollerContract = ({
+  passSigner = false,
+  address,
+  chainId,
+}: UseGetIsolatedPoolComptrollerContractInput) => {
+  const provider = useProvider({ chainId });
+  const signer = useSigner({ chainId });
   const signerOrProvider = passSigner ? signer : provider;
 
   return useMemo(
@@ -125,8 +134,7 @@ export const useGetIsolatedPoolComptrollerContract = ({ passSigner = false, addr
 exports[`generateGetters > calls writeFile with the right arguments 3`] = `
 [
   {
-    "content": "/* Automatically generated file, do not update manually */
-import type { Provider } from '@ethersproject/abstract-provider';
+    "content": "import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
 import abi from 'packages/contracts/generated/infos/abis/SwapRouter.json';
 import addresses from 'packages/contracts/generated/infos/addresses';
@@ -135,6 +143,8 @@ import { useMemo } from 'react';
 import { ChainId } from 'types';
 
 import { useAuth } from 'context/AuthContext';
+import useProvider from 'context/AuthContext/useProvider';
+import useSigner from 'context/AuthContext/useSigner';
 
 interface GetSwapRouterContractAddressInput {
   comptrollerContractAddress: string;
@@ -154,12 +164,15 @@ export const getSwapRouterContractAddress = ({
 
 interface UseGetSwapRouterContractAddressInput {
   comptrollerContractAddress: string;
+  chainId?: ChainId;
 }
 
 export const useGetSwapRouterContractAddress = ({
   comptrollerContractAddress,
+  chainId: passedChainId,
 }: UseGetSwapRouterContractAddressInput) => {
-  const { chainId } = useAuth();
+  const { chainId: currentChainId } = useAuth();
+  const chainId = passedChainId || currentChainId;
 
   return useMemo(
     () =>
@@ -189,13 +202,19 @@ export const getSwapRouterContract = ({
 interface UseGetSwapRouterContractInput {
   passSigner: boolean;
   comptrollerContractAddress: string;
+  chainId?: ChainId;
 }
 
 export const useGetSwapRouterContract = ({
   passSigner = false,
   comptrollerContractAddress,
+  chainId: passedChainId,
 }: UseGetSwapRouterContractInput) => {
-  const { signer, provider, chainId } = useAuth();
+  const { chainId: currentChainId } = useAuth();
+  const chainId = passedChainId || currentChainId;
+
+  const provider = useProvider({ chainId });
+  const signer = useSigner({ chainId });
   const signerOrProvider = passSigner ? signer : provider;
 
   return useMemo(

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/genericContractGettersTemplate.hbs
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/genericContractGettersTemplate.hbs
@@ -1,27 +1,37 @@
-/* Automatically generated file, do not update manually */
 import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
 import abi from 'packages/contracts/generated/infos/abis/{{contractName}}.json';
 import { {{contractName}} } from 'packages/contracts/generated/infos/contractTypes';
 import { useMemo } from 'react';
+import { ChainId } from 'types';
 
-import { useAuth } from 'context/AuthContext';
+import useProvider from 'context/AuthContext/useProvider';
+import useSigner from 'context/AuthContext/useSigner';
 
 interface Get{{contractName}}ContractInput {
   address: string;
   signerOrProvider: Signer | Provider;
 }
 
-export const get{{contractName}}Contract = ({ signerOrProvider, address }: Get{{contractName}}ContractInput) =>
+export const get{{contractName}}Contract = ({
+  signerOrProvider,
+  address,
+}: Get{{contractName}}ContractInput) =>
   new Contract(address, abi, signerOrProvider) as {{contractName}};
 
 interface UseGet{{contractName}}ContractInput {
   passSigner: boolean;
   address: string;
+  chainId?: ChainId;
 }
 
-export const useGet{{contractName}}Contract = ({ passSigner = false, address }: UseGet{{contractName}}ContractInput) => {
-  const { signer, provider } = useAuth();
+export const useGet{{contractName}}Contract = ({
+  passSigner = false,
+  address,
+  chainId,
+}: UseGet{{contractName}}ContractInput) => {
+  const provider = useProvider({ chainId });
+  const signer = useSigner({ chainId });
   const signerOrProvider = passSigner ? signer : provider;
 
   return useMemo(

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/swapRouterContractGettersTemplate.hbs
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/swapRouterContractGettersTemplate.hbs
@@ -1,4 +1,3 @@
-/* Automatically generated file, do not update manually */
 import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
 import abi from 'packages/contracts/generated/infos/abis/{{contractName}}.json';
@@ -8,6 +7,8 @@ import { useMemo } from 'react';
 import { ChainId } from 'types';
 
 import { useAuth } from 'context/AuthContext';
+import useProvider from 'context/AuthContext/useProvider';
+import useSigner from 'context/AuthContext/useSigner';
 
 interface Get{{contractName}}ContractAddressInput {
   comptrollerContractAddress: string;
@@ -27,12 +28,15 @@ export const get{{contractName}}ContractAddress = ({
 
 interface UseGet{{contractName}}ContractAddressInput {
   comptrollerContractAddress: string;
+  chainId?: ChainId;
 }
 
 export const useGet{{contractName}}ContractAddress = ({
   comptrollerContractAddress,
+  chainId: passedChainId,
 }: UseGet{{contractName}}ContractAddressInput) => {
-  const { chainId } = useAuth();
+  const { chainId: currentChainId } = useAuth();
+  const chainId = passedChainId || currentChainId;
 
   return useMemo(
     () =>
@@ -62,13 +66,19 @@ export const get{{contractName}}Contract = ({
 interface UseGet{{contractName}}ContractInput {
   passSigner: boolean;
   comptrollerContractAddress: string;
+  chainId?: ChainId;
 }
 
 export const useGet{{contractName}}Contract = ({
   passSigner = false,
   comptrollerContractAddress,
+  chainId: passedChainId,
 }: UseGet{{contractName}}ContractInput) => {
-  const { signer, provider, chainId } = useAuth();
+  const { chainId: currentChainId } = useAuth();
+  const chainId = passedChainId || currentChainId;
+
+  const provider = useProvider({ chainId });
+  const signer = useSigner({ chainId });
   const signerOrProvider = passSigner ? signer : provider;
 
   return useMemo(

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniqueContractGettersTemplate.hbs
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniqueContractGettersTemplate.hbs
@@ -1,3 +1,4 @@
+/* Automatically generated file, do not update manually */
 import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
 import abi from 'packages/contracts/generated/infos/abis/{{contractName}}.json';
@@ -6,15 +7,15 @@ import { useMemo } from 'react';
 import { ChainId } from 'types';
 
 import { useAuth } from 'context/AuthContext';
+import useProvider from 'context/AuthContext/useProvider';
+import useSigner from 'context/AuthContext/useSigner';
 import { getUniqueContractAddress } from 'packages/contracts/utilities/getUniqueContractAddress';
 
 interface Get{{contractName}}ContractAddressInput {
   chainId: ChainId;
 }
 
-export const get{{contractName}}ContractAddress = ({
-  chainId,
-}: Get{{contractName}}ContractAddressInput) =>
+export const get{{contractName}}ContractAddress = ({ chainId }: Get{{contractName}}ContractAddressInput) =>
   getUniqueContractAddress({ name: '{{contractName}}', chainId });
 
 export const useGet{{contractName}}ContractAddress = () => {
@@ -34,24 +35,22 @@ interface Get{{contractName}}ContractInput {
   signerOrProvider: Signer | Provider;
 }
 
-export const get{{contractName}}Contract = ({
-  chainId,
-  signerOrProvider,
-}: Get{{contractName}}ContractInput) => {
+export const get{{contractName}}Contract = ({ chainId, signerOrProvider }: Get{{contractName}}ContractInput) => {
   const address = get{{contractName}}ContractAddress({ chainId });
-  return address
-    ? (new Contract(address, abi, signerOrProvider) as {{contractName}})
-    : undefined;
+  return address ? (new Contract(address, abi, signerOrProvider) as {{contractName}}) : undefined;
 };
 
 interface UseGet{{contractName}}ContractInput {
-  passSigner: boolean;
+  passSigner?: boolean;
+  chainId?: ChainId;
 }
 
-export const useGet{{contractName}}Contract = (
-  input?: UseGet{{contractName}}ContractInput,
-) => {
-  const { signer, provider, chainId } = useAuth();
+export const useGet{{contractName}}Contract = (input?: UseGet{{contractName}}ContractInput) => {
+  const { chainId: currentChainId } = useAuth();
+  const chainId = input?.chainId || currentChainId;
+
+  const provider = useProvider({ chainId: input?.chainId });
+  const signer = useSigner({ chainId: input?.chainId });
   const signerOrProvider = input?.passSigner ? signer : provider;
 
   return useMemo(

--- a/src/setupTests.tsx
+++ b/src/setupTests.tsx
@@ -15,6 +15,8 @@ vi.mock('hooks/useTokenApproval');
 vi.mock('clients/api');
 vi.mock('clients/web3/Web3Wrapper');
 vi.mock('packages/tokens');
+vi.mock('context/AuthContext/useSigner');
+vi.mock('context/AuthContext/useProvider');
 
 // Mock zustand library (optimized state manager)
 vi.mock('zustand');

--- a/src/stories/decorators.tsx
+++ b/src/stories/decorators.tsx
@@ -3,7 +3,7 @@ import { StoryFn } from '@storybook/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider, useQueryClient } from 'react-query';
 import { BrowserRouter } from 'react-router-dom';
-import { Token } from 'types';
+import { ChainId, Token } from 'types';
 
 import { GetAllowanceOutput } from 'clients/api';
 import { UseGetAllowanceQueryKey } from 'clients/api/queries/getAllowance/useGetAllowance';
@@ -72,6 +72,7 @@ export const withApprovedToken =
     const queryKey: UseGetAllowanceQueryKey = [
       FunctionKey.GET_TOKEN_ALLOWANCE,
       {
+        chainId: ChainId.BSC_TESTNET,
         tokenAddress: token.address,
         spenderAddress,
         accountAddress,


### PR DESCRIPTION
## Jira ticket(s)

VEN-2126

## Changes

- add `governanceChain` to web3 client, representing the chain on which all governance-related contracts are deployed for the current environment
- update contract getter hooks to accept an optional `chainId` parameter
- pass `chainId` parameter to all query functions linked to a specific chain
- replace `staleTime` option of `useGetIsAddressAuthorized` hook with `refetchInterval` to trigger an refetch every hour
