### PR TITLE
refactor: disable isolated pools on opBNB testnet network

### DIFF
--- a/src/containers/Layout/useGetMenuItems.tsx
+++ b/src/containers/Layout/useGetMenuItems.tsx
@@ -14,6 +14,7 @@ const useGetMenuItems = () => {
   const vaiRouteEnabled = useIsFeatureEnabled({ name: 'vaiRoute' });
   const xvsRouteEnabled = useIsFeatureEnabled({ name: 'xvsRoute' });
   const bridgeRouteEnabled = useIsFeatureEnabled({ name: 'bridgeRoute' });
+  const isolatedPoolsRouteEnabled = useIsFeatureEnabled({ name: 'isolatedPools' });
 
   return useMemo(() => {
     const menuItems: MenuItem[] = [
@@ -45,22 +46,23 @@ const useGetMenuItems = () => {
       iconName: 'venus',
     });
 
-    menuItems.push(
-      {
+    if (isolatedPoolsRouteEnabled) {
+      menuItems.push({
         to: routes.isolatedPools.path,
         // Translation key: do not remove this comment
         // t('layout.menuItems.isolatedPools')
         i18nKey: 'layout.menuItems.isolatedPools',
         iconName: 'fourDots',
-      },
-      {
-        to: routes.vaults.path,
-        // Translation key: do not remove this comment
-        // t('layout.menuItems.vaults')
-        i18nKey: 'layout.menuItems.vaults',
-        iconName: 'vault',
-      },
-    );
+      });
+    }
+
+    menuItems.push({
+      to: routes.vaults.path,
+      // Translation key: do not remove this comment
+      // t('layout.menuItems.vaults')
+      i18nKey: 'layout.menuItems.vaults',
+      iconName: 'vault',
+    });
 
     if (swapRouteEnabled) {
       menuItems.push({
@@ -140,6 +142,7 @@ const useGetMenuItems = () => {
     vaiRouteEnabled,
     xvsRouteEnabled,
     bridgeRouteEnabled,
+    isolatedPoolsRouteEnabled,
   ]);
 };
 

--- a/src/hooks/useIsFeatureEnabled/index.tsx
+++ b/src/hooks/useIsFeatureEnabled/index.tsx
@@ -21,6 +21,7 @@ const featureFlags = {
   marketParticipantCounts: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   vaiMintPrimeOnlyWarning: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   bridgeRoute: [ChainId.BSC_TESTNET, ChainId.SEPOLIA],
+  isolatedPools: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET, ChainId.SEPOLIA],
 };
 
 export type FeatureFlag = keyof typeof featureFlags;


### PR DESCRIPTION
## Changes

- disable isolated pools on opBNB testnet network by using a feature flag, as this network will only have the core pool available at launch
