### PR TITLE
refactor: allow empty strings on Create proposal form

### DIFF
--- a/.changeset/witty-houses-sniff.md
+++ b/.changeset/witty-houses-sniff.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+Update Create proposal form to accept empty strings

--- a/apps/evm/src/components/Form/FormikTextField.tsx
+++ b/apps/evm/src/components/Form/FormikTextField.tsx
@@ -1,5 +1,6 @@
 import { useField } from 'formik';
 
+import { useEffect } from 'react';
 import { TextField, type TextFieldProps } from '../TextField';
 
 interface FormikTextFieldProps extends Omit<TextFieldProps, 'name' | 'onChange' | 'value'> {
@@ -11,9 +12,17 @@ export const FormikTextField = ({
   name,
   displayableErrorCodes = [],
   onBlur,
+  defaultValue,
   ...rest
 }: FormikTextFieldProps) => {
   const [{ value, onBlur: formikOnBlur }, { error, touched }, { setValue }] = useField(name);
+
+  // Set default value on mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies:
+  useEffect(() => {
+    setValue(value ?? defaultValue ?? '');
+  }, [setValue]);
+
   const onChange: React.ChangeEventHandler<HTMLInputElement> = e => {
     const val = e.target.value;
     setValue(val);
@@ -32,6 +41,7 @@ export const FormikTextField = ({
       value={value !== undefined || value !== null ? value : ''}
       onChange={onChange}
       onBlur={handleBlur}
+      defaultValue={defaultValue}
       hasError={!!(error && displayableErrorCodes.includes(error) && touched)}
       {...rest}
     />

--- a/apps/evm/src/pages/Governance/ProposalList/CreateProposalModal/index.spec.tsx
+++ b/apps/evm/src/pages/Governance/ProposalList/CreateProposalModal/index.spec.tsx
@@ -14,7 +14,7 @@ import TEST_IDS from './testIds';
 
 const fakeName = 'Proposal';
 const fakeDescription = 'Interesting idea';
-const fakeSignature = '_setAbc(string, bool)';
+const fakeSignature = '_setAbc(string,address)';
 const fakeForOption = 'fakeForOption';
 const fakeAgainstOption = 'fakeAgainstOption';
 const fakeAbstainOption = 'fakeAbstainOption';
@@ -188,7 +188,7 @@ describe('pages/Proposal/CreateProposalModal', () => {
     const dataInput1 = await waitFor(() => getByTestId('actions.0.callData.1'));
 
     fireEvent.change(dataInput0, { target: { value: 'root' } });
-    fireEvent.change(dataInput1, { target: { value: 'false' } });
+    fireEvent.change(dataInput1, { target: { value: fakeAddress } });
 
     await waitFor(() => expect(addActionButton).toBeEnabled());
     await waitFor(() => fireEvent.click(addActionButton));
@@ -243,18 +243,12 @@ describe('pages/Proposal/CreateProposalModal', () => {
     const dataInput1 = await waitFor(() => getByTestId('actions.0.callData.1'));
 
     fireEvent.change(dataInput0, { target: { value: 'root' } });
-    fireEvent.change(dataInput1, { target: { value: 'false' } });
+    fireEvent.change(dataInput1, { target: { value: 'invalid-address' } });
 
-    await waitFor(() => fireEvent.click(addActionButton));
-
-    fireEvent.change(signatureInput0, { target: { value: 'bad Address' } });
     await waitFor(() => expect(addActionButton).toBeDisabled());
 
-    fireEvent.change(signatureInput0, { target: { value: fakeSignature } });
+    fireEvent.change(dataInput1, { target: { value: fakeAddress } });
     await waitFor(() => expect(addActionButton).toBeEnabled());
-
-    fireEvent.change(signatureInput0, { target: { value: '' } });
-    await waitFor(() => expect(addActionButton).toBeDisabled());
   });
 
   it('Sets signature as accordion title', async () => {
@@ -306,7 +300,7 @@ describe('pages/Proposal/CreateProposalModal', () => {
     const dataInput1 = await waitFor(() => getByTestId('actions.0.callData.1'));
 
     fireEvent.change(dataInput0, { target: { value: 'root' } });
-    fireEvent.change(dataInput1, { target: { value: 'false' } });
+    fireEvent.change(dataInput1, { target: { value: fakeAddress } });
 
     await waitFor(() => expect(addActionButton).toBeEnabled()); // failing
 
@@ -363,9 +357,9 @@ describe('pages/Proposal/CreateProposalModal', () => {
     fireEvent.change(addressInputs[0], { target: { value: fakeAddress } });
     fireEvent.change(signatureInputs[0], { target: { value: fakeSignature } });
 
-    // fake Signature should add an input with a bool placeholder and on with a string placeholder
+    // fake Signature should add an input with an address and a string placeholder
     getByPlaceholderText('string');
-    getByPlaceholderText('bool');
+    getByPlaceholderText('address');
   });
 
   it('Imports a valid proposal file and allows the VIP creation', async () => {

--- a/apps/evm/src/pages/Governance/ProposalList/CreateProposalModal/index.tsx
+++ b/apps/evm/src/pages/Governance/ProposalList/CreateProposalModal/index.tsx
@@ -132,6 +132,7 @@ export const CreateProposal: React.FC<CreateProposalProps> = ({
         onSubmit={handleCreateProposal}
         validateOnBlur
         validateOnMount
+        validateOnChange
       >
         <Form>
           <ProposalWizard

--- a/apps/evm/src/pages/Governance/ProposalList/CreateProposalModal/proposalSchema.ts
+++ b/apps/evm/src/pages/Governance/ProposalList/CreateProposalModal/proposalSchema.ts
@@ -43,26 +43,29 @@ const proposalSchema = yup.object({
         callData: yup
           .array()
           .of(
-            yup.string().test({
-              name: 'validArguments',
-              message: ErrorCode.CALL_DATA_ARGUMENT_INVALID,
-              test(value) {
-                let valid = true;
-                try {
-                  const dataTypes =
-                    // @ts-expect-error The yup type doesn't show this value exists but it does
-                    parseFunctionSignature(this.options.from[0].value.signature)?.inputs || [];
-                  encodeParameters(
-                    // @ts-expect-error The yup type doesn't show this value exists but it does
-                    [dataTypes[this.options.index]],
-                    [formatIfArray(value || '')],
-                  );
-                } catch {
-                  valid = false;
-                }
-                return valid;
-              },
-            }),
+            yup
+              .string()
+              .default('')
+              .test({
+                name: 'validArguments',
+                message: ErrorCode.CALL_DATA_ARGUMENT_INVALID,
+                test(value) {
+                  let valid = true;
+                  try {
+                    const dataTypes =
+                      // @ts-expect-error The yup type doesn't show this value exists but it does
+                      parseFunctionSignature(this.options.from[0].value.signature)?.inputs || [];
+                    encodeParameters(
+                      // @ts-expect-error The yup type doesn't show this value exists but it does
+                      [dataTypes[this.options.index]],
+                      [formatIfArray(value || '')],
+                    );
+                  } catch {
+                    valid = false;
+                  }
+                  return valid;
+                },
+              }),
           )
           .test({
             name: 'min',
@@ -70,7 +73,7 @@ const proposalSchema = yup.object({
             test(value) {
               const fragment = parseFunctionSignature(this.parent.signature);
               const min = fragment?.inputs.length ?? 0;
-              const filteredValue = value?.filter(v => !!v);
+              const filteredValue = value?.filter(v => v !== undefined && v !== null);
               return !!(filteredValue && filteredValue.length >= min);
             },
           })


### PR DESCRIPTION
## Changes

- update `FormikTextField` to set default value on mount
- update validation schema of Create proposal form to allow empty strings in call data
