### PR TITLE
fix: stuck LUNA/UST warning modal

### DIFF
--- a/src/packages/lunaUstWarning/LunaUstWarningModal/__tests__/index.spec.tsx
+++ b/src/packages/lunaUstWarning/LunaUstWarningModal/__tests__/index.spec.tsx
@@ -14,6 +14,7 @@ describe('LunaUstWarningModal', () => {
     (useLunaUstWarning as Vi.Mock).mockImplementation(() => ({
       userHasLunaOrUstCollateralEnabled: false,
       isLunaUstWarningModalOpen: false,
+      hasLunaUstWarningModalBeenOpened: false,
       closeLunaUstWarningModal: vi.fn(),
       openLunaUstWarningModal: vi.fn(),
     }));
@@ -36,6 +37,7 @@ describe('LunaUstWarningModal', () => {
     // Simulate userHasLunaOrUstCollateralEnabled becoming true
     (useLunaUstWarning as Vi.Mock).mockImplementation(() => ({
       userHasLunaOrUstCollateralEnabled: true,
+      hasLunaUstWarningModalBeenOpened: false,
       openLunaUstWarningModal: openLunaUstWarningModalMock,
       isLunaUstWarningModalOpen: false,
       closeLunaUstWarningModal: vi.fn(),
@@ -44,5 +46,34 @@ describe('LunaUstWarningModal', () => {
     rerender(<LunaUstWarningModal />);
 
     expect(openLunaUstWarningModalMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when userHasLunaOrUstCollateralEnabled property becomes true but hasLunaUstWarningModalBeenOpened is true', () => {
+    const openLunaUstWarningModalMock = vi.fn();
+
+    (useLunaUstWarning as Vi.Mock).mockImplementation(() => ({
+      userHasLunaOrUstCollateralEnabled: false,
+      hasLunaUstWarningModalBeenOpened: true,
+      openLunaUstWarningModal: openLunaUstWarningModalMock,
+      isLunaUstWarningModalOpen: false,
+      closeLunaUstWarningModal: vi.fn(),
+    }));
+
+    const { queryByText, rerender } = renderComponent(<LunaUstWarningModal />);
+
+    expect(queryByText(en.lunaUstWarningModal.title)).toBeNull();
+
+    // Simulate userHasLunaOrUstCollateralEnabled becoming true
+    (useLunaUstWarning as Vi.Mock).mockImplementation(() => ({
+      userHasLunaOrUstCollateralEnabled: true,
+      hasLunaUstWarningModalBeenOpened: true,
+      openLunaUstWarningModal: openLunaUstWarningModalMock,
+      isLunaUstWarningModalOpen: false,
+      closeLunaUstWarningModal: vi.fn(),
+    }));
+
+    rerender(<LunaUstWarningModal />);
+
+    expect(openLunaUstWarningModalMock).not.toHaveBeenCalled();
   });
 });

--- a/src/packages/lunaUstWarning/LunaUstWarningModal/index.tsx
+++ b/src/packages/lunaUstWarning/LunaUstWarningModal/index.tsx
@@ -9,13 +9,18 @@ export const LunaUstWarningModal: React.FC = () => {
     closeLunaUstWarningModal,
     openLunaUstWarningModal,
     userHasLunaOrUstCollateralEnabled,
+    hasLunaUstWarningModalBeenOpened,
   } = useLunaUstWarning();
 
   useEffect(() => {
-    if (userHasLunaOrUstCollateralEnabled) {
+    if (userHasLunaOrUstCollateralEnabled && !hasLunaUstWarningModalBeenOpened) {
       openLunaUstWarningModal();
     }
-  }, [openLunaUstWarningModal, userHasLunaOrUstCollateralEnabled]);
+  }, [
+    openLunaUstWarningModal,
+    userHasLunaOrUstCollateralEnabled,
+    hasLunaUstWarningModalBeenOpened,
+  ]);
 
   return <Modal isOpen={isLunaUstWarningModalOpen} onClose={closeLunaUstWarningModal} />;
 };

--- a/src/packages/lunaUstWarning/useLunaUstWarning/index.tsx
+++ b/src/packages/lunaUstWarning/useLunaUstWarning/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
 
 import { useGetLegacyPool } from 'clients/api';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
@@ -17,10 +17,18 @@ export const useLunaUstWarning = () => {
   });
 
   const isLunaUstWarningModalOpen = store.use.isModalOpen();
-  const setIsModalOpen = store.use.setIsModalOpen();
 
-  const openLunaUstWarningModal = () => setIsModalOpen({ isModalOpen: true });
-  const closeLunaUstWarningModal = () => setIsModalOpen({ isModalOpen: false });
+  const setIsModalOpen = store.use.setIsModalOpen();
+  const hasLunaUstWarningModalBeenOpened = store.use.wasModalOpenedThisSession();
+
+  const openLunaUstWarningModal = useCallback(
+    () => setIsModalOpen({ isModalOpen: true }),
+    [setIsModalOpen],
+  );
+  const closeLunaUstWarningModal = useCallback(
+    () => setIsModalOpen({ isModalOpen: false }),
+    [setIsModalOpen],
+  );
 
   const userHasLunaOrUstCollateralEnabled = useMemo(
     () =>
@@ -40,5 +48,6 @@ export const useLunaUstWarning = () => {
     openLunaUstWarningModal,
     closeLunaUstWarningModal,
     isLunaUstWarningModalOpen,
+    hasLunaUstWarningModalBeenOpened,
   };
 };

--- a/src/packages/lunaUstWarning/useLunaUstWarning/store.ts
+++ b/src/packages/lunaUstWarning/useLunaUstWarning/store.ts
@@ -4,12 +4,14 @@ import { createStoreSelectors } from 'utilities';
 
 interface State {
   isModalOpen: boolean;
+  wasModalOpenedThisSession: boolean;
   setIsModalOpen: (input: { isModalOpen: boolean }) => void;
 }
 
 const useStore = create<State>()(set => ({
   isModalOpen: false,
-  setIsModalOpen: ({ isModalOpen }) => set({ isModalOpen }),
+  wasModalOpenedThisSession: false,
+  setIsModalOpen: ({ isModalOpen }) => set({ isModalOpen, wasModalOpenedThisSession: true }),
 }));
 
 export const store = createStoreSelectors(useStore);


### PR DESCRIPTION
## Changes

- memoize functions to open and close LUNA/UST modal to prevent it from automatically reopening after closing
- add `hasLunaUstWarningModalBeenOpened` property to `lunaUstWarning` store to detect modal has been opened during that session and prevent it from showing again when legacy pool is refetched
