### PR TITLE
chore: ignore package.json when formatting

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,7 @@
 {
   "$schema": "node_modules/@biomejs/biome/configuration_schema.json",
   "formatter": {
+    "ignore": ["package.json"],
     "indentStyle": "space",
     "lineWidth": 100
   },


### PR DESCRIPTION
## Changes

- Ignore package.json when formatting with Biome, it is currently conflicting with the github-actions bot which bumps and overwrites the formatting
