### PR TITLE
feat: add support for disabled vaults

### DIFF
--- a/src/__mocks__/models/vaults.ts
+++ b/src/__mocks__/models/vaults.ts
@@ -8,6 +8,7 @@ export const vaults: Vault[] = [
   {
     rewardToken: xvs,
     stakedToken: vai,
+    isPaused: false,
     lockingPeriodMs: 300000,
     dailyEmissionMantissa: new BigNumber('144000000000000000000'),
     totalStakedMantissa: new BigNumber('415000000000000000000'),
@@ -16,6 +17,7 @@ export const vaults: Vault[] = [
   {
     rewardToken: xvs,
     stakedToken: xvs,
+    isPaused: false,
     lockingPeriodMs: 300000,
     dailyEmissionMantissa: new BigNumber('144000000000000000000'),
     totalStakedMantissa: new BigNumber('400000000000000000000000000'),

--- a/src/clients/api/queries/getPendingRewards/__testUtils__/fakeData.ts
+++ b/src/clients/api/queries/getPendingRewards/__testUtils__/fakeData.ts
@@ -4,6 +4,8 @@ export const fakeGetPriceOutput = BN.from('0x30f7dc8a6370b000');
 
 export const fakeGetPendingXvsOutput = BN.from('1000000000000000000');
 
+export const fakeGetVaultPaused = false;
+
 export const fakeGetIsolatedPoolPendingRewardsOutput = [
   {
     distributorAddress: '0xb0269d68CfdCc30Cb7Cd2E0b52b08Fa7Ffd3079b',

--- a/src/clients/api/queries/getPendingRewards/__tests__/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getPendingRewards/__tests__/__snapshots__/index.spec.ts.snap
@@ -41,6 +41,7 @@ exports[`getPendingRewards > returns pool rewards of the user in the correct for
       "type": "isolatedPool",
     },
     {
+      "isDisabled": false,
       "rewardAmountCents": "352.853132",
       "rewardAmountMantissa": "1000000000000000000",
       "rewardToken": {
@@ -58,6 +59,7 @@ exports[`getPendingRewards > returns pool rewards of the user in the correct for
       "type": "vault",
     },
     {
+      "isDisabled": false,
       "poolIndex": 0,
       "rewardAmountCents": "227.6612616584371779",
       "rewardAmountMantissa": "645201192825000000",
@@ -120,6 +122,7 @@ exports[`getPendingRewards > returns pool rewards of the user, including Prime r
       "type": "isolatedPool",
     },
     {
+      "isDisabled": false,
       "rewardAmountCents": "352.853132",
       "rewardAmountMantissa": "1000000000000000000",
       "rewardToken": {
@@ -137,6 +140,7 @@ exports[`getPendingRewards > returns pool rewards of the user, including Prime r
       "type": "vault",
     },
     {
+      "isDisabled": false,
       "poolIndex": 0,
       "rewardAmountCents": "227.6612616584371779",
       "rewardAmountMantissa": "645201192825000000",

--- a/src/clients/api/queries/getPendingRewards/__tests__/index.spec.ts
+++ b/src/clients/api/queries/getPendingRewards/__tests__/index.spec.ts
@@ -17,6 +17,7 @@ import {
   fakeGetPendingXvsOutput,
   fakeGetPriceOutput,
   fakeGetPrimePendingRewardsOutput,
+  fakeGetVaultPaused,
   fakeGetXvsVaultPendingRewardOutput,
   fakeGetXvsVaultPendingWithdrawalsBeforeUpgradeOutput,
   fakeGetXvsVaultPoolInfosOutput,
@@ -39,10 +40,12 @@ const fakeVenusLensContract = {
 
 const fakeVaiVaultContract = {
   pendingXVS: async () => fakeGetPendingXvsOutput,
+  vaultPaused: async () => fakeGetVaultPaused,
 } as unknown as VaiVault;
 
 const fakeXvsVaultContract = {
   poolInfos: async () => fakeGetXvsVaultPoolInfosOutput,
+  vaultPaused: async () => fakeGetVaultPaused,
   pendingReward: async () => fakeGetXvsVaultPendingRewardOutput,
   pendingWithdrawalsBeforeUpgrade: async () => fakeGetXvsVaultPendingWithdrawalsBeforeUpgradeOutput,
 } as unknown as XvsVault;

--- a/src/clients/api/queries/getPendingRewards/formatOutput/formatToVaultPendingRewardGroup.ts
+++ b/src/clients/api/queries/getPendingRewards/formatOutput/formatToVaultPendingRewardGroup.ts
@@ -8,12 +8,14 @@ import convertMantissaToTokens from 'utilities/convertMantissaToTokens';
 import { VaultPendingRewardGroup } from '../types';
 
 const formatToVaultPendingRewardGroup = ({
+  isDisabled,
   pendingRewardAmountMantissa,
   tokenPriceMapping,
   stakedTokenSymbol,
   rewardTokenSymbol,
   tokens,
 }: {
+  isDisabled: boolean;
   pendingRewardAmountMantissa: BigNumber;
   tokenPriceMapping: Record<string, BigNumber>;
   stakedTokenSymbol: string;
@@ -50,6 +52,7 @@ const formatToVaultPendingRewardGroup = ({
 
   const vaiVaultRewardGroup: VaultPendingRewardGroup = {
     type: 'vault',
+    isDisabled,
     stakedToken,
     rewardToken,
     rewardAmountMantissa: pendingRewardAmountMantissa,

--- a/src/clients/api/queries/getPendingRewards/formatOutput/formatToVestingVaultPendingRewardGroup.ts
+++ b/src/clients/api/queries/getPendingRewards/formatOutput/formatToVestingVaultPendingRewardGroup.ts
@@ -10,6 +10,7 @@ import { XvsVestingVaultPendingRewardGroup } from '../types';
 
 const formatToVestingVaultPendingRewardGroup = ({
   poolIndex,
+  isDisabled,
   userPendingRewardsAmountMantissa,
   userPendingWithdrawalsBeforeUpgradeAmountMantissa,
   tokenPriceMapping,
@@ -17,6 +18,7 @@ const formatToVestingVaultPendingRewardGroup = ({
   stakedTokenAddress,
 }: {
   poolIndex: number;
+  isDisabled: boolean;
   userPendingRewardsAmountMantissa: BigNumber;
   userPendingWithdrawalsBeforeUpgradeAmountMantissa: BigNumber;
   tokenPriceMapping: Record<string, BigNumber>;
@@ -72,6 +74,7 @@ const formatToVestingVaultPendingRewardGroup = ({
 
   const vaiVaultRewardGroup: XvsVestingVaultPendingRewardGroup = {
     type: 'xvsVestingVault',
+    isDisabled,
     poolIndex,
     stakedToken,
     rewardToken,

--- a/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
+++ b/src/clients/api/queries/getPendingRewards/formatOutput/index.ts
@@ -27,9 +27,10 @@ const formatOutput = ({
   venusLensPendingRewards,
   primePendingRewards,
   isPrimeContractPaused,
+  isVaiVaultContractPaused,
+  isXvsVestingVaultContractPaused,
 }: {
   tokens: Token[];
-  vaiVaultPendingXvs?: Awaited<ReturnType<VaiVault['pendingXVS']>>;
   isolatedPoolsPendingRewards: Array<
     Awaited<ReturnType<PoolLens['getPendingRewards']>> | undefined
   >;
@@ -40,7 +41,10 @@ const formatOutput = ({
   >;
   tokenPriceMapping: Record<string, BigNumber>;
   isolatedPoolComptrollerAddresses: string[];
+  isVaiVaultContractPaused: boolean;
+  isXvsVestingVaultContractPaused: boolean;
   isPrimeContractPaused: boolean;
+  vaiVaultPendingXvs?: Awaited<ReturnType<VaiVault['pendingXVS']>>;
   venusLensPendingRewards?: Awaited<ReturnType<VenusLens['pendingRewards']>>;
   legacyPoolComptrollerContractAddress?: string;
   primePendingRewards?: Awaited<ReturnType<Prime['callStatic']['getPendingRewards']>>;
@@ -87,6 +91,7 @@ const formatOutput = ({
   const vaiVaultPendingRewardGroup =
     vaiVaultPendingRewardAmountMantissa &&
     formatToVaultPendingRewardGroup({
+      isDisabled: isVaiVaultContractPaused,
       pendingRewardAmountMantissa: vaiVaultPendingRewardAmountMantissa,
       tokenPriceMapping,
       stakedTokenSymbol: 'VAI',
@@ -124,6 +129,7 @@ const formatOutput = ({
 
       return formatToVestingVaultPendingRewardGroup({
         poolIndex: index,
+        isDisabled: isXvsVestingVaultContractPaused,
         userPendingRewardsAmountMantissa,
         userPendingWithdrawalsBeforeUpgradeAmountMantissa,
         tokenPriceMapping,

--- a/src/clients/api/queries/getPendingRewards/types.ts
+++ b/src/clients/api/queries/getPendingRewards/types.ts
@@ -53,6 +53,7 @@ export interface LegacyPoolPendingRewardGroup {
 
 export interface VaultPendingRewardGroup {
   type: 'vault';
+  isDisabled: boolean;
   stakedToken: Token;
   rewardToken: Token;
   rewardAmountMantissa: BigNumber;
@@ -61,6 +62,7 @@ export interface VaultPendingRewardGroup {
 
 export interface XvsVestingVaultPendingRewardGroup {
   type: 'xvsVestingVault';
+  isDisabled: boolean;
   poolIndex: number;
   stakedToken: Token;
   rewardToken: Token;

--- a/src/containers/Layout/ClaimRewardButton/__testUtils__/fakeData.ts
+++ b/src/containers/Layout/ClaimRewardButton/__testUtils__/fakeData.ts
@@ -43,6 +43,7 @@ export const fakePendingRewardGroups: PendingRewardGroup[] = [
   },
   {
     type: 'vault',
+    isDisabled: false,
     stakedToken: vai,
     rewardToken: xvs,
     rewardAmountMantissa: new BigNumber('3000000000000000000000000000'),
@@ -50,6 +51,7 @@ export const fakePendingRewardGroups: PendingRewardGroup[] = [
   },
   {
     type: 'xvsVestingVault',
+    isDisabled: false,
     stakedToken: xvs,
     rewardToken: xvs,
     rewardAmountMantissa: new BigNumber('4000000000000000000000000000'),

--- a/src/containers/Layout/ClaimRewardButton/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/src/containers/Layout/ClaimRewardButton/__tests__/__snapshots__/index.spec.tsx.snap
@@ -1,6 +1,6 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ClaimRewardButton > it claims only selected rewards on submit button click on success 1`] = `
+exports[`ClaimRewardButton > it claims only selected and enabled rewards on submit button click on success 1`] = `
 {
   "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
   "claims": [
@@ -20,16 +20,6 @@ exports[`ClaimRewardButton > it claims only selected rewards on submit button cl
       "vTokenAddressesWithPendingReward": [
         "0xcfc8a73f9c888eea9af9ccca24646e84a915510b",
       ],
-    },
-    {
-      "contract": "xvsVestingVault",
-      "poolIndex": 0,
-      "rewardToken": {
-        "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-        "asset": "/src/packages/tokens/img/xvs.svg",
-        "decimals": 18,
-        "symbol": "XVS",
-      },
     },
     {
       "contract": "prime",

--- a/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
+++ b/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
@@ -63,7 +63,63 @@ describe('ClaimRewardButton', () => {
     expect(getByTestId(TEST_IDS.claimRewardBreakdown).textContent).toMatchSnapshot();
   });
 
-  it('displays warning message and removes checkbox of Prime group when Prime group is disabled', async () => {
+  it('displays warning message and removes checkbox of vault group when it is disabled', async () => {
+    (getPendingRewards as Vi.Mock).mockImplementation(() => ({
+      pendingRewardGroups: fakePendingRewardGroups.map(fakePendingRewardGroup => {
+        if (fakePendingRewardGroup.type !== 'vault') {
+          return fakePendingRewardGroup;
+        }
+
+        return {
+          ...fakePendingRewardGroup,
+          isDisabled: true,
+        };
+      }),
+    }));
+
+    const { getByTestId, getByText } = renderComponent(<ClaimRewardButton />, {
+      accountAddress: fakeAddress,
+    });
+
+    await waitFor(() => expect(getByTestId(TEST_IDS.claimRewardOpenModalButton)));
+
+    // Open modal
+    fireEvent.click(getByTestId(TEST_IDS.claimRewardOpenModalButton));
+
+    await waitFor(() =>
+      expect(getByText(en.layout.claimRewardModal.vaultGroup.disabledContractWarningMessage)),
+    );
+  });
+
+  it('displays warning message and removes checkbox of XVS vesting vault group when it is disabled', async () => {
+    (getPendingRewards as Vi.Mock).mockImplementation(() => ({
+      pendingRewardGroups: fakePendingRewardGroups.map(fakePendingRewardGroup => {
+        if (fakePendingRewardGroup.type !== 'xvsVestingVault') {
+          return fakePendingRewardGroup;
+        }
+
+        return {
+          ...fakePendingRewardGroup,
+          isDisabled: true,
+        };
+      }),
+    }));
+
+    const { getByTestId, getByText } = renderComponent(<ClaimRewardButton />, {
+      accountAddress: fakeAddress,
+    });
+
+    await waitFor(() => expect(getByTestId(TEST_IDS.claimRewardOpenModalButton)));
+
+    // Open modal
+    fireEvent.click(getByTestId(TEST_IDS.claimRewardOpenModalButton));
+
+    await waitFor(() =>
+      expect(getByText(en.layout.claimRewardModal.vaultGroup.disabledContractWarningMessage)),
+    );
+  });
+
+  it('displays warning message and removes checkbox of Prime group when it is disabled', async () => {
     (getPendingRewards as Vi.Mock).mockImplementation(() => ({
       pendingRewardGroups: fakePendingRewardGroups.map(fakePendingRewardGroup => {
         if (fakePendingRewardGroup.type !== 'prime') {
@@ -188,8 +244,21 @@ describe('ClaimRewardButton', () => {
     await waitFor(() => expect(queryByTestId(TEST_IDS.claimRewardSubmitButton)).toBeNull());
   });
 
-  it('it claims only selected rewards on submit button click on success', async () => {
+  it('it claims only selected and enabled rewards on submit button click on success', async () => {
     (claimRewards as Vi.Mock).mockImplementationOnce(() => fakeContractTransaction);
+
+    (getPendingRewards as Vi.Mock).mockImplementation(() => ({
+      pendingRewardGroups: fakePendingRewardGroups.map(fakePendingRewardGroup => {
+        if (fakePendingRewardGroup.type !== 'xvsVestingVault') {
+          return fakePendingRewardGroup;
+        }
+
+        return {
+          ...fakePendingRewardGroup,
+          isDisabled: true,
+        };
+      }),
+    }));
 
     const { getByTestId } = renderComponent(<ClaimRewardButton />, {
       accountAddress: fakeAddress,

--- a/src/containers/Layout/ClaimRewardButton/index.tsx
+++ b/src/containers/Layout/ClaimRewardButton/index.tsx
@@ -163,7 +163,7 @@ export const ClaimRewardButton: React.FC<ClaimRewardButtonProps> = props => {
 
     // Extract all claims from checked groups
     const claims = groups.reduce<Claim[]>(
-      (acc, group) => (group.isChecked ? acc.concat(group.claims) : acc),
+      (acc, group) => (group.isChecked && !group.isDisabled ? acc.concat(group.claims) : acc),
       [],
     );
 

--- a/src/containers/Layout/ClaimRewardButton/useGetGroups.ts
+++ b/src/containers/Layout/ClaimRewardButton/useGetGroups.ts
@@ -45,10 +45,10 @@ const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) =>
 
             const name =
               pendingRewardGroup.type === 'vault'
-                ? t('layout.claimRewardModal.vaultGroup', {
+                ? t('layout.claimRewardModal.vaultGroup.name', {
                     stakedTokenSymbol: pendingRewardGroup.stakedToken.symbol,
                   })
-                : t('layout.claimRewardModal.vestingVaultGroup', {
+                : t('layout.claimRewardModal.vestingVaultGroup.name', {
                     stakedTokenSymbol: xvs?.symbol,
                   });
 
@@ -66,7 +66,11 @@ const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) =>
             const group: Group = {
               id,
               name,
-              isChecked: !uncheckedGroupIds.includes(id),
+              isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
+              isDisabled: pendingRewardGroup.isDisabled,
+              warningMessage: pendingRewardGroup.isDisabled
+                ? t('layout.claimRewardModal.vaultGroup.disabledContractWarningMessage')
+                : undefined,
               pendingRewards: [
                 {
                   rewardToken: pendingRewardGroup.rewardToken,
@@ -86,10 +90,10 @@ const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) =>
 
             const group: Group = {
               id,
-              name: t('layout.claimRewardModal.primeGroup.name'),
               isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
-              pendingRewards: pendingRewardGroup.pendingRewards,
+              name: t('layout.claimRewardModal.primeGroup.name'),
               isDisabled: pendingRewardGroup.isDisabled,
+              pendingRewards: pendingRewardGroup.pendingRewards,
               warningMessage: pendingRewardGroup.isDisabled
                 ? t('layout.claimRewardModal.primeGroup.disabledContractWarningMessage')
                 : undefined,

--- a/src/packages/translations/translations/en.json
+++ b/src/packages/translations/translations/en.json
@@ -329,8 +329,13 @@
         "disabledContractWarningMessage": "The Prime contract is currently paused. Interests from Prime are still accruing but can't be claimed until the contract is unpaused.",
         "name": "Prime"
       },
-      "vaultGroup": "{{stakedTokenSymbol}} vault",
-      "vestingVaultGroup": "{{stakedTokenSymbol}} vesting vault"
+      "vaultGroup": {
+        "disabledContractWarningMessage": "This vault is currently paused. Interest rates are still accruing but can't be claimed until the vault is unpaused.",
+        "name": "{{stakedTokenSymbol}} vault"
+      },
+      "vestingVaultGroup": {
+        "name": "{{stakedTokenSymbol}} vesting vault"
+      }
     },
     "menu": {
       "navLink": {
@@ -972,6 +977,7 @@
   "vaultItem": {
     "blockingPendingWithdrawalsWarning": "You must complete pending withdrawals to interact with this vault.",
     "dailyEmission": "Daily Emission",
+    "pausedWarning": "This vault is currently paused. Interest rates are still accruing but claiming, staking, and withdrawing are disabled until the vault is unpaused",
     "stakeButton": "Stake",
     "stakingApr": "{{stakeTokenName}} Stake APR",
     "totalStaked": "Total Staked",

--- a/src/pages/Vault/VaultItem/index.spec.tsx
+++ b/src/pages/Vault/VaultItem/index.spec.tsx
@@ -37,7 +37,7 @@ describe('pages/Vault/VaultItem', () => {
     );
   });
 
-  it('hides withdraw button userStakedMantissa is equal to 0', async () => {
+  it('hides withdraw button if userStakedMantissa is equal to 0', async () => {
     const customBaseProps: VaultItemProps = {
       ...baseProps,
       stakedToken: vrt,
@@ -50,5 +50,22 @@ describe('pages/Vault/VaultItem', () => {
 
     // Click on withdraw button
     expect(queryByText(en.vaultItem.withdrawButton)).toBeNull();
+  });
+
+  it('disables stake and withdraw buttons and displays message if isPaused is true', async () => {
+    const customBaseProps: VaultItemProps = {
+      ...baseProps,
+      isPaused: true,
+    };
+
+    const { queryByText } = renderComponent(<VaultItem {...customBaseProps} />, {
+      accountAddress: fakeAddress,
+    });
+
+    // Check stake and withdraw buttons are disabled
+    expect(queryByText(en.vaultItem.stakeButton)?.closest('button')).toBeDisabled();
+    expect(queryByText(en.vaultItem.withdrawButton)?.closest('button')).toBeDisabled();
+    // Check warning is displayed
+    expect(queryByText(en.vaultItem.pausedWarning));
   });
 });

--- a/src/pages/Vault/VaultItem/index.tsx
+++ b/src/pages/Vault/VaultItem/index.tsx
@@ -30,6 +30,7 @@ export interface VaultItemUiProps {
   onStake: () => void;
   onWithdraw: () => void;
   closeActiveModal: () => void;
+  isPaused: boolean;
   canWithdraw?: boolean;
   poolIndex?: number;
   activeModal?: ActiveModal;
@@ -47,6 +48,7 @@ export const VaultItemUi: React.FC<VaultItemUiProps> = ({
   totalStakedMantissa,
   onStake,
   onWithdraw,
+  isPaused,
   canWithdraw = true,
   activeModal,
   poolIndex,
@@ -164,9 +166,13 @@ export const VaultItemUi: React.FC<VaultItemUiProps> = ({
           ))}
         </ul>
 
-        {hasPendingWithdrawalsFromBeforeUpgrade && (
+        {(isPaused || hasPendingWithdrawalsFromBeforeUpgrade) && (
           <NoticeWarning
-            description={t('vaultItem.blockingPendingWithdrawalsWarning')}
+            description={
+              isPaused
+                ? t('vaultItem.pausedWarning')
+                : t('vaultItem.blockingPendingWithdrawalsWarning')
+            }
             className="mt-6"
           />
         )}
@@ -176,13 +182,18 @@ export const VaultItemUi: React.FC<VaultItemUiProps> = ({
             onClick={onStake}
             css={styles.button}
             variant="primary"
-            disabled={hasPendingWithdrawalsFromBeforeUpgrade}
+            disabled={isPaused || hasPendingWithdrawalsFromBeforeUpgrade}
           >
             {t('vaultItem.stakeButton')}
           </Button>
 
           {canWithdraw && (
-            <Button onClick={onWithdraw} css={styles.button} variant="secondary">
+            <Button
+              onClick={onWithdraw}
+              css={styles.button}
+              variant="secondary"
+              disabled={isPaused}
+            >
               {t('vaultItem.withdrawButton')}
             </Button>
           )}


### PR DESCRIPTION
## Jira ticket(s)

VEN-2333

## Changes

- add `getVaiVaultPaused` and `getXvsVaultPaused` query functions
- update `useGetVaults` hook to handle disabled vaults
- update Vault page to disable CTAs and display warning message when a vault is disabled
- update "Claim rewards" modal to handle disabled vaults
