### PR TITLE
feat: update behaviors of MAX buttons

### DIFF
--- a/.changeset/shaggy-jars-serve.md
+++ b/.changeset/shaggy-jars-serve.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Change behaviors of Supply and Repay forms MAX buttons

--- a/apps/evm/src/hooks/useOperationModal/Modal/RepayForm/__tests__/indexIntegratedSwap.spec.tsx
+++ b/apps/evm/src/hooks/useOperationModal/Modal/RepayForm/__tests__/indexIntegratedSwap.spec.tsx
@@ -442,7 +442,7 @@ describe('RepayForm - Feature flag enabled: integratedSwap', () => {
     expect(getByTestId(SWAP_SUMMARY_TEST_IDS.swapSummary).textContent).toMatchSnapshot();
   });
 
-  it('updates input value to 0 when pressing on max button if wallet balance is 0', async () => {
+  it('updates input value to 0 when pressing on MAX button if wallet balance is 0', async () => {
     const customFakeTokenBalances: TokenBalance[] = fakeTokenBalances.map(tokenBalance => ({
       ...tokenBalance,
       balanceMantissa:
@@ -478,7 +478,7 @@ describe('RepayForm - Feature flag enabled: integratedSwap', () => {
     ) as HTMLInputElement;
     expect(selectTokenTextField.value).toBe('');
 
-    // Click on max button
+    // Click on MAX button
     fireEvent.click(getByText(en.operationModal.repay.rightMaxButtonLabel));
 
     // Check input value was updated correctly
@@ -490,7 +490,7 @@ describe('RepayForm - Feature flag enabled: integratedSwap', () => {
     ).toBeDisabled();
   });
 
-  it('updates input value to wallet balance when clicking on max button', async () => {
+  it('updates input value to wallet balance when clicking on MAX button', async () => {
     const { container, getByText, getByTestId } = renderComponent(
       <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
@@ -514,7 +514,7 @@ describe('RepayForm - Feature flag enabled: integratedSwap', () => {
     ) as HTMLInputElement;
     expect(selectTokenTextField.value).toBe('');
 
-    // Click on max button
+    // Click on MAX button
     fireEvent.click(getByText(en.operationModal.repay.rightMaxButtonLabel));
 
     // Check input value was updated correctly

--- a/apps/evm/src/hooks/useOperationModal/Modal/SupplyForm/__tests__/indexIntegratedSwap.spec.tsx
+++ b/apps/evm/src/hooks/useOperationModal/Modal/SupplyForm/__tests__/indexIntegratedSwap.spec.tsx
@@ -22,7 +22,7 @@ import { IsTokenActionEnabledInput, isTokenActionEnabled } from 'libs/tokens';
 import { en } from 'libs/translations';
 import { Asset, Swap, TokenBalance } from 'types';
 
-import Repay from '..';
+import Supply from '..';
 import SWAP_SUMMARY_TEST_IDS from '../../SwapSummary/testIds';
 import { fakeAsset, fakePool } from '../__testUtils__/fakeData';
 import TEST_IDS from '../testIds';
@@ -76,7 +76,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
   });
 
   it('renders without crashing', () => {
-    renderComponent(<Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />);
+    renderComponent(<Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />);
   });
 
   it('disables swap feature when swapAndSupply action of underlying token is disabled', async () => {
@@ -86,7 +86,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     );
 
     const { queryByTestId } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -102,7 +102,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     );
 
     const { queryByTestId } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -113,7 +113,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
 
   it('displays correct wallet balance', async () => {
     const { getByText, container } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -130,7 +130,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
 
   it('disables submit button if no amount was entered in input', async () => {
     const { getByText } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -158,7 +158,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     };
 
     const { getByText, container, getByTestId } = renderComponent(
-      <Repay asset={customFakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={customFakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -193,7 +193,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     }));
 
     const { getByTestId, getByText } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -220,7 +220,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
 
   it('disables submit button if amount entered in input is higher than wallet balance', async () => {
     const { container, getByTestId, getByText } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -265,7 +265,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     }));
 
     const { container, getByTestId, getByText } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -301,7 +301,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     }));
 
     const { container, getByTestId } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -327,7 +327,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     expect(getByTestId(SWAP_SUMMARY_TEST_IDS.swapSummary).textContent).toMatchSnapshot();
   });
 
-  it('updates input value to 0 when pressing on max button if wallet balance is 0', async () => {
+  it('updates input value to 0 when pressing on MAX button if wallet balance is 0', async () => {
     const customFakeTokenBalances: TokenBalance[] = fakeTokenBalances.map(tokenBalance => ({
       ...tokenBalance,
       balanceMantissa:
@@ -341,7 +341,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     }));
 
     const { container, getByText, getByTestId } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -363,7 +363,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     ) as HTMLInputElement;
     expect(selectTokenTextField.value).toBe('');
 
-    // Click on max button
+    // Click on MAX button
     fireEvent.click(getByText(en.operationModal.supply.rightMaxButtonLabel));
 
     // Check input value was updated correctly
@@ -375,9 +375,9 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     ).toBeDisabled();
   });
 
-  it('updates input value to wallet balance when clicking on max button', async () => {
+  it('updates input value to wallet balance when clicking on MAX button', async () => {
     const { container, getByText, getByTestId } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={noop} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -399,7 +399,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     ) as HTMLInputElement;
     expect(selectTokenTextField.value).toBe('');
 
-    // Click on max button
+    // Click on MAX button
     fireEvent.click(getByText(en.operationModal.supply.rightMaxButtonLabel));
 
     // Check input value was updated correctly
@@ -425,7 +425,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     const onCloseMock = vi.fn();
 
     const { container, getByTestId, getByText } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={onCloseMock} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={onCloseMock} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -473,7 +473,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     const onCloseMock = vi.fn();
 
     const { container, getByTestId, getByText } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={onCloseMock} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={onCloseMock} />,
       {
         accountAddress: fakeAccountAddress,
       },
@@ -513,7 +513,7 @@ describe('hooks/useSupplyWithdrawModal/Supply - Feature flag enabled: integrated
     const onCloseMock = vi.fn();
 
     const { container, getByText, getByTestId } = renderComponent(
-      <Repay asset={fakeAsset} pool={fakePool} onCloseModal={onCloseMock} />,
+      <Supply asset={fakeAsset} pool={fakePool} onCloseModal={onCloseMock} />,
       {
         accountAddress: fakeAccountAddress,
       },

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -542,8 +542,8 @@
     "repay": {
       "amountAboveWalletSpendingLimit": "You entered an amount that exceeds your spending limit for this asset. Please revoke your spending limit then set a new one in order to proceed with this transaction.",
       "connectWalletMessage": "Please connect your wallet to repay",
-      "currentlyBorrowing": "Currently borrowing",
       "fullRepaymentWarning": "The transaction value might be slightly higher than the current borrow amount to cover any newly-accumulated interests",
+      "repaybaleAmount": "Repayable amount",
       "rightMaxButtonLabel": "MAX",
       "submitButtonLabel": {
         "amountHigherThanRepayBalance": "Amount entered higher than repay balance",
@@ -559,8 +559,7 @@
         "unwrappingUnsupported": "Unwrapping unsupported",
         "wrappingUnsupported": "Wrapping unsupported"
       },
-      "swappingWithHighPriceImpactWarning": "The price impact of this transaction is high, which might indicate an unfavorable swap. Make sure the exchange rate and the amount of tokens exchanged meet your expectations.",
-      "walletBalance": "Wallet balance"
+      "swappingWithHighPriceImpactWarning": "The price impact of this transaction is high, which might indicate an unfavorable swap. Make sure the exchange rate and the amount of tokens exchanged meet your expectations."
     },
     "repayTabTitle": "Repay",
     "supply": {
@@ -582,9 +581,9 @@
         "swapAndSupply": "Swap and supply",
         "swapAndSupplyWithHighPriceImpact": "Swap and supply with high price impact",
         "unwrappingUnsupported": "Unwrapping unsupported",
-        "wrapAndSupply": "Wrap and supply",
         "wrappingUnsupported": "Wrapping unsupported"
       },
+      "supplyableAmount": "Supplyable amount",
       "supplyCapReachedWarning": "The supply cap of {{assetSupplyCap}} has been reached for this pool. You can not supply to this market anymore until withdraws are made or its supply cap is increased.",
       "swappingWithHighPriceImpactWarning": "The price impact of this transaction is high, which might indicate an unfavorable swap. Make sure the exchange rate and the amount of tokens exchanged meet your expectations.",
       "walletBalance": "Wallet balance",
@@ -1002,7 +1001,6 @@
         "label": "Borrow APR",
         "tooltip": "The annualized interest rate to be paid in the future, on top of the minted VAI"
       },
-      "borrowBalance": "Currently borrowing",
       "notice": {
         "amountHigherThanBorrowBalance": "Amount entered higher than repay balance",
         "amountHigherThanWalletBalance": "Insufficient {{tokenSymbol}} balance",


### PR DESCRIPTION
## Changes

- update behavior of MAX button in Supply form so it takes the spending limit and the supply cap in consideration (when not using the swap)
- display supplyable amount on Supply form instead of wallet balance
- update behavior of MAX button in Repay form so it takes spending limit and repay balance in consideration (when not using the swap)
- display repayable amount on Repay form instead of wallet balance
