### PR TITLE
fix: incorrect conversion from APR to APY

### DIFF
--- a/src/clients/api/queries/getHypotheticalPrimeApys/index.spec.ts
+++ b/src/clients/api/queries/getHypotheticalPrimeApys/index.spec.ts
@@ -42,8 +42,8 @@ describe('getHypotheticalPrimeApys', () => {
 
     expect(response).toMatchInlineSnapshot(`
       {
-        "borrowApyPercentage": "3.4582968502661515",
-        "supplyApyPercentage": "2.633999809916232",
+        "borrowApyPercentage": "0.3405770666813801",
+        "supplyApyPercentage": "0.2603373646915319",
       }
     `);
   });

--- a/src/clients/api/queries/getMainPool/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getMainPool/__tests__/__snapshots__/index.spec.ts.snap
@@ -22,7 +22,7 @@ exports[`getMainPool > does not fetch Prime distributions if user is not Prime 1
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.0200781032923",
+            "apyPercentage": "0.20019958435848473",
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
@@ -64,7 +64,7 @@ exports[`getMainPool > does not fetch Prime distributions if user is not Prime 1
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.3265798060834175",
+            "apyPercentage": "0.23026397657694986",
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
@@ -118,7 +118,7 @@ exports[`getMainPool > does not fetch Prime distributions if user is not Prime 1
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.0200781032923",
+            "apyPercentage": "0.20019958435848473",
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
@@ -160,7 +160,7 @@ exports[`getMainPool > does not fetch Prime distributions if user is not Prime 1
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.3265798060834175",
+            "apyPercentage": "0.23026397657694986",
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
@@ -214,7 +214,7 @@ exports[`getMainPool > does not fetch Prime distributions if user is not Prime 1
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.0200781032923",
+            "apyPercentage": "0.20019958435848473",
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",
@@ -256,7 +256,7 @@ exports[`getMainPool > does not fetch Prime distributions if user is not Prime 1
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.3265798060834175",
+            "apyPercentage": "0.23026397657694986",
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",
@@ -657,7 +657,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "3.2516057037486057",
+            "apyPercentage": "0.32051113933926345",
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
               "asset": "/src/packages/tokens/img/usdc.svg",
@@ -667,7 +667,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "prime",
           },
           {
-            "apyPercentage": "2.0200781032923",
+            "apyPercentage": "0.20019958435848473",
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
@@ -709,7 +709,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.942340858505288",
+            "apyPercentage": "0.2904197513866391",
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
               "asset": "/src/packages/tokens/img/usdc.svg",
@@ -719,7 +719,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "prime",
           },
           {
-            "apyPercentage": "2.3265798060834175",
+            "apyPercentage": "0.23026397657694986",
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
@@ -773,7 +773,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "3.2516057037486057",
+            "apyPercentage": "0.32051113933926345",
             "token": {
               "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
               "asset": "/src/packages/tokens/img/usdt.svg",
@@ -783,7 +783,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "prime",
           },
           {
-            "apyPercentage": "2.0200781032923",
+            "apyPercentage": "0.20019958435848473",
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
@@ -825,7 +825,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.942340858505288",
+            "apyPercentage": "0.2904197513866391",
             "token": {
               "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
               "asset": "/src/packages/tokens/img/usdt.svg",
@@ -835,7 +835,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "prime",
           },
           {
-            "apyPercentage": "2.3265798060834175",
+            "apyPercentage": "0.23026397657694986",
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
@@ -889,7 +889,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "3.2516057037486057",
+            "apyPercentage": "0.32051113933926345",
             "token": {
               "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
               "asset": "/src/packages/tokens/img/busd.svg",
@@ -899,7 +899,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "prime",
           },
           {
-            "apyPercentage": "2.0200781032923",
+            "apyPercentage": "0.20019958435848473",
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",
@@ -941,7 +941,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "rewardDistributor",
           },
           {
-            "apyPercentage": "2.942340858505288",
+            "apyPercentage": "0.2904197513866391",
             "token": {
               "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
               "asset": "/src/packages/tokens/img/busd.svg",
@@ -951,7 +951,7 @@ exports[`getMainPool > fetches and formats Prime distributions and Prime distrib
             "type": "prime",
           },
           {
-            "apyPercentage": "2.3265798060834175",
+            "apyPercentage": "0.23026397657694986",
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",

--- a/src/containers/PrimeStatusBanner/index.tsx
+++ b/src/containers/PrimeStatusBanner/index.tsx
@@ -87,6 +87,7 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
   const readableStakeDeltaTokens = useConvertWeiToReadableTokenString({
     value: stakeDeltaTokens,
     token: xvs,
+    roundingMode: BigNumber.ROUND_UP,
   });
 
   const readableApyBoostPercentage = useFormatPercentageToReadableValue({

--- a/src/utilities/convertAprToApy/__tests__/index.spec.ts
+++ b/src/utilities/convertAprToApy/__tests__/index.spec.ts
@@ -6,6 +6,6 @@ describe('convertAprToApy', () => {
       aprBips: '23',
     });
 
-    expect(res).toMatchInlineSnapshot('"2.3265798060834175"');
+    expect(res).toMatchInlineSnapshot('"0.23026397657694986"');
   });
 });

--- a/src/utilities/convertAprToApy/index.ts
+++ b/src/utilities/convertAprToApy/index.ts
@@ -6,7 +6,7 @@ import calculateApy from '../calculateApy';
 
 export const convertAprToApy = ({ aprBips }: { aprBips: string }) => {
   // Convert bips to daily rate
-  const dailyRate = new BigNumber(aprBips).div(1000).div(DAYS_PER_YEAR);
+  const dailyRate = new BigNumber(aprBips).div(10000).div(DAYS_PER_YEAR);
   // Convert daily rate to APY
   return calculateApy({ dailyRate });
 };

--- a/src/utilities/formatTokensToReadableValue/__tests__/index.spec.ts
+++ b/src/utilities/formatTokensToReadableValue/__tests__/index.spec.ts
@@ -5,7 +5,7 @@ import PLACEHOLDER_KEY from 'constants/placeholderKey';
 
 import formatTokensToReadableValue, { FormatTokensToReadableValueInput } from '..';
 
-describe('utilities/formatTokensToReadableValue', () => {
+describe('formatTokensToReadableValue', () => {
   test('should return placeholder when value is undefined', () => {
     const result = formatTokensToReadableValue({
       value: undefined,
@@ -78,5 +78,22 @@ describe('utilities/formatTokensToReadableValue', () => {
       value: new BigNumber(-1234.5678),
     });
     expect(negativeResult).toEqual('-1.23K BUSD');
+  });
+
+  test('should return a formatted value rounded using the passed rounding mode', () => {
+    const input: FormatTokensToReadableValueInput = {
+      value: new BigNumber(12.5678),
+      token: busd,
+      roundingMode: BigNumber.ROUND_DOWN,
+    };
+
+    const result = formatTokensToReadableValue(input);
+    expect(result).toEqual('12.56 BUSD');
+
+    const negativeResult = formatTokensToReadableValue({
+      ...input,
+      value: new BigNumber(-12.5678),
+    });
+    expect(negativeResult).toEqual('-12.56 BUSD');
   });
 });

--- a/src/utilities/formatTokensToReadableValue/index.ts
+++ b/src/utilities/formatTokensToReadableValue/index.ts
@@ -14,12 +14,14 @@ export interface FormatTokensToReadableValueInput {
   value: BigNumber | undefined;
   token: Token | VToken | undefined;
   addSymbol?: boolean;
+  roundingMode?: BigNumber.RoundingMode;
 }
 
 export const formatTokensToReadableValue = ({
   value,
   token,
   addSymbol = true,
+  roundingMode,
 }: FormatTokensToReadableValueInput) => {
   if (!token || !value) {
     return PLACEHOLDER_KEY;
@@ -35,6 +37,7 @@ export const formatTokensToReadableValue = ({
     const formattedReadableValue = shortenValueWithSuffix({
       minDecimalPlaces: MIN_DECIMALS,
       value: new BigNumber(MAX_VALUE),
+      roundingMode,
     });
     readableValue = `${isNegative ? '< -' : '> '}${formattedReadableValue}`;
   } else if (absoluteValue.isLessThan(MIN_VALUE)) {
@@ -44,6 +47,7 @@ export const formatTokensToReadableValue = ({
       value: absoluteValue,
       minDecimalPlaces: MIN_DECIMALS,
       maxDecimalPlaces: token.decimals,
+      roundingMode,
     });
 
     readableValue = `${isNegative ? '-' : ''}${formattedReadableValue}`;

--- a/src/utilities/shortenValueWithSuffix/__tests__/index.spec.ts
+++ b/src/utilities/shortenValueWithSuffix/__tests__/index.spec.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 
 import shortenValueWithSuffix from '..';
 
-describe('utilities/shortenValueWithSuffix', () => {
+describe('shortenValueWithSuffix', () => {
   it('should return a formatted value in billions with "T" suffix when value is greater or equal to one trillion', () => {
     const value = new BigNumber(1500000000000);
     const result = shortenValueWithSuffix({
@@ -67,5 +67,14 @@ describe('utilities/shortenValueWithSuffix', () => {
       maxDecimalPlaces: 3,
     });
     expect(result).toEqual('100.001');
+  });
+
+  it('should return a formatted value rounded using the passed rounding mode', () => {
+    const value = new BigNumber('100.0013921');
+    const result = shortenValueWithSuffix({
+      value,
+      roundingMode: BigNumber.ROUND_DOWN,
+    });
+    expect(result).toEqual('100.0013');
   });
 });

--- a/src/utilities/shortenValueWithSuffix/index.ts
+++ b/src/utilities/shortenValueWithSuffix/index.ts
@@ -7,12 +7,14 @@ export interface ShortenValueWithSuffix {
   value: BigNumber;
   minDecimalPlaces?: number;
   maxDecimalPlaces?: number;
+  roundingMode?: BigNumber.RoundingMode;
 }
 
 const shortenValueWithSuffix = ({
   value,
   minDecimalPlaces,
   maxDecimalPlaces,
+  roundingMode,
 }: ShortenValueWithSuffix) => {
   if (value.isEqualTo(0)) {
     return '0';
@@ -44,7 +46,7 @@ const shortenValueWithSuffix = ({
     maxDecimalPlaces,
   });
 
-  return `${new BigNumber(formattedValue).toFormat(decimalPlaces)}${suffix}`;
+  return `${new BigNumber(formattedValue).toFormat(decimalPlaces, roundingMode)}${suffix}`;
 };
 
 export default shortenValueWithSuffix;


### PR DESCRIPTION
## Changes

- fix conversion from APR to APY
- add `roundingMode` parameter to `formatTokensToReadableValue` and `shortenValueWithSuffix`
