### PR TITLE
fix: hide commonTokenBalances section if token list has 2 or less tokens

### DIFF
--- a/.changeset/swift-houses-smash.md
+++ b/.changeset/swift-houses-smash.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+hide commonTokenBalances section if token list has 2 or less tokens

--- a/apps/evm/src/components/SelectTokenTextField/TokenList/index.tsx
+++ b/apps/evm/src/components/SelectTokenTextField/TokenList/index.tsx
@@ -85,28 +85,29 @@ export const TokenList: React.FC<TokenListProps> = ({
     <div css={styles.container}>
       <div className={cn(commonTokenBalances.length > 2 && 'mb-5 pl-3 pr-3 pt-3')}>
         {commonTokenBalances.length > 2 && (
-          <TextField
-            css={styles.searchField}
-            isSmall
-            autoFocus
-            value={searchValue}
-            onChange={handleSearchInputChange}
-            placeholder={t('selectTokenTextField.searchInput.placeholder')}
-            leftIconSrc="magnifier"
-          />
+          <>
+            <TextField
+              css={styles.searchField}
+              isSmall
+              autoFocus
+              value={searchValue}
+              onChange={handleSearchInputChange}
+              placeholder={t('selectTokenTextField.searchInput.placeholder')}
+              leftIconSrc="magnifier"
+            />
+            <div css={styles.commonTokenList}>
+              {commonTokenBalances.map(commonTokenBalance => (
+                <SenaryButton
+                  onClick={() => onTokenClick(commonTokenBalance.token)}
+                  css={styles.commonTokenButton}
+                  key={`select-token-text-field-common-token-${commonTokenBalance.token.symbol}`}
+                >
+                  <TokenIconWithSymbol css={parentStyles.token} token={commonTokenBalance.token} />
+                </SenaryButton>
+              ))}
+            </div>
+          </>
         )}
-
-        <div css={styles.commonTokenList}>
-          {commonTokenBalances.map(commonTokenBalance => (
-            <SenaryButton
-              onClick={() => onTokenClick(commonTokenBalance.token)}
-              css={styles.commonTokenButton}
-              key={`select-token-text-field-common-token-${commonTokenBalance.token.symbol}`}
-            >
-              <TokenIconWithSymbol css={parentStyles.token} token={commonTokenBalance.token} />
-            </SenaryButton>
-          ))}
-        </div>
       </div>
 
       <div css={styles.list}>


### PR DESCRIPTION
## Changes

- Hide commonTokenBalances section if token list has 2 or less tokens. The issue was visible in the opBNB testnet chain, where we could see BNB as the only option for the common tokens list, since the component is shared by the integrated swap and the wrap/unwrap native token feature
