### PR TITLE
feat: update available VAI limit logic and enable VAI minting

### DIFF
--- a/src/__mocks__/contracts/vai.ts
+++ b/src/__mocks__/contracts/vai.ts
@@ -1,0 +1,11 @@
+import { BigNumber as BN } from 'ethers';
+
+import { Vai } from 'packages/contracts';
+
+const vaiContractResponses: {
+  totalSupply: Awaited<ReturnType<Vai['totalSupply']>>;
+} = {
+  totalSupply: BN.from('50000000000000000000'),
+};
+
+export default vaiContractResponses;

--- a/src/__mocks__/contracts/vaiController.ts
+++ b/src/__mocks__/contracts/vaiController.ts
@@ -5,9 +5,11 @@ import { VaiController } from 'packages/contracts';
 const vaiControllerResponses: {
   getMintableVAI: Awaited<ReturnType<VaiController['getMintableVAI']>>;
   getVAIRepayRatePerBlock: Awaited<ReturnType<VaiController['getVAIRepayRatePerBlock']>>;
+  mintCap: Awaited<ReturnType<VaiController['mintCap']>>;
 } = {
-  getMintableVAI: [BN.from('20000000000000000000'), BN.from('40000000000000000000')],
+  getMintableVAI: [BN.from('0'), BN.from('40000000000000000000')],
   getVAIRepayRatePerBlock: BN.from('4000000000000000000'),
+  mintCap: BN.from('90000000000000000000'),
 };
 
 export default vaiControllerResponses;

--- a/src/clients/api/queries/getMintableVai/formatToOutput.ts
+++ b/src/clients/api/queries/getMintableVai/formatToOutput.ts
@@ -1,13 +1,40 @@
 import BigNumber from 'bignumber.js';
 
-import { VaiController } from 'packages/contracts';
+import { Vai, VaiController } from 'packages/contracts';
 
 import { GetMintableVaiOutput } from './types';
 
-const formatToProposal = (
-  response: Awaited<ReturnType<VaiController['getMintableVAI']>>,
-): GetMintableVaiOutput => ({
-  mintableVaiMantissa: new BigNumber(response[1].toString()),
-});
+interface FormatMintableVaiInput {
+  mintCapResponse: Awaited<ReturnType<VaiController['mintCap']>>;
+  vaiTotalSupplyResponse: Awaited<ReturnType<Vai['totalSupply']>>;
+  accountMintableVaiResponse: Awaited<ReturnType<VaiController['getMintableVAI']>>;
+}
 
-export default formatToProposal;
+const formatToOutput = ({
+  mintCapResponse,
+  vaiTotalSupplyResponse,
+  accountMintableVaiResponse,
+}: FormatMintableVaiInput): GetMintableVaiOutput => {
+  const mintCapMantissa = new BigNumber(mintCapResponse.toString());
+  const vaiTotalSupplyMantissa = new BigNumber(vaiTotalSupplyResponse.toString());
+  const accountMintableVaiMantissa = new BigNumber(accountMintableVaiResponse[1].toString());
+
+  const remainingMintableVaiMantissa = mintCapMantissa.minus(vaiTotalSupplyMantissa);
+  // if there is no more VAI available to be minted globally, return 0
+  if (remainingMintableVaiMantissa.lte(0)) {
+    return {
+      mintableVaiMantissa: new BigNumber(0),
+    };
+  }
+
+  // if there is VAI available, return either the user's limit or up to what is available globally
+  const mintableVaiMantissa = remainingMintableVaiMantissa.gte(accountMintableVaiMantissa)
+    ? accountMintableVaiMantissa
+    : remainingMintableVaiMantissa;
+
+  return {
+    mintableVaiMantissa,
+  };
+};
+
+export default formatToOutput;

--- a/src/clients/api/queries/getMintableVai/index.spec.ts
+++ b/src/clients/api/queries/getMintableVai/index.spec.ts
@@ -1,26 +1,36 @@
 import BigNumber from 'bignumber.js';
 
+import vaiContractResponses from '__mocks__/contracts/vai';
 import vaiControllerResponses from '__mocks__/contracts/vaiController';
 import fakeAddress from '__mocks__/models/address';
 
-import { VaiController } from 'packages/contracts';
+import { Vai, VaiController } from 'packages/contracts';
 
 import getMintableVai from '.';
 
 describe('api/queries/getMintableVai', () => {
   test('returns the mintable VAI in the correct format on success', async () => {
     const getMintableVAIMock = vi.fn(async () => vaiControllerResponses.getMintableVAI);
+    const mintCapMock = vi.fn(async () => vaiControllerResponses.mintCap);
+    const totalSupplyMock = vi.fn(async () => vaiContractResponses.totalSupply);
 
-    const fakeContract = {
+    const fakeVaiControllerContract = {
+      mintCap: mintCapMock,
       getMintableVAI: getMintableVAIMock,
     } as unknown as VaiController;
 
+    const fakeVaiContract = {
+      totalSupply: totalSupplyMock,
+    } as unknown as Vai;
+
     const response = await getMintableVai({
-      vaiControllerContract: fakeContract,
+      vaiContract: fakeVaiContract,
+      vaiControllerContract: fakeVaiControllerContract,
       accountAddress: fakeAddress,
     });
 
     expect(getMintableVAIMock).toHaveBeenCalledTimes(1);
+    expect(totalSupplyMock).toHaveBeenCalledTimes(1);
     expect(response).toMatchSnapshot();
     expect(response.mintableVaiMantissa instanceof BigNumber).toBeTruthy();
   });

--- a/src/clients/api/queries/getMintableVai/index.ts
+++ b/src/clients/api/queries/getMintableVai/index.ts
@@ -5,11 +5,20 @@ export * from './types';
 
 const getMintableVai = async ({
   vaiControllerContract,
+  vaiContract,
   accountAddress,
 }: GetMintableVaiInput): Promise<GetMintableVaiOutput> => {
-  const res = await vaiControllerContract.getMintableVAI(accountAddress);
+  const [vaiTotalSupplyResponse, mintCapResponse, accountMintableVaiResponse] = await Promise.all([
+    vaiContract.totalSupply(),
+    vaiControllerContract.mintCap(),
+    vaiControllerContract.getMintableVAI(accountAddress),
+  ]);
 
-  return formatToOutput(res);
+  return formatToOutput({
+    mintCapResponse,
+    accountMintableVaiResponse,
+    vaiTotalSupplyResponse,
+  });
 };
 
 export default getMintableVai;

--- a/src/clients/api/queries/getMintableVai/types.ts
+++ b/src/clients/api/queries/getMintableVai/types.ts
@@ -1,10 +1,11 @@
 import BigNumber from 'bignumber.js';
 
-import { VaiController } from 'packages/contracts';
+import { Vai, VaiController } from 'packages/contracts';
 
 export interface GetMintableVaiInput {
   accountAddress: string;
   vaiControllerContract: VaiController;
+  vaiContract: Vai;
 }
 
 export interface GetMintableVaiOutput {

--- a/src/clients/api/queries/getMintableVai/useGetMintableVai.ts
+++ b/src/clients/api/queries/getMintableVai/useGetMintableVai.ts
@@ -5,12 +5,17 @@ import getMintableVai, {
   GetMintableVaiOutput,
 } from 'clients/api/queries/getMintableVai';
 import FunctionKey from 'constants/functionKey';
-import { useGetVaiControllerContract } from 'packages/contracts';
+import { useGetVaiContract, useGetVaiControllerContract } from 'packages/contracts';
 import { useChainId } from 'packages/wallet';
-import { ChainId } from 'types';
+import { ChainId, Token } from 'types';
 import { callOrThrow } from 'utilities';
 
-type TrimmedGetMintableVaiInput = Omit<GetMintableVaiInput, 'vaiControllerContract'>;
+type TrimmedGetMintableVaiInput = Omit<
+  GetMintableVaiInput,
+  'vaiControllerContract' | 'vaiContract'
+> & {
+  vai: Token;
+};
 
 export type UseGetMintableVaiQueryKey = [
   FunctionKey.GET_MINTABLE_VAI,
@@ -25,14 +30,19 @@ type Options = QueryObserverOptions<
   UseGetMintableVaiQueryKey
 >;
 
-const useGetMintableVai = (input: TrimmedGetMintableVaiInput, options?: Options) => {
+const useGetMintableVai = ({ vai, ...input }: TrimmedGetMintableVaiInput, options?: Options) => {
   const { chainId } = useChainId();
   const vaiControllerContract = useGetVaiControllerContract();
+  const vaiContract = useGetVaiContract({
+    address: vai.address,
+    chainId,
+    passSigner: false,
+  });
 
   return useQuery(
-    [FunctionKey.GET_MINTABLE_VAI, { ...input, chainId }],
+    [FunctionKey.GET_MINTABLE_VAI, { ...input, vai, chainId }],
     () =>
-      callOrThrow({ vaiControllerContract }, params =>
+      callOrThrow({ vaiControllerContract, vaiContract }, params =>
         getMintableVai({
           ...params,
           ...input,

--- a/src/clients/api/queries/getMintableVai/useGetMintableVai.ts
+++ b/src/clients/api/queries/getMintableVai/useGetMintableVai.ts
@@ -5,6 +5,7 @@ import getMintableVai, {
   GetMintableVaiOutput,
 } from 'clients/api/queries/getMintableVai';
 import FunctionKey from 'constants/functionKey';
+import { useGetChainMetadata } from 'hooks/useGetChainMetadata';
 import { useGetVaiContract, useGetVaiControllerContract } from 'packages/contracts';
 import { useChainId } from 'packages/wallet';
 import { ChainId, Token } from 'types';
@@ -33,6 +34,7 @@ type Options = QueryObserverOptions<
 const useGetMintableVai = ({ vai, ...input }: TrimmedGetMintableVaiInput, options?: Options) => {
   const { chainId } = useChainId();
   const vaiControllerContract = useGetVaiControllerContract();
+  const { blockTimeMs } = useGetChainMetadata();
   const vaiContract = useGetVaiContract({
     address: vai.address,
     chainId,
@@ -48,7 +50,10 @@ const useGetMintableVai = ({ vai, ...input }: TrimmedGetMintableVaiInput, option
           ...input,
         }),
       ),
-    options,
+    {
+      refetchInterval: blockTimeMs,
+      ...options,
+    },
   );
 };
 

--- a/src/pages/Vai/MintVai/Form/index.tsx
+++ b/src/pages/Vai/MintVai/Form/index.tsx
@@ -73,21 +73,21 @@ export const Form: React.FC = () => {
   const shouldShowPrimeOnlyWarning =
     isVaiMintPrimeOnlyWarningEnabled && isPrimeEnabled && !isUserPrime;
 
-  const { isLoading: isGetMintableVaiLoading } = useGetMintableVai(
+  const { data: mintableVaiData, isLoading: isGetMintableVaiLoading } = useGetMintableVai(
     {
       accountAddress: accountAddress || '',
+      vai: vai!,
     },
     {
-      enabled: !!accountAddress,
+      enabled: !!accountAddress && !!vai,
     },
   );
 
-  // TODO: use VAI contract value
-  const limitMantissa = new BigNumber(0);
+  const limitMantissa = mintableVaiData?.mintableVaiMantissa;
 
   const isInitialLoading = isGetMintableVaiLoading || isGetPrimeTokenLoading;
 
-  const { data: userVaiBalanceData } = useGetBalanceOf(
+  const { data: userVaiBalanceData, isLoading: isGetUserVaiBalance } = useGetBalanceOf(
     {
       accountAddress: accountAddress || '',
       token: vai!,
@@ -101,7 +101,8 @@ export const Form: React.FC = () => {
 
   const { data: getVaiRepayApyData } = useGetVaiRepayApy();
 
-  const { data: vaiTreasuryData } = useGetVaiTreasuryPercentage();
+  const { data: vaiTreasuryData, isLoading: isGetVaiTreasuryPercentageLoading } =
+    useGetVaiTreasuryPercentage();
 
   const mintFeePercentage = vaiTreasuryData?.percentage;
 
@@ -167,8 +168,7 @@ export const Form: React.FC = () => {
     }
   };
 
-  // TODO: use VAI contract values
-  const isDisabled = true;
+  const isDisabled = !accountAddress || isGetVaiTreasuryPercentageLoading || isGetUserVaiBalance;
 
   if (isInitialLoading) {
     return <Spinner />;

--- a/src/pages/Vai/MintVai/__tests__/index.spec.tsx
+++ b/src/pages/Vai/MintVai/__tests__/index.spec.tsx
@@ -1,6 +1,8 @@
 import { fireEvent, waitFor } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
 import Vi from 'vitest';
 
+import vaiContractResponses from '__mocks__/contracts/vai';
 import vaiControllerResponses from '__mocks__/contracts/vaiController';
 import fakeAccountAddress from '__mocks__/models/address';
 import fakeContractTransaction from '__mocks__/models/contractTransaction';
@@ -14,7 +16,13 @@ import { convertMantissaToTokens } from 'utilities';
 
 import MintVai from '..';
 
-const fakeGetMintableVaiOutput = formatToMintableVaiOutput(vaiControllerResponses.getMintableVAI);
+const fakeFormatToMintableVaiInput = {
+  mintCapResponse: vaiControllerResponses.mintCap,
+  vaiTotalSupplyResponse: vaiContractResponses.totalSupply,
+  accountMintableVaiResponse: vaiControllerResponses.getMintableVAI,
+};
+
+const fakeGetMintableVaiOutput = formatToMintableVaiOutput(fakeFormatToMintableVaiInput);
 
 const fakeVaiTreasuryPercentage = 7.19;
 
@@ -78,6 +86,79 @@ describe('MintVai', () => {
     await waitFor(() => expect(mintVai).toHaveBeenCalledTimes(1));
     expect(mintVai).toHaveBeenCalledWith({
       amountMantissa: fakeGetMintableVaiOutput.mintableVaiMantissa,
+    });
+  });
+
+  it('does not let user mint VAI if there is no VAI left to mint', async () => {
+    // mock getMintableVai, simulating that the total supply has reached the cap
+    const fakeGetMintableVaiOutputToppedCap = formatToMintableVaiOutput({
+      ...fakeFormatToMintableVaiInput,
+      vaiTotalSupplyResponse: fakeFormatToMintableVaiInput.mintCapResponse,
+    });
+    (getMintableVai as Vi.Mock).mockImplementation(() => fakeGetMintableVaiOutputToppedCap);
+
+    const { getByText, getByPlaceholderText } = renderComponent(<MintVai />, {
+      accountAddress: fakeAccountAddress,
+    });
+    await waitFor(() => getByText(en.vai.mintVai.submitButtonDisabledLabel));
+
+    // Check if the "SAFE MAX" button is disabled
+    const safeMaxButton = getByText(en.vai.mintVai.rightMaxButtonLabel).closest(
+      'button',
+    ) as HTMLButtonElement;
+    await waitFor(() => expect(safeMaxButton).toBeDisabled());
+
+    // Check if the input is disabled
+    const tokenTextFieldInput = getByPlaceholderText('0.00') as HTMLInputElement;
+    await waitFor(() => expect(tokenTextFieldInput).toBeDisabled());
+  });
+
+  it('lets user mint up to global VAI left for minting if lower than the account limit', async () => {
+    (mintVai as Vi.Mock).mockImplementationOnce(async () => fakeContractTransaction);
+    const remainingVaiAvailable = '10000000000000000';
+    const remainingVaiAvailableMantissa = new BigNumber(remainingVaiAvailable);
+    const totalVaiSupply = fakeFormatToMintableVaiInput.mintCapResponse.sub(remainingVaiAvailable);
+    const fakeGetMintableVaiOutputWithTotalVaiSupply = formatToMintableVaiOutput({
+      ...fakeFormatToMintableVaiInput,
+      vaiTotalSupplyResponse: totalVaiSupply,
+    });
+    (getMintableVai as Vi.Mock).mockImplementation(
+      () => fakeGetMintableVaiOutputWithTotalVaiSupply,
+    );
+
+    const { getByText, getByPlaceholderText } = renderComponent(<MintVai />, {
+      accountAddress: fakeAccountAddress,
+    });
+    await waitFor(() => getByText(en.vai.mintVai.submitButtonDisabledLabel));
+    // Click on "SAFE MAX" button
+    const safeMaxButton = getByText(en.vai.mintVai.rightMaxButtonLabel).closest(
+      'button',
+    ) as HTMLButtonElement;
+    fireEvent.click(safeMaxButton);
+
+    // Check input value updated to max amount of available VAI
+    const fakeRemainingAvailableVaiTokens = convertMantissaToTokens({
+      value: new BigNumber(remainingVaiAvailable),
+      token: vai,
+    });
+
+    const tokenTextFieldInput = getByPlaceholderText('0.00') as HTMLInputElement;
+    await waitFor(() =>
+      expect(tokenTextFieldInput.value).toBe(fakeRemainingAvailableVaiTokens.toFixed()),
+    );
+
+    // Submit repayment request
+    await waitFor(() => expect(getByText(en.vai.mintVai.submitButtonLabel)));
+
+    const submitButton = getByText(en.vai.mintVai.submitButtonLabel).closest(
+      'button',
+    ) as HTMLButtonElement;
+    fireEvent.click(submitButton);
+
+    // Check mintVai was called correctly
+    await waitFor(() => expect(mintVai).toHaveBeenCalledTimes(1));
+    expect(mintVai).toHaveBeenCalledWith({
+      amountMantissa: remainingVaiAvailableMantissa,
     });
   });
 });

--- a/src/pages/Vai/MintVai/__tests__/index.spec.tsx
+++ b/src/pages/Vai/MintVai/__tests__/index.spec.tsx
@@ -4,11 +4,13 @@ import Vi from 'vitest';
 import vaiControllerResponses from '__mocks__/contracts/vaiController';
 import fakeAccountAddress from '__mocks__/models/address';
 import fakeContractTransaction from '__mocks__/models/contractTransaction';
+import { vai } from '__mocks__/models/tokens';
 import { renderComponent } from 'testUtils/render';
 
 import { getMintableVai, getVaiTreasuryPercentage, mintVai } from 'clients/api';
 import formatToMintableVaiOutput from 'clients/api/queries/getMintableVai/formatToOutput';
 import { en } from 'packages/translations';
+import { convertMantissaToTokens } from 'utilities';
 
 import MintVai from '..';
 
@@ -27,7 +29,7 @@ describe('MintVai', () => {
     });
   });
 
-  it('displays 0 as the available VAI limit and mint fee', async () => {
+  it('displays the correct available VAI limit and mint fee', async () => {
     (getVaiTreasuryPercentage as Vi.Mock).mockImplementationOnce(async () => ({
       percentage: fakeVaiTreasuryPercentage,
     }));
@@ -37,26 +39,45 @@ describe('MintVai', () => {
     });
 
     // Check available VAI limit displays correctly
-    await waitFor(() => getByText('0 VAI'));
+    await waitFor(() => getByText('40.00 VAI'));
     // Check mint fee displays correctly
     await waitFor(() => getByText(`0 VAI (${fakeVaiTreasuryPercentage.toString()}%)`));
   });
 
-  it('disables minting VAI', async () => {
+  it('lets user mint VAI', async () => {
     (mintVai as Vi.Mock).mockImplementationOnce(async () => fakeContractTransaction);
 
     const { getByText, getByPlaceholderText } = renderComponent(<MintVai />, {
       accountAddress: fakeAccountAddress,
     });
     await waitFor(() => getByText(en.vai.mintVai.submitButtonDisabledLabel));
-
     // Click on "SAFE MAX" button
     const safeMaxButton = getByText(en.vai.mintVai.rightMaxButtonLabel).closest(
       'button',
     ) as HTMLButtonElement;
     fireEvent.click(safeMaxButton);
 
+    // Check input value updated to max amount of mintable VAI
+    const fakeMintableVai = convertMantissaToTokens({
+      value: fakeGetMintableVaiOutput.mintableVaiMantissa,
+      token: vai,
+    });
+
     const tokenTextFieldInput = getByPlaceholderText('0.00') as HTMLInputElement;
-    await waitFor(() => expect(tokenTextFieldInput.value).toBe(''));
+    await waitFor(() => expect(tokenTextFieldInput.value).toBe(fakeMintableVai.toFixed()));
+
+    // Submit repayment request
+    await waitFor(() => expect(getByText(en.vai.mintVai.submitButtonLabel)));
+
+    const submitButton = getByText(en.vai.mintVai.submitButtonLabel).closest(
+      'button',
+    ) as HTMLButtonElement;
+    fireEvent.click(submitButton);
+
+    // Check mintVai was called correctly
+    await waitFor(() => expect(mintVai).toHaveBeenCalledTimes(1));
+    expect(mintVai).toHaveBeenCalledWith({
+      amountMantissa: fakeGetMintableVaiOutput.mintableVaiMantissa,
+    });
   });
 });


### PR DESCRIPTION
## Jira ticket(s)

VEN-2284

## Changes

- Updated logic to calculate mintable VAI, now takes into account the global amount of previously minted VAI
- Reenable VAI minting
