### PR TITLE
fix: swap page now redirects when switching to a chain that has swap disabled

### DIFF
--- a/.changeset/gentle-gorillas-boil.md
+++ b/.changeset/gentle-gorillas-boil.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+swap page now redirects when switching to a chain that has swap disabled

--- a/apps/evm/src/App/Routes/index.tsx
+++ b/apps/evm/src/App/Routes/index.tsx
@@ -31,6 +31,7 @@ const Bridge = lazy(() => import('pages/Bridge'));
 
 const AppRoutes = () => {
   const { accountAddress } = useAccountAddress();
+  const swapRouteEnabled = useIsFeatureEnabled({ name: 'swapRoute' });
   const historyRouteEnabled = useIsFeatureEnabled({ name: 'historyRoute' });
   const convertVrtRouteEnabled = useIsFeatureEnabled({ name: 'convertVrtRoute' });
   const vaiRouteEnabled = useIsFeatureEnabled({ name: 'vaiRoute' });
@@ -239,14 +240,16 @@ const AppRoutes = () => {
           />
         )}
 
-        <Route
-          path={Subdirectory.SWAP}
-          element={
-            <PageSuspense>
-              <Swap />
-            </PageSuspense>
-          }
-        />
+        {swapRouteEnabled && (
+          <Route
+            path={Subdirectory.SWAP}
+            element={
+              <PageSuspense>
+                <Swap />
+              </PageSuspense>
+            }
+          />
+        )}
 
         {vaiRouteEnabled && (
           <Route


### PR DESCRIPTION
## Changes

- This PR fixes the swap page not redirecting if switching to a chain that has the swap feature disabled.
