### PR TITLE
fix: hide Prime status banner when no user is logged in

### DIFF
--- a/src/pages/Vault/VaultItem/index.tsx
+++ b/src/pages/Vault/VaultItem/index.tsx
@@ -142,7 +142,7 @@ export const VaultItemUi: React.FC<VaultItemUiProps> = ({
           {readableUserStakedTokens}
         </Typography>
 
-        {isPrimeEnabled && poolIndex === primePoolIndex && (
+        {isPrimeEnabled && primePoolIndex !== undefined && poolIndex === primePoolIndex && (
           <PrimeStatusBanner className="bg-background p-4 sm:mt-2" hidePromotionalTitle />
         )}
 


### PR DESCRIPTION
## Changes

- hide Prime status banner when no user is logged in
