### PR TITLE
ci: increase build memory allocation

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "start": "vite",
-    "build": "vite build",
+    "build": "export NODE_OPTIONS=\"--max-old-space-size=16384\" && vite build",
     "serve": "vite preview",
     "test": "TZ=UTC VITE_ENVIRONMENT=testnet vitest run",
     "test:ci": "TZ=UTC vitest run",


### PR DESCRIPTION
## Changes

- increase memory allocated to build process. Since we now generate source maps when building the app, the process uses substantially more memory and so it needs to be manually set to a pretty high value (16GB here)
