### PR TITLE
feat: revert d68c2a2e55f6e0264622e3415a3c79946c31c4e2

### DIFF
--- a/src/clients/api/queries/getLegacyPool/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getLegacyPool/__tests__/__snapshots__/index.spec.ts.snap
@@ -26,7 +26,7 @@ exports[`getLegacyPool > does not fetch Prime distributions if user is not Prime
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
@@ -68,7 +68,7 @@ exports[`getLegacyPool > does not fetch Prime distributions if user is not Prime
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
@@ -122,7 +122,7 @@ exports[`getLegacyPool > does not fetch Prime distributions if user is not Prime
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -164,7 +164,7 @@ exports[`getLegacyPool > does not fetch Prime distributions if user is not Prime
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -218,7 +218,7 @@ exports[`getLegacyPool > does not fetch Prime distributions if user is not Prime
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
@@ -260,7 +260,7 @@ exports[`getLegacyPool > does not fetch Prime distributions if user is not Prime
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
@@ -671,7 +671,7 @@ exports[`getLegacyPool > fetches and formats Prime distributions and Prime distr
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
@@ -723,7 +723,7 @@ exports[`getLegacyPool > fetches and formats Prime distributions and Prime distr
             "referenceValues": {
               "userBorrowBalanceTokens": "66012867068.78838627155172413793",
               "userSupplyBalanceTokens": "15951129109546755.24488088106947945753",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
@@ -787,7 +787,7 @@ exports[`getLegacyPool > fetches and formats Prime distributions and Prime distr
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -839,7 +839,7 @@ exports[`getLegacyPool > fetches and formats Prime distributions and Prime distr
             "referenceValues": {
               "userBorrowBalanceTokens": "110643.61749019365079365079",
               "userSupplyBalanceTokens": "1.358795738297682434014619091383216952499549585717162e+31",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -903,7 +903,7 @@ exports[`getLegacyPool > fetches and formats Prime distributions and Prime distr
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
@@ -955,7 +955,7 @@ exports[`getLegacyPool > fetches and formats Prime distributions and Prime distr
             "referenceValues": {
               "userBorrowBalanceTokens": "453577420.21510010545510979029",
               "userSupplyBalanceTokens": "447427293535420150.537063455989777353",
-              "userXvsStakedTokens": "10000",
+              "userXvsStakedTokens": "1000",
             },
             "token": {
               "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",

--- a/src/clients/api/queries/getLegacyPool/index.ts
+++ b/src/clients/api/queries/getLegacyPool/index.ts
@@ -175,6 +175,7 @@ const getLegacyPool = async ({
       primeContract,
       primeVTokenAddresses,
       accountAddress,
+      primeMinimumXvsToStakeMantissa: new BigNumber(primeMinimumXvsToStakeMantissa.toString()),
       xvs,
     });
   }


### PR DESCRIPTION
## Changes

- revert change to XVS stake value used for Prime simulations. A decision hasn't been made on whether to push this change to production, so in the meantime I'm reverting this commit so we can keep deploying changes to mainnet
