### PR TITLE
feat: set isIsolatedPoolMarket for non BNB core pools

### DIFF
--- a/src/pages/Market/CorePoolMarket/index.tsx
+++ b/src/pages/Market/CorePoolMarket/index.tsx
@@ -2,18 +2,23 @@
 import { useParams } from 'react-router-dom';
 
 import { useGetChainMetadata } from 'hooks/useGetChainMetadata';
+import { useChainId } from 'packages/wallet';
+import { ChainId } from 'types';
 
 import Market from '..';
 import MarketLoader from '../MarketLoader';
 
 const CorePoolMarket: React.FC = () => {
   const { vTokenAddress } = useParams();
+  const { chainId } = useChainId();
+  const isBnbChain = chainId === ChainId.BSC_MAINNET || chainId === ChainId.BSC_TESTNET;
   const { corePoolComptrollerContractAddress } = useGetChainMetadata();
 
   return (
     <MarketLoader
       poolComptrollerAddress={corePoolComptrollerContractAddress}
       vTokenAddress={vTokenAddress}
+      isIsolatedPoolMarket={!isBnbChain}
     >
       {marketProps => <Market {...marketProps} />}
     </MarketLoader>


### PR DESCRIPTION
## Jira ticket(s)

VEN-2233

## Changes

- When not using a BNB chain, we now set the flag `isIsolatedPoolMarket` to be true, so we correctly use the `JumpRateModelV2` contract to generate the Interest Rate Model chart
