### PR TITLE
fix: provider and signer initialization in contract hooks

### DIFF
--- a/src/clients/api/queries/getVTokenApySimulations/useGetVTokenApySimulations.ts
+++ b/src/clients/api/queries/getVTokenApySimulations/useGetVTokenApySimulations.ts
@@ -10,6 +10,7 @@ import { useGetChainMetadata } from 'hooks/useGetChainMetadata';
 import { getJumpRateModelContract, getJumpRateModelV2Contract } from 'packages/contracts';
 import { useChainId, useProvider } from 'packages/wallet';
 import { Asset, ChainId, VToken } from 'types';
+import { callOrThrow } from 'utilities';
 
 export type UseGetVTokenApySimulationsQueryKey = [
   FunctionKey.GET_V_TOKEN_APY_SIMULATIONS,
@@ -60,12 +61,13 @@ const useGetVTokenApySimulations = (
   return useQuery(
     [FunctionKey.GET_V_TOKEN_APY_SIMULATIONS, { vTokenAddress: vToken.address, chainId }],
     () =>
-      getVTokenApySimulations({
-        interestRateModelContract: interestRateModelContract!, // Checked through enabled option
-        asset: asset!, // Checked through enabled option
-        isIsolatedPoolMarket,
-        blocksPerDay,
-      }),
+      callOrThrow({ interestRateModelContract, asset }, params =>
+        getVTokenApySimulations({
+          ...params,
+          isIsolatedPoolMarket,
+          blocksPerDay,
+        }),
+      ),
     {
       ...options,
       enabled:

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/__snapshots__/index.spec.ts.snap
@@ -3,22 +3,23 @@
 exports[`generateGetters > calls writeFile with the right arguments 1`] = `
 [
   {
-    "content": "/* Automatically generated file, do not update manually */
-import type { Provider } from '@ethersproject/abstract-provider';
+    "content": "import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
+import { useMemo } from 'react';
+
 import abi from 'packages/contracts/generated/infos/abis/PoolLens.json';
 import { PoolLens } from 'packages/contracts/generated/infos/contractTypes';
-import { useMemo } from 'react';
-import { ChainId } from 'types';
-
 import { getUniqueContractAddress } from 'packages/contracts/utilities/getUniqueContractAddress';
 import { useChainId, useProvider, useSigner } from 'packages/wallet';
+import { ChainId } from 'types';
 
 interface GetPoolLensContractAddressInput {
   chainId: ChainId;
 }
 
-export const getPoolLensContractAddress = ({ chainId }: GetPoolLensContractAddressInput) =>
+export const getPoolLensContractAddress = ({
+  chainId,
+}: GetPoolLensContractAddressInput) =>
   getUniqueContractAddress({ name: 'PoolLens', chainId });
 
 export const useGetPoolLensContractAddress = () => {
@@ -38,7 +39,10 @@ interface GetPoolLensContractInput {
   signerOrProvider: Signer | Provider;
 }
 
-export const getPoolLensContract = ({ chainId, signerOrProvider }: GetPoolLensContractInput) => {
+export const getPoolLensContract = ({
+  chainId,
+  signerOrProvider,
+}: GetPoolLensContractInput) => {
   const address = getPoolLensContractAddress({ chainId });
   return address ? (new Contract(address, abi, signerOrProvider) as PoolLens) : undefined;
 };
@@ -78,22 +82,19 @@ exports[`generateGetters > calls writeFile with the right arguments 2`] = `
   {
     "content": "import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
+import { useMemo } from 'react';
+
 import abi from 'packages/contracts/generated/infos/abis/IsolatedPoolComptroller.json';
 import { IsolatedPoolComptroller } from 'packages/contracts/generated/infos/contractTypes';
-import { useMemo } from 'react';
-import { ChainId } from 'types';
-
 import { useProvider, useSigner } from 'packages/wallet';
+import { ChainId } from 'types';
 
 interface GetIsolatedPoolComptrollerContractInput {
   address: string;
   signerOrProvider: Signer | Provider;
 }
 
-export const getIsolatedPoolComptrollerContract = ({
-  signerOrProvider,
-  address,
-}: GetIsolatedPoolComptrollerContractInput) =>
+export const getIsolatedPoolComptrollerContract = ({ signerOrProvider, address }: GetIsolatedPoolComptrollerContractInput) =>
   new Contract(address, abi, signerOrProvider) as IsolatedPoolComptroller;
 
 interface UseGetIsolatedPoolComptrollerContractInput {
@@ -133,13 +134,13 @@ exports[`generateGetters > calls writeFile with the right arguments 3`] = `
   {
     "content": "import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
+import { useMemo } from 'react';
+
 import abi from 'packages/contracts/generated/infos/abis/SwapRouter.json';
 import addresses from 'packages/contracts/generated/infos/addresses';
 import { SwapRouter } from 'packages/contracts/generated/infos/contractTypes';
-import { useMemo } from 'react';
-import { ChainId } from 'types';
-
 import { useChainId, useProvider, useSigner } from 'packages/wallet';
+import { ChainId } from 'types';
 
 interface GetSwapRouterContractAddressInput {
   comptrollerContractAddress: string;

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/genericContractGettersTemplate.hbs
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/genericContractGettersTemplate.hbs
@@ -1,21 +1,18 @@
 import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
+import { useMemo } from 'react';
+
 import abi from 'packages/contracts/generated/infos/abis/{{contractName}}.json';
 import { {{contractName}} } from 'packages/contracts/generated/infos/contractTypes';
-import { useMemo } from 'react';
-import { ChainId } from 'types';
-
 import { useProvider, useSigner } from 'packages/wallet';
+import { ChainId } from 'types';
 
 interface Get{{contractName}}ContractInput {
   address: string;
   signerOrProvider: Signer | Provider;
 }
 
-export const get{{contractName}}Contract = ({
-  signerOrProvider,
-  address,
-}: Get{{contractName}}ContractInput) =>
+export const get{{contractName}}Contract = ({ signerOrProvider, address }: Get{{contractName}}ContractInput) =>
   new Contract(address, abi, signerOrProvider) as {{contractName}};
 
 interface UseGet{{contractName}}ContractInput {

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/swapRouterContractGettersTemplate.hbs
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/swapRouterContractGettersTemplate.hbs
@@ -1,12 +1,12 @@
 import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
+import { useMemo } from 'react';
+
 import abi from 'packages/contracts/generated/infos/abis/{{contractName}}.json';
 import addresses from 'packages/contracts/generated/infos/addresses';
 import { {{contractName}} } from 'packages/contracts/generated/infos/contractTypes';
-import { useMemo } from 'react';
-import { ChainId } from 'types';
-
 import { useChainId, useProvider, useSigner } from 'packages/wallet';
+import { ChainId } from 'types';
 
 interface Get{{contractName}}ContractAddressInput {
   comptrollerContractAddress: string;

--- a/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniqueContractGettersTemplate.hbs
+++ b/src/packages/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniqueContractGettersTemplate.hbs
@@ -1,19 +1,20 @@
-/* Automatically generated file, do not update manually */
 import type { Provider } from '@ethersproject/abstract-provider';
 import { Contract, Signer } from 'ethers';
+import { useMemo } from 'react';
+
 import abi from 'packages/contracts/generated/infos/abis/{{contractName}}.json';
 import { {{contractName}} } from 'packages/contracts/generated/infos/contractTypes';
-import { useMemo } from 'react';
-import { ChainId } from 'types';
-
 import { getUniqueContractAddress } from 'packages/contracts/utilities/getUniqueContractAddress';
 import { useChainId, useProvider, useSigner } from 'packages/wallet';
+import { ChainId } from 'types';
 
 interface Get{{contractName}}ContractAddressInput {
   chainId: ChainId;
 }
 
-export const get{{contractName}}ContractAddress = ({ chainId }: Get{{contractName}}ContractAddressInput) =>
+export const get{{contractName}}ContractAddress = ({
+  chainId,
+}: Get{{contractName}}ContractAddressInput) =>
   getUniqueContractAddress({ name: '{{contractName}}', chainId });
 
 export const useGet{{contractName}}ContractAddress = () => {
@@ -33,7 +34,10 @@ interface Get{{contractName}}ContractInput {
   signerOrProvider: Signer | Provider;
 }
 
-export const get{{contractName}}Contract = ({ chainId, signerOrProvider }: Get{{contractName}}ContractInput) => {
+export const get{{contractName}}Contract = ({
+  chainId,
+  signerOrProvider,
+}: Get{{contractName}}ContractInput) => {
   const address = get{{contractName}}ContractAddress({ chainId });
   return address ? (new Contract(address, abi, signerOrProvider) as {{contractName}}) : undefined;
 };

--- a/src/packages/wallet/hooks/useProvider/index.ts
+++ b/src/packages/wallet/hooks/useProvider/index.ts
@@ -3,6 +3,7 @@ import { usePublicClient } from 'wagmi';
 
 import { ChainId } from 'types';
 
+import { useChainId } from '../useChainId';
 import { getProvider } from './getProvider';
 
 export interface UseProviderInput {
@@ -10,7 +11,10 @@ export interface UseProviderInput {
 }
 
 export const useProvider = (input?: UseProviderInput) => {
-  const publicClient = usePublicClient({ chainId: input?.chainId });
+  const { chainId: currentChainId } = useChainId();
+  const chainId = input?.chainId || currentChainId;
+  const publicClient = usePublicClient({ chainId });
+
   const provider = useMemo(() => getProvider({ publicClient }), [publicClient]);
 
   return { provider };

--- a/src/packages/wallet/hooks/useSigner/index.ts
+++ b/src/packages/wallet/hooks/useSigner/index.ts
@@ -3,6 +3,7 @@ import { useWalletClient } from 'wagmi';
 
 import { ChainId } from 'types';
 
+import { useChainId } from '../useChainId';
 import { getSigner } from './getSigner';
 
 export interface UseSignerInput {
@@ -10,7 +11,10 @@ export interface UseSignerInput {
 }
 
 export const useSigner = (input?: UseSignerInput) => {
-  const { data: walletClient } = useWalletClient({ chainId: input?.chainId });
+  const { chainId: currentChainId } = useChainId();
+  const chainId = input?.chainId || currentChainId;
+  const { data: walletClient } = useWalletClient({ chainId });
+
   const signer = useMemo(
     () => getSigner({ walletClient: walletClient || undefined }),
     [walletClient],


### PR DESCRIPTION
## Changes

- refactor `useGetVTokenApySimulations` hook to use `callOrThrow` function instead of non-null type assertion
- update `useProvider` and `useSigner` so they use the current chain ID if none was passed through parameters
- update `contracts` package templates to follow latest format

