### PR TITLE
refactor: do not persist chain store state

### DIFF
--- a/src/clients/web3/chains.ts
+++ b/src/clients/web3/chains.ts
@@ -15,5 +15,6 @@ const getSupportedChains = (): Chain[] => {
 
 export const governanceChain = localConfig.isOnTestnet ? bscTestnet : bsc;
 
-// Note: the first chain listed will be used as the default chain
 export const chains = getSupportedChains();
+
+export const defaultChain = chains[0];

--- a/src/context/AuthContext/index.tsx
+++ b/src/context/AuthContext/index.tsx
@@ -41,7 +41,7 @@ export const AuthContext = React.createContext<AuthContextValue>({
   closeAuthModal: noop,
   switchChain: noop,
   provider: getDefaultProvider(),
-  chainId: ChainId.BSC_MAINNET,
+  chainId: store.getState().chainId,
 });
 
 export interface AuthProviderProps {

--- a/src/context/AuthContext/store/index.ts
+++ b/src/context/AuthContext/store/index.ts
@@ -1,27 +1,17 @@
 import { ChainId } from 'types';
 import { createStoreSelectors } from 'utilities';
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
-import { chains } from 'clients/web3';
+import { defaultChain } from 'clients/web3';
 
 interface State {
   chainId: ChainId;
   setChainId: (input: { chainId: ChainId }) => void;
 }
 
-const defaultChainId = chains[0].id;
-
-const useStore = create<State>()(
-  persist(
-    set => ({
-      chainId: defaultChainId,
-      setChainId: ({ chainId }) => set({ chainId }),
-    }),
-    {
-      name: 'venus-chain-id',
-    },
-  ),
-);
+const useStore = create<State>()(set => ({
+  chainId: defaultChain.id,
+  setChainId: ({ chainId }) => set({ chainId }),
+}));
 
 export const store = createStoreSelectors(useStore);


### PR DESCRIPTION
## Changes

- do not persist chain store state
- define and export default chain from web3 client
