### PR TITLE
fix: hide the "all Prime tokens claimed" warning if the Prime token limit is 0

### DIFF
--- a/.changeset/silent-llamas-fetch.md
+++ b/.changeset/silent-llamas-fetch.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+hide the "all Prime tokens claimed" warning if the Prime token limit is 0

--- a/apps/evm/src/containers/PrimeStatusBanner/__tests__/index.spec.tsx
+++ b/apps/evm/src/containers/PrimeStatusBanner/__tests__/index.spec.tsx
@@ -6,6 +6,7 @@ import { renderComponent } from 'testUtils/render';
 
 import { useGetPrimeStatus, useGetPrimeToken, useGetXvsVaultUserInfo } from 'clients/api';
 
+import { en } from 'libs/translations';
 import PrimeStatusBanner from '..';
 import TEST_IDS from '../testIds';
 
@@ -128,5 +129,32 @@ describe('PrimeStatusBanner', () => {
 
     expect(queryByTestId(TEST_IDS.claimPrimeTokenButton)).toBeVisible();
     expect(queryByTestId(TEST_IDS.claimPrimeTokenButton)).toBeEnabled();
+  });
+
+  it('shows the all Prime tokens claimed warning if all Prime tokens have been claimed', async () => {
+    (useGetPrimeStatus as Vi.Mock).mockImplementation(() => ({
+      data: {
+        ...MOCK_DEFAULT_PRIME_STATUS,
+        claimedPrimeTokenCount: 1000,
+      },
+    }));
+
+    const { queryByText } = renderComponent(<PrimeStatusBanner />);
+    await waitFor(() => queryByText(en.primeStatusBanner.noPrimeTokenWarning.text));
+    expect(queryByText(en.primeStatusBanner.noPrimeTokenWarning.text)).toBeVisible();
+  });
+
+  it('does not show the all Prime tokens claimed warning if there are no tokens to be claimed', async () => {
+    (useGetPrimeStatus as Vi.Mock).mockImplementation(() => ({
+      data: {
+        ...MOCK_DEFAULT_PRIME_STATUS,
+        primeTokenLimit: 0,
+      },
+    }));
+
+    const { queryByText } = renderComponent(<PrimeStatusBanner />);
+    await waitFor(() =>
+      expect(queryByText(en.primeStatusBanner.noPrimeTokenWarning.text)).toBeNull(),
+    );
   });
 });

--- a/apps/evm/src/containers/PrimeStatusBanner/index.tsx
+++ b/apps/evm/src/containers/PrimeStatusBanner/index.tsx
@@ -155,7 +155,7 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
   });
 
   const displayProgress = !isUserXvsStakeHighEnoughForPrime;
-  const displayWarning = haveAllPrimeTokensBeenClaimed;
+  const displayWarning = haveAllPrimeTokensBeenClaimed && primeTokenLimit > 0;
   const displayStakeButton =
     !haveAllPrimeTokensBeenClaimed && !hidePromotionalTitle && !isUserXvsStakeHighEnoughForPrime;
   const displayClaimButton =
@@ -194,11 +194,10 @@ export const PrimeStatusBannerUi: React.FC<PrimeStatusBannerUiProps> = ({
             <PrimeTokensLeft tokensLeft={primeTokensLeft} />
           </div>
         )}
-        {displayWarning && (
+        {displayWarning && hidePromotionalTitle && (
           <div
             className={cn(
-              'mb-4 flex items-center text-right sm:hidden',
-              hidePromotionalTitle && 'sm:flex',
+              'mb-4 flex items-center text-right sm:flex',
               displayProgress && 'md:mb-4',
             )}
           >


### PR DESCRIPTION
## Changes

- Hide the "all Prime tokens claimed" warning if the Prime token limit is 0
