### PR TITLE
fix: always fetch proposal previews using Governance chain provider

### DIFF
--- a/.changeset/rare-news-think.md
+++ b/.changeset/rare-news-think.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+always fetch governance previews using governance chain provider

--- a/apps/evm/src/clients/api/queries/getBlockNumber/useGetBlockNumber.ts
+++ b/apps/evm/src/clients/api/queries/getBlockNumber/useGetBlockNumber.ts
@@ -1,6 +1,6 @@
 import { type QueryObserverOptions, useQuery } from 'react-query';
 
-import { getBlockNumber } from 'clients/api/';
+import getBlockNumber, { type GetBlockNumberOutput } from 'clients/api/queries/getBlockNumber';
 import FunctionKey from 'constants/functionKey';
 import { useGetChainMetadata } from 'hooks/useGetChainMetadata';
 import { useChainId, useProvider } from 'libs/wallet';
@@ -8,8 +8,8 @@ import type { ChainId } from 'types';
 
 export type UseGetBlockNumberQueryKey = [FunctionKey.GET_BLOCK_NUMBER, { chainId: ChainId }];
 
-interface GetBlockNumberOutput {
-  blockNumber: number;
+interface Input {
+  chainId?: ChainId;
 }
 
 type Options = QueryObserverOptions<
@@ -20,9 +20,10 @@ type Options = QueryObserverOptions<
   UseGetBlockNumberQueryKey
 >;
 
-const useGetBlockNumber = (options?: Options) => {
-  const { provider } = useProvider();
-  const { chainId } = useChainId();
+const useGetBlockNumber = (input?: Input, options?: Options) => {
+  const { chainId: currentChainId } = useChainId();
+  const chainId = input?.chainId ?? currentChainId;
+  const { provider } = useProvider({ chainId });
   const { blockTimeMs } = useGetChainMetadata();
 
   return useQuery([FunctionKey.GET_BLOCK_NUMBER, { chainId }], () => getBlockNumber({ provider }), {

--- a/apps/evm/src/clients/api/queries/getProposalPreviews/useGetProposalPreviews.ts
+++ b/apps/evm/src/clients/api/queries/getProposalPreviews/useGetProposalPreviews.ts
@@ -30,7 +30,9 @@ export const useGetProposalPreviews = (
   params: TrimmedGetProposalPreviewsInput = {},
   options?: Options,
 ) => {
-  const { data } = useGetBlockNumber();
+  const { data } = useGetBlockNumber({
+    chainId: governanceChain.id,
+  });
   const { blockTimeMs } = CHAIN_METADATA[governanceChain.id];
   const page = params.page || 0;
   const limit = params.limit || 10;


### PR DESCRIPTION
## Changes

- add optional `chainId` parameter to input of `useGetBlockNumber` hook
- always fetch governance previews using governance chain provider
