### PR TITLE
fix: chain ID detection from URL in getChainId function

### DIFF
--- a/src/packages/wallet/utilities/getChainId/index.tsx
+++ b/src/packages/wallet/utilities/getChainId/index.tsx
@@ -1,6 +1,6 @@
 import { getChainIdFromSearchParams } from 'packages/wallet/utilities/getChainIdFromSearchParams';
 
 export const getChainId = () => {
-  const searchParams = new URLSearchParams(document.location.search);
+  const searchParams = new URLSearchParams(`?${window.location.hash.split('?')[1]}`);
   return getChainIdFromSearchParams({ searchParams });
 };


### PR DESCRIPTION
## Changes

- fix how chain ID search param is extracted from URL in `getChainId` function
