### PR TITLE
feat: add feature flag for VAI mint warning

### DIFF
--- a/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
+++ b/src/clients/api/queries/useGetVaults/useGetVaiVault.ts
@@ -99,7 +99,6 @@ const useGetVaiVault = ({ accountAddress }: { accountAddress?: string }): UseGet
     isGetXvsPriceLoading ||
     isGetVaiVaultUserInfoLoading;
 
-
   return {
     data,
     isLoading,

--- a/src/hooks/useIsFeatureEnabled/__tests__/index.spec.ts
+++ b/src/hooks/useIsFeatureEnabled/__tests__/index.spec.ts
@@ -248,4 +248,46 @@ describe('useIsFeatureEnabled', () => {
 
     expect(result.current).toBe(false);
   });
+
+  it('should return false for the VAI mint warning for Prime users on BSC_MAINNET', () => {
+    (useChainId as Vi.Mock).mockImplementation(() => ({
+      chainId: ChainId.BSC_MAINNET,
+    }));
+
+    const { result } = renderHook(() =>
+      useIsFeatureEnabled({
+        name: 'vaiMintPrimeOnlyWarning',
+      }),
+    );
+
+    expect(result.current).toBe(false);
+  });
+
+  it('should return true for the VAI mint warning for Prime users on BSC_TESTNET', () => {
+    (useChainId as Vi.Mock).mockImplementation(() => ({
+      chainId: ChainId.BSC_TESTNET,
+    }));
+
+    const { result } = renderHook(() =>
+      useIsFeatureEnabled({
+        name: 'vaiMintPrimeOnlyWarning',
+      }),
+    );
+
+    expect(result.current).toBe(true);
+  });
+
+  it('should return false for the VAI mint warning for Prime users on SEPOLIA', () => {
+    (useChainId as Vi.Mock).mockImplementation(() => ({
+      chainId: ChainId.SEPOLIA,
+    }));
+
+    const { result } = renderHook(() =>
+      useIsFeatureEnabled({
+        name: 'vaiMintPrimeOnlyWarning',
+      }),
+    );
+
+    expect(result.current).toBe(false);
+  });
 });

--- a/src/hooks/useIsFeatureEnabled/index.tsx
+++ b/src/hooks/useIsFeatureEnabled/index.tsx
@@ -18,6 +18,7 @@ const featureFlags = {
   lunaUstWarning: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   marketHistory: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   marketParticipantCounts: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
+  vaiMintPrimeOnlyWarning: [ChainId.BSC_TESTNET],
 };
 
 export type FeatureFlag = keyof typeof featureFlags;

--- a/src/packages/contracts/config/index.ts
+++ b/src/packages/contracts/config/index.ts
@@ -147,8 +147,10 @@ export const contracts: ContractConfig[] = [
     name: 'GovernorBravoDelegate',
     abi: GovernorBravoDelegateAbi,
     address: {
-      [ChainId.BSC_TESTNET]: venusGovernanceBscTestnetDeployments.addresses.GovernorBravoDelegator_Proxy,
-      [ChainId.BSC_MAINNET]: venusGovernanceBscMainnetDeployments.addresses.GovernorBravoDelegator_Proxy,
+      [ChainId.BSC_TESTNET]:
+        venusGovernanceBscTestnetDeployments.addresses.GovernorBravoDelegator_Proxy,
+      [ChainId.BSC_MAINNET]:
+        venusGovernanceBscMainnetDeployments.addresses.GovernorBravoDelegator_Proxy,
     },
   },
   {

--- a/src/pages/Vai/MintVai/Form/index.tsx
+++ b/src/pages/Vai/MintVai/Form/index.tsx
@@ -67,7 +67,11 @@ export const Form: React.FC = () => {
   const isPrimeEnabled = useIsFeatureEnabled({
     name: 'prime',
   });
-  const shouldShowPrimeOnlyWarning = isPrimeEnabled && !isUserPrime;
+  const isVaiMintPrimeOnlyWarningEnabled = useIsFeatureEnabled({
+    name: 'vaiMintPrimeOnlyWarning',
+  });
+  const shouldShowPrimeOnlyWarning =
+    isVaiMintPrimeOnlyWarningEnabled && isPrimeEnabled && !isUserPrime;
 
   const { data: mintableVaiData, isLoading: isGetMintableVaiLoading } = useGetMintableVai(
     {

--- a/src/pages/Vai/MintVai/__tests__/indexPrime.spec.tsx
+++ b/src/pages/Vai/MintVai/__tests__/indexPrime.spec.tsx
@@ -14,7 +14,7 @@ import TEST_IDS from '../../testIds';
 describe('MintVai - Feature enabled: Prime', () => {
   beforeEach(() => {
     (useIsFeatureEnabled as Vi.Mock).mockImplementation(
-      ({ name }: UseIsFeatureEnabled) => name === 'prime',
+      ({ name }: UseIsFeatureEnabled) => name === 'prime' || name === 'vaiMintPrimeOnlyWarning',
     );
   });
 


### PR DESCRIPTION
## Changes

- Added a feature flag for the `Only users who hold a Prime token can mint VAI` warning. It is only active in testnet at the moment.
