### PR TITLE
feat: update display name of LegacyPoolComptroller contract

### DIFF
--- a/.changeset/polite-flies-prove.md
+++ b/.changeset/polite-flies-prove.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Display LegacyPoolComptroller as CorePoolComptroller

--- a/apps/evm/src/containers/ReadableActionSignature/getContractName.ts
+++ b/apps/evm/src/containers/ReadableActionSignature/getContractName.ts
@@ -58,7 +58,9 @@ const getContractName = ({ target, vTokens, tokens, chainId }: GetContractNameIn
 
   if (matchingUniqueContractInfo) {
     const contractName = matchingUniqueContractInfo[0];
-    return `${contractName.charAt(0).toUpperCase()}${contractName.slice(1)}`;
+    // Return "CorePoolComptroller" for the name of the legacy pool Comptroller contract in order to
+    // make it easier for users to understand what pool is concerned here
+    return contractName === 'LegacyPoolComptroller' ? 'CorePoolComptroller' : contractName;
   }
 
   return target;


### PR DESCRIPTION
## Changes

- display LegacyPoolComptroller contract as CorePoolComptroller to make it easier for users to understand what contract of what pool is concerned here
