### PR TITLE
feat: multiply bridge USD limits by BRIDGE_USD_LIMIT_FACTOR

### DIFF
--- a/src/clients/api/queries/getXvsBridgeStatus/__snapshots__/index.spec.ts.snap
+++ b/src/clients/api/queries/getXvsBridgeStatus/__snapshots__/index.spec.ts.snap
@@ -3,8 +3,8 @@
 exports[`getXvsBridgeStatus > returns the the data describing the status of the XVS bridge contract 1`] = `
 {
   "dailyLimitResetTimestamp": "1705273290",
-  "maxDailyLimitUsd": "500",
-  "maxSingleTransactionLimitUsd": "10",
+  "maxDailyLimitUsd": "450",
+  "maxSingleTransactionLimitUsd": "9",
   "totalTransferredLast24HourUsd": "9.310366874",
 }
 `;

--- a/src/clients/api/queries/getXvsBridgeStatus/index.ts
+++ b/src/clients/api/queries/getXvsBridgeStatus/index.ts
@@ -17,6 +17,10 @@ export interface GetXvsBridgeStatusOutput {
   maxSingleTransactionLimitUsd: BigNumber;
 }
 
+// the XVS price might vary during the time it takes to complete a bridge operation,
+// so this is used as a safe margin (90% of the actual limit)
+const BRIDGE_USD_LIMIT_FACTOR = new BigNumber('0.9');
+
 const getXvsBridgeStatus = async ({
   toChainId,
   tokenBridgeContract,
@@ -37,7 +41,7 @@ const getXvsBridgeStatus = async ({
   const maxDailyLimitUsd = convertPriceMantissaToDollars({
     priceMantissa: new BigNumber(maxDailyLimitUsdMantissa.toString()),
     decimals: 18,
-  });
+  }).multipliedBy(BRIDGE_USD_LIMIT_FACTOR);
   const totalTransferredLast24HourUsd = convertPriceMantissaToDollars({
     priceMantissa: new BigNumber(totalTransferredLast24HourUsdMantissa.toString()),
     decimals: 18,
@@ -45,7 +49,7 @@ const getXvsBridgeStatus = async ({
   const maxSingleTransactionLimitUsd = convertPriceMantissaToDollars({
     priceMantissa: new BigNumber(maxSingleTransactionLimitUsdMantissa.toString()),
     decimals: 18,
-  });
+  }).multipliedBy(BRIDGE_USD_LIMIT_FACTOR);
 
   return {
     dailyLimitResetTimestamp,


### PR DESCRIPTION
## Jira ticket(s)

VEN-2368

## Changes

- Add `BRIDGE_USD_LIMIT_FACTOR` and multiply the USD bridge limits by it. This helps mitigate possible errors if the XVS price spikes up during the operation.
