### PR TITLE
refactor: updated opBNB explorer URLs

### DIFF
--- a/.changeset/hungry-toys-kiss.md
+++ b/.changeset/hungry-toys-kiss.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+updated opBNB explorer URLs

--- a/apps/evm/src/constants/chainMetadata.ts
+++ b/apps/evm/src/constants/chainMetadata.ts
@@ -30,7 +30,7 @@ export const CHAIN_METADATA: {
   [ChainId.OPBNB_MAINNET]: {
     name: 'opBNB',
     logoSrc: opbnbLogo,
-    explorerUrl: 'https://opbnb.bscscan.com/',
+    explorerUrl: 'https://opbnbscan.com',
     layerZeroScanUrl: 'https://layerzeroscan.com/',
     blockTimeMs: 1000,
     blocksPerDay: 86400,
@@ -40,7 +40,7 @@ export const CHAIN_METADATA: {
   [ChainId.OPBNB_TESTNET]: {
     name: 'opBNB testnet',
     logoSrc: opbnbLogo,
-    explorerUrl: 'https://opbnb-testnet.bscscan.com/',
+    explorerUrl: 'https://testnet.opbnbscan.com',
     layerZeroScanUrl: 'https://testnet.layerzeroscan.com/',
     blockTimeMs: 1000,
     blocksPerDay: 86400,


### PR DESCRIPTION
## Changes

- Changed opBNB mainnet explorer URL to https://opbnbscan.com
- Changed opBNB testnet explorer URL to https://testnet.opbnbscan.com
