### PR TITLE
fix: add chainId to the dependencies of memoized menuItems

### DIFF
--- a/src/containers/Layout/useGetMenuItems.tsx
+++ b/src/containers/Layout/useGetMenuItems.tsx
@@ -126,6 +126,7 @@ const useGetMenuItems = () => {
     accountAddress,
     convertVrtRouteEnabled,
     corePoolRouteEnabled,
+    swapRouteEnabled,
     historyRouteEnabled,
     vaiRouteEnabled,
   ]);


### PR DESCRIPTION
## Changes

- Fix for the menuItems list not getting refreshed when the chainId changes
