### PR TITLE
feat: force Vite to use relative imports in generated build

### DIFF
--- a/apps/evm/vite.config.ts
+++ b/apps/evm/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
 
   return {
+    base: './', // Force Vite to use relative imports in generated build
     plugins: [react(), viteTsconfigPaths(), svgrPlugin()],
     optimizeDeps: {
       esbuildOptions: {


### PR DESCRIPTION
## Changes

- force Vite to use relative imports in generated build 

This is a test branch for John from devOps.