### PR TITLE
fix: max button dirties Bridge form

### DIFF
--- a/src/pages/Bridge/index.tsx
+++ b/src/pages/Bridge/index.tsx
@@ -350,6 +350,7 @@ const BridgePage: React.FC = () => {
                   onClick: () => {
                     setValue('amountTokens', walletBalanceTokens.toFixed(), {
                       shouldValidate: true,
+                      shouldDirty: true,
                     });
                   },
                 }}


### PR DESCRIPTION
## Changes

- Clicking on the MAX button will make the form dirty
