### PR TITLE
feat: remove next header from API requests

### DIFF
--- a/src/clients/api/queries/getIsAddressAuthorized/index.ts
+++ b/src/clients/api/queries/getIsAddressAuthorized/index.ts
@@ -13,7 +13,6 @@ const getIsAddressAuthorized = async ({
     const response = await restService({
       endpoint: `/authentication/${accountAddress}`,
       method: 'GET',
-      next: true,
     });
 
     const authorized = response.status !== 403;

--- a/src/clients/api/queries/getLegacyPoolMarkets/index.ts
+++ b/src/clients/api/queries/getLegacyPoolMarkets/index.ts
@@ -30,7 +30,6 @@ const getLegacyPoolMarkets = async ({
   const response = await restService<GetLegacyPoolMarketsResponse>({
     endpoint: '/markets/core-pool',
     method: 'GET',
-    next: true,
     params: {
       limit: 50,
     },

--- a/src/clients/api/queries/getMarketHistory/index.spec.ts
+++ b/src/clients/api/queries/getMarketHistory/index.spec.ts
@@ -44,7 +44,6 @@ describe('api/queries/getMarketHistory', () => {
     expect(restService).toHaveBeenCalledWith({
       endpoint: `/markets/history?asset=${vBusd.address}`,
       method: 'GET',
-      next: true,
     });
   });
 });

--- a/src/clients/api/queries/getMarketHistory/index.ts
+++ b/src/clients/api/queries/getMarketHistory/index.ts
@@ -36,7 +36,6 @@ const getMarketHistory = async ({
   const response = await restService<GetMarketHistoryResponse>({
     endpoint,
     method: 'GET',
-    next: true,
   });
 
   // @todo Add specific api error handling

--- a/src/clients/api/queries/getProposals/getProposal.spec.ts
+++ b/src/clients/api/queries/getProposals/getProposal.spec.ts
@@ -23,7 +23,6 @@ describe('api/queries/getProposal', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/governance/proposals/1',
       method: 'GET',
-      next: true,
     });
 
     expect(response).toMatchSnapshot();

--- a/src/clients/api/queries/getProposals/getProposal.ts
+++ b/src/clients/api/queries/getProposals/getProposal.ts
@@ -10,7 +10,6 @@ const getProposal = async ({
   const response = await restService<ProposalApiResponse>({
     endpoint: `/governance/proposals/${proposalId}`,
     method: 'GET',
-    next: true,
   });
 
   const payload = response.data;

--- a/src/clients/api/queries/getProposals/index.spec.ts
+++ b/src/clients/api/queries/getProposals/index.spec.ts
@@ -13,7 +13,6 @@ describe('api/queries/getProposals', () => {
     (restService as Vi.Mock).mockImplementationOnce(async () => ({
       data: proposalResponse,
       limit: 10,
-      next: true,
     }));
 
     const response = await getProposals({
@@ -25,7 +24,6 @@ describe('api/queries/getProposals', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/governance/proposals',
       method: 'GET',
-      next: true,
       params: {
         limit: 10,
         page: 2,
@@ -47,7 +45,6 @@ describe('api/queries/getProposals', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/governance/proposals',
       method: 'GET',
-      next: true,
       params: {
         limit: 5,
         page: 0,

--- a/src/clients/api/queries/getProposals/index.ts
+++ b/src/clients/api/queries/getProposals/index.ts
@@ -13,7 +13,6 @@ const getProposals = async ({
   const response = await restService<ProposalsApiResponse>({
     endpoint: '/governance/proposals',
     method: 'GET',
-    next: true,
     params: { page, limit },
   });
   const payload = response.data;

--- a/src/clients/api/queries/getTransactions/index.spec.ts
+++ b/src/clients/api/queries/getTransactions/index.spec.ts
@@ -32,7 +32,6 @@ describe('api/queries/getTransactions', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/activity/transactions',
       method: 'GET',
-      next: true,
       params: {
         page: 2,
         event: 'Withdraw',
@@ -61,7 +60,6 @@ describe('api/queries/getTransactions', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/activity/transactions',
       method: 'GET',
-      next: true,
       params: {
         page: 0,
         event: undefined,

--- a/src/clients/api/queries/getTransactions/index.ts
+++ b/src/clients/api/queries/getTransactions/index.ts
@@ -52,7 +52,6 @@ const getTransactions = async ({
   const response = await restService<GetTransactionsResponse>({
     endpoint: '/activity/transactions',
     method: 'GET',
-    next: true,
     params: {
       page,
       event,

--- a/src/clients/api/queries/getVoteSummary/index.spec.ts
+++ b/src/clients/api/queries/getVoteSummary/index.spec.ts
@@ -22,7 +22,6 @@ describe('api/queries/getVoteSummary', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/governance/proposals/1/voteSummary',
       method: 'GET',
-      next: true,
     });
 
     expect(response).toMatchSnapshot();

--- a/src/clients/api/queries/getVoteSummary/index.ts
+++ b/src/clients/api/queries/getVoteSummary/index.ts
@@ -12,7 +12,6 @@ const getVoteSummary = async ({
   const response = await restService<GetVoteSummaryApiResponse>({
     endpoint: `/governance/proposals/${proposalId}/voteSummary`,
     method: 'GET',
-    next: true,
   });
 
   const payload = response.data;

--- a/src/clients/api/queries/getVoterAccounts/index.spec.ts
+++ b/src/clients/api/queries/getVoterAccounts/index.spec.ts
@@ -29,7 +29,6 @@ describe('api/queries/getVoterAccounts', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/governance/voters',
       method: 'GET',
-      next: true,
       params: {
         limit: 16,
         page: 2,
@@ -57,7 +56,6 @@ describe('api/queries/getVoterAccounts', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/governance/voters',
       method: 'GET',
-      next: true,
       params: {
         limit: 16,
         page: 0,

--- a/src/clients/api/queries/getVoterAccounts/index.ts
+++ b/src/clients/api/queries/getVoterAccounts/index.ts
@@ -28,7 +28,6 @@ const getVoterAccounts = async ({
   const response = await restService<GetVoterAccountsResponse>({
     endpoint: '/governance/voters',
     method: 'GET',
-    next: true,
     params: {
       limit,
       page,

--- a/src/clients/api/queries/getVoterDetails/index.spec.ts
+++ b/src/clients/api/queries/getVoterDetails/index.spec.ts
@@ -21,7 +21,6 @@ describe('api/queries/getVoterDetail', () => {
     expect(restService).toBeCalledWith({
       endpoint: `/governance/voters/${fakeAddress}/summary`,
       method: 'GET',
-      next: true,
     });
 
     expect(response).toMatchSnapshot();

--- a/src/clients/api/queries/getVoterDetails/index.ts
+++ b/src/clients/api/queries/getVoterDetails/index.ts
@@ -17,7 +17,6 @@ const getVoterDetails = async ({
   const response = await restService<GetVoterDetailsResponse>({
     endpoint: `/governance/voters/${address}/summary`,
     method: 'GET',
-    next: true,
   });
   const payload = response.data;
   // @todo Add specific api error handling

--- a/src/clients/api/queries/getVoterHistory/index.spec.ts
+++ b/src/clients/api/queries/getVoterHistory/index.spec.ts
@@ -24,7 +24,6 @@ describe('api/queries/getVoterHistory', () => {
     expect(restService).toBeCalledWith({
       endpoint: `/governance/voters/${fakeAddress}/history`,
       method: 'GET',
-      next: true,
       params: {
         limit: 6,
         page: 2,
@@ -47,7 +46,6 @@ describe('api/queries/getVoterHistory', () => {
     expect(restService).toBeCalledWith({
       endpoint: `/governance/voters/${fakeAddress}/history`,
       method: 'GET',
-      next: true,
       params: {
         limit: 6,
         page: 0,

--- a/src/clients/api/queries/getVoterHistory/index.ts
+++ b/src/clients/api/queries/getVoterHistory/index.ts
@@ -23,7 +23,6 @@ const getVoterHistory = async ({
   const response = await restService<GetVoterHistoryResponse>({
     endpoint: `/governance/voters/${address}/history`,
     method: 'GET',
-    next: true,
     params: {
       limit: 6,
       page,

--- a/src/clients/api/queries/getVoters/index.spec.ts
+++ b/src/clients/api/queries/getVoters/index.spec.ts
@@ -22,7 +22,6 @@ describe('api/queries/getVoters', () => {
     expect(restService).toBeCalledWith({
       endpoint: '/governance/proposals/votes',
       method: 'GET',
-      next: true,
       params: {
         support: undefined,
         limit: 50,

--- a/src/clients/api/queries/getVoters/index.ts
+++ b/src/clients/api/queries/getVoters/index.ts
@@ -16,7 +16,6 @@ const getVoters = async ({
   const response = await restService<GetVotersApiResponse>({
     endpoint: '/governance/proposals/votes',
     method: 'GET',
-    next: true,
     params: {
       support,
       address,


### PR DESCRIPTION
## Changes

- Removes the `next` header from requests, since those have been made stable