### PR TITLE
feat: integrate Sepolia and Ethereum subgraphs

### DIFF
--- a/src/clients/api/queries/getIsolatedPools/__tests__/index.spec.ts
+++ b/src/clients/api/queries/getIsolatedPools/__tests__/index.spec.ts
@@ -20,7 +20,7 @@ import {
   getIsolatedPoolComptrollerContract,
   getRewardsDistributorContract,
 } from 'packages/contracts';
-import { Token } from 'types';
+import { ChainId, Token } from 'types';
 
 import getIsolatedPools from '..';
 import {
@@ -92,6 +92,7 @@ describe('api/queries/getIsolatedPools', () => {
     );
 
     const response = await getIsolatedPools({
+      chainId: ChainId.BSC_TESTNET,
       xvs,
       blocksPerDay: 28800,
       tokens,
@@ -114,6 +115,7 @@ describe('api/queries/getIsolatedPools', () => {
     } as unknown as Prime;
 
     const response = await getIsolatedPools({
+      chainId: ChainId.BSC_TESTNET,
       xvs,
       blocksPerDay: 28800,
       tokens,
@@ -141,6 +143,7 @@ describe('api/queries/getIsolatedPools', () => {
     } as unknown as Prime;
 
     const response = await getIsolatedPools({
+      chainId: ChainId.BSC_TESTNET,
       xvs,
       blocksPerDay: 28800,
       tokens,

--- a/src/clients/api/queries/getIsolatedPools/index.ts
+++ b/src/clients/api/queries/getIsolatedPools/index.ts
@@ -1,6 +1,9 @@
 import BigNumber from 'bignumber.js';
 
-import { getIsolatedPoolParticipantsCount } from 'clients/subgraph';
+import {
+  GetIsolatedPoolParticipantsCountInput,
+  getIsolatedPoolParticipantsCount,
+} from 'clients/subgraph';
 import { IsolatedPoolComptroller, getIsolatedPoolComptrollerContract } from 'packages/contracts';
 import { logError } from 'packages/errors';
 import { Asset, PrimeApy, Token } from 'types';
@@ -24,9 +27,11 @@ export type { GetIsolatedPoolsInput, GetIsolatedPoolsOutput } from './types';
 
 // Since the borrower and supplier counts aren't essential information, we make the logic so the
 // dApp can still function if the subgraph is down
-const safelyGetIsolatedPoolParticipantsCount = async () => {
+const safelyGetIsolatedPoolParticipantsCount = async ({
+  chainId,
+}: GetIsolatedPoolParticipantsCountInput) => {
   try {
-    const res = await getIsolatedPoolParticipantsCount();
+    const res = await getIsolatedPoolParticipantsCount({ chainId });
     return res;
   } catch (error) {
     logError(error);
@@ -34,6 +39,7 @@ const safelyGetIsolatedPoolParticipantsCount = async () => {
 };
 
 const getIsolatedPools = async ({
+  chainId,
   xvs,
   blocksPerDay,
   accountAddress,
@@ -55,7 +61,7 @@ const getIsolatedPools = async ({
     // Fetch all pools
     poolLensContract.getAllPools(poolRegistryContractAddress),
     // Fetch borrower and supplier counts of each isolated token
-    safelyGetIsolatedPoolParticipantsCount(),
+    safelyGetIsolatedPoolParticipantsCount({ chainId }),
     // Fetch current block number
     getBlockNumber({ provider }),
     // Prime related calls

--- a/src/clients/api/queries/getIsolatedPools/types.ts
+++ b/src/clients/api/queries/getIsolatedPools/types.ts
@@ -1,8 +1,9 @@
 import { PoolLens, Prime, ResilientOracle } from 'packages/contracts';
 import { type Provider } from 'packages/wallet';
-import { Pool, Token } from 'types';
+import { ChainId, Pool, Token } from 'types';
 
 export interface GetIsolatedPoolsInput {
+  chainId: ChainId;
   xvs: Token;
   blocksPerDay: number;
   tokens: Token[];

--- a/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
+++ b/src/clients/api/queries/getIsolatedPools/useGetIsolatedPools.ts
@@ -20,6 +20,7 @@ import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 type TrimmedInput = Omit<
   GetIsolatedPoolsInput,
+  | 'chainId'
   | 'xvs'
   | 'blocksPerDay'
   | 'provider'
@@ -67,7 +68,7 @@ const useGetIsolatedPools = (input: TrimmedInput, options?: Options) => {
     [FunctionKey.GET_ISOLATED_POOLS, { ...input, chainId }],
     () =>
       callOrThrow(
-        { poolLensContract, poolRegistryContractAddress, resilientOracleContract, xvs },
+        { chainId, poolLensContract, poolRegistryContractAddress, resilientOracleContract, xvs },
         params =>
           getIsolatedPools({
             provider,

--- a/src/clients/subgraph/queries/getIsolatedPoolParticipantsCount/index.ts
+++ b/src/clients/subgraph/queries/getIsolatedPoolParticipantsCount/index.ts
@@ -2,6 +2,18 @@ import { request } from 'graphql-request';
 
 import gql from 'clients/subgraph/gql';
 import config from 'config';
+import { ChainId } from 'types';
 
-export const getIsolatedPoolParticipantsCount = () =>
-  request(config.subgraphUrl, gql.IsolatedPoolParticipantsCountDocument);
+export interface GetIsolatedPoolParticipantsCountInput {
+  chainId: ChainId;
+}
+
+export const getIsolatedPoolParticipantsCount = ({
+  chainId,
+}: GetIsolatedPoolParticipantsCountInput) => {
+  const subgraphUrl = config.subgraphUrls[chainId];
+  if (subgraphUrl) {
+    return request(subgraphUrl, gql.IsolatedPoolParticipantsCountDocument);
+  }
+  return undefined;
+};

--- a/src/config/codegen.ts
+++ b/src/config/codegen.ts
@@ -1,14 +1,20 @@
 /** @type {import('graphql-config').IGraphQLConfig } */
 
-export const MAINNET_SUBGRAPH_URL =
+export const BSC_MAINNET_SUBGRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/venusprotocol/venus-isolated-pools';
 
-export const TESTNET_SUBGRAPH_URL =
+export const BSC_TESTNET_SUBGRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/venusprotocol/venus-isolated-pools-chapel';
+
+export const ETHEREUM_SUBGRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/venusprotocol/venus-isolated-pools-ethereum';
+
+export const SEPOLIA_SUBGRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/venusprotocol/venus-isolated-pools-sepolia';
 
 export const projects = {
   mainnet: {
-    schema: MAINNET_SUBGRAPH_URL,
+    schema: BSC_MAINNET_SUBGRAPH_URL,
     documents: ['../clients/subgraph/**/*.graphql'],
     extensions: {
       codegen: {
@@ -21,7 +27,7 @@ export const projects = {
     },
   },
   testnet: {
-    schema: TESTNET_SUBGRAPH_URL,
+    schema: BSC_TESTNET_SUBGRAPH_URL,
     documents: ['../clients/subgraph/**/*.graphql'],
     extensions: {
       codegen: {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,7 +1,12 @@
 import { API_ENDPOINT_URLS } from 'constants/endpoints';
 import { ChainId, Environment } from 'types';
 
-import { MAINNET_SUBGRAPH_URL, TESTNET_SUBGRAPH_URL } from './codegen';
+import {
+  BSC_MAINNET_SUBGRAPH_URL,
+  BSC_TESTNET_SUBGRAPH_URL,
+  ETHEREUM_SUBGRAPH_URL,
+  SEPOLIA_SUBGRAPH_URL,
+} from './codegen';
 import { ENV_VARIABLES } from './envVariables';
 
 export interface Config {
@@ -15,7 +20,7 @@ export interface Config {
       webSocket?: string;
     };
   };
-  subgraphUrl: string;
+  subgraphUrls: Partial<Record<ChainId, string>>;
   sentryDsn: string;
   posthog: {
     apiKey: string;
@@ -55,7 +60,13 @@ const rpcUrls = {
 };
 
 const apiUrl = API_ENDPOINT_URLS[environment];
-const subgraphUrl = isOnTestnet ? TESTNET_SUBGRAPH_URL : MAINNET_SUBGRAPH_URL;
+const subgraphUrls = {
+  [ChainId.BSC_MAINNET]: BSC_MAINNET_SUBGRAPH_URL,
+  [ChainId.BSC_TESTNET]: BSC_TESTNET_SUBGRAPH_URL,
+  // TODO: add opBNB testnet subgraph URL
+  [ChainId.ETHEREUM]: ETHEREUM_SUBGRAPH_URL,
+  [ChainId.SEPOLIA]: SEPOLIA_SUBGRAPH_URL,
+};
 
 const config: Config = {
   environment,
@@ -63,7 +74,7 @@ const config: Config = {
   isLocalServer,
   apiUrl,
   rpcUrls,
-  subgraphUrl,
+  subgraphUrls,
   sentryDsn: ENV_VARIABLES.VITE_SENTRY_DSN || '',
   posthog: {
     apiKey: ENV_VARIABLES.VITE_POSTHOG_API_KEY || '',

--- a/src/hooks/useIsFeatureEnabled/index.tsx
+++ b/src/hooks/useIsFeatureEnabled/index.tsx
@@ -18,7 +18,12 @@ const featureFlags = {
   voteProposal: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   lunaUstWarning: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   marketHistory: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
-  marketParticipantCounts: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
+  marketParticipantCounts: [
+    ChainId.BSC_MAINNET,
+    ChainId.BSC_TESTNET,
+    ChainId.ETHEREUM,
+    ChainId.SEPOLIA,
+  ],
   vaiMintPrimeOnlyWarning: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   isolatedPools: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET, ChainId.SEPOLIA],
   bridgeRoute: [ChainId.BSC_TESTNET, ChainId.SEPOLIA, ChainId.OPBNB_TESTNET],


### PR DESCRIPTION
## Jira ticket(s)

VEN-2342
VEN-2343

## Changes

- Activate `marketParticipantCounts` feature flag for Ethereum and Sepolia
- Add Ethereum and Sepolia subgraph URLs
- Fetch participants count based on current `chainId`
