### PR TITLE
fix: withdrawable amount edge case

### DIFF
--- a/src/hooks/useOperationModal/Modal/WithdrawForm/index.tsx
+++ b/src/hooks/useOperationModal/Modal/WithdrawForm/index.tsx
@@ -54,8 +54,9 @@ export const WithdrawFormUi: React.FC<WithdrawFormUiProps> = ({
     if (
       !asset ||
       !asset.isCollateralOfUser ||
+      pool?.userBorrowLimitCents === undefined ||
       pool?.userBorrowBalanceCents === undefined ||
-      pool?.userBorrowLimitCents === undefined
+      pool.userBorrowBalanceCents.isEqualTo(0)
     ) {
       return maxTokensBeforeLiquidation;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7606,38 +7606,12 @@
     abitype "0.8.7"
     eventemitter3 "^4.0.7"
 
-"@wagmi/connectors@3.1.8":
-  version "3.1.8"
-  resolved "https://registry.yarnpkg.com/@wagmi/connectors/-/connectors-3.1.8.tgz#9ba724e815adc28b28a1cdc039727b668dcf6785"
-  integrity sha512-J6m8xWFw/Qb4V6VeERazEgfXPztx7wDWCfmUSrfSM54SSjdaFprAOZlcAMqBtibqH8HgnPvbdFA0DEOHbeX2ag==
-  dependencies:
-    "@coinbase/wallet-sdk" "^3.6.6"
-    "@ledgerhq/connect-kit-loader" "^1.1.0"
-    "@safe-global/safe-apps-provider" "^0.17.1"
-    "@safe-global/safe-apps-sdk" "^8.0.0"
-    "@walletconnect/ethereum-provider" "2.10.6"
-    "@walletconnect/legacy-provider" "^2.0.0"
-    "@walletconnect/modal" "2.6.2"
-    "@walletconnect/utils" "2.10.2"
-    abitype "0.8.7"
-    eventemitter3 "^4.0.7"
-
-"@wagmi/core@1.4.8":
+"@wagmi/core@1.4.8", "@wagmi/core@^1.3.9":
   version "1.4.8"
   resolved "https://registry.yarnpkg.com/@wagmi/core/-/core-1.4.8.tgz#aa5addebf0edebd7a415e13fd34f8390cd480822"
   integrity sha512-zIkyw8ZJlMwb04+yohQVMWKjcX5FFlM30tRDanr6dQ+qlYqtUoB70CJGpSRtCYmbK3JlYxH21JNykjOZzdM88Q==
   dependencies:
     "@wagmi/connectors" "3.1.6"
-    abitype "0.8.7"
-    eventemitter3 "^4.0.7"
-    zustand "^4.3.1"
-
-"@wagmi/core@^1.3.9":
-  version "1.4.10"
-  resolved "https://registry.yarnpkg.com/@wagmi/core/-/core-1.4.10.tgz#be3303f760e2c6fbc311f47028589cd3d6787461"
-  integrity sha512-XJ5iSWZKOZSgQP3LFn/QHJqLGoX53SiBKc0/6s7KkVc68VmFenrZymNRg3fSwBsINlZgRVWpSj2lAVsl8IjSgw==
-  dependencies:
-    "@wagmi/connectors" "3.1.8"
     abitype "0.8.7"
     eventemitter3 "^4.0.7"
     zustand "^4.3.1"


### PR DESCRIPTION
## Changes

- check borrow balance of user is greater than 0 when defining withdrawable amount on withdraw form. This fixes an edge-case where users could not withdraw collateralized tokens with a collateral factor of 0
- revert wagmi upgrade as Binance W3W is not compatible with the latest version
