### PR TITLE
fix: XVS and VAI price fetching on Account page

### DIFF
--- a/.changeset/yellow-hairs-perform.md
+++ b/.changeset/yellow-hairs-perform.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fetch VAI and XVS price from contracts on Account page

--- a/apps/evm/src/clients/api/queries/getTokenUsdPrice/useGetTokenUsdPrice.ts
+++ b/apps/evm/src/clients/api/queries/getTokenUsdPrice/useGetTokenUsdPrice.ts
@@ -49,7 +49,10 @@ const useGetTokenUsdPrice = ({ token }: UseGetTokenUsdPriceInput, options?: Opti
     ],
     () =>
       callOrThrow({ token, resilientOracleContract }, params => getTokenUsdPrice({ ...params })),
-    options,
+    {
+      ...options,
+      enabled: (options?.enabled === undefined || options?.enabled) && !!token,
+    },
   );
 };
 

--- a/apps/evm/src/hooks/useConvertDollarsToCents/index.ts
+++ b/apps/evm/src/hooks/useConvertDollarsToCents/index.ts
@@ -1,0 +1,11 @@
+import { useMemo } from 'react';
+
+import type BigNumber from 'bignumber.js';
+import { convertDollarsToCents } from 'utilities';
+
+export interface UseConvertDollarsToCentsInput {
+  value: BigNumber;
+}
+
+export const useConvertDollarsToCents = (params: UseConvertDollarsToCentsInput) =>
+  useMemo(() => convertDollarsToCents(params.value), [params]);

--- a/apps/evm/src/pages/Account/AccountBreakdown/index.spec.tsx
+++ b/apps/evm/src/pages/Account/AccountBreakdown/index.spec.tsx
@@ -1,9 +1,83 @@
-import { renderComponent } from 'testUtils/render';
+import { waitFor } from '@testing-library/dom';
+import BigNumber from 'bignumber.js';
+import type Vi from 'vitest';
 
+import fakeAccountAddress from '__mocks__/models/address';
+import { poolData } from '__mocks__/models/pools';
+import { vaults } from '__mocks__/models/vaults';
+import { useGetPools, useGetVaults } from 'clients/api';
+import SPINNER_TEST_IDS from 'components/Spinner/testIds';
+import { en } from 'libs/translations';
+import { renderComponent } from 'testUtils/render';
 import Account from '.';
 
-describe('pages/Account', () => {
+describe('Account', () => {
   it('renders without crashing', () => {
     renderComponent(<Account />);
+  });
+
+  it('displays spinner while loading data', async () => {
+    (useGetVaults as Vi.Mock).mockImplementation(() => ({
+      isLoading: true,
+      data: undefined,
+    }));
+
+    const { getByTestId } = renderComponent(<Account />, {
+      accountAddress: fakeAccountAddress,
+    });
+
+    await waitFor(() => expect(getByTestId(SPINNER_TEST_IDS.spinner)).toBeInTheDocument());
+  });
+
+  it('displays AccountPlaceholder when there are no positions', async () => {
+    (useGetVaults as Vi.Mock).mockImplementation(() => ({
+      isLoading: false,
+      data: vaults.map(({ userStakedMantissa: _, ...vault }) => vault),
+    }));
+
+    (useGetPools as Vi.Mock).mockImplementation(() => ({
+      isLoading: false,
+      data: {
+        pools: poolData.map(pool => ({
+          ...pool,
+          userBorrowLimitCents: new BigNumber(0),
+          userBorrowBalanceCents: new BigNumber(0),
+          userSupplyBalanceCents: new BigNumber(0),
+          assets: pool.assets.map(asset => ({
+            ...asset,
+            userBorrowBalanceCents: new BigNumber(0),
+            userBorrowBalanceTokens: new BigNumber(0),
+            userSupplyBalanceCents: new BigNumber(0),
+            userSupplyBalanceTokens: new BigNumber(0),
+            userWalletBalanceCents: new BigNumber(0),
+            userWalletBalanceTokens: new BigNumber(0),
+            isCollateralOfUser: false,
+          })),
+        })),
+      },
+    }));
+
+    const { getByText } = renderComponent(<Account />, {
+      accountAddress: fakeAccountAddress,
+    });
+
+    await waitFor(() =>
+      expect(getByText(en.accountPlaceholder.assetsWillAppearHere)).toBeInTheDocument(),
+    );
+  });
+
+  it('displays page when there are positions', async () => {
+    const { getByText } = renderComponent(<Account />, {
+      accountAddress: fakeAccountAddress,
+    });
+
+    // Check account summary is displayed
+    await waitFor(() =>
+      expect(getByText(en.account.summary.cellGroup.totalVaultStake)).toBeInTheDocument(),
+    );
+    // Check pool position breakdown is displayed
+    expect(getByText(en.account.poolsBreakdown.title)).toBeInTheDocument();
+    // Check vault position breakdown is displayed
+    expect(getByText(en.account.vaultsBreakdown.title)).toBeInTheDocument();
   });
 });

--- a/apps/evm/src/pages/Account/AccountBreakdown/index.tsx
+++ b/apps/evm/src/pages/Account/AccountBreakdown/index.tsx
@@ -6,7 +6,6 @@ import { useGetPools, useGetVaults } from 'clients/api';
 import { Spinner } from 'components';
 import { useGetToken } from 'libs/tokens';
 import { useAccountAddress } from 'libs/wallet';
-import type { Pool, Vault } from 'types';
 import { areTokensEqual } from 'utilities';
 
 import { useStyles } from '../styles';
@@ -15,16 +14,24 @@ import PoolsBreakdown from './PoolsBreakdown';
 import Summary from './Summary';
 import VaultsBreakdown from './VaultsBreakdown';
 
-export interface AccountUiProps {
-  pools: Pool[];
-  vaults: Vault[];
-  isFetching?: boolean;
-}
-
-// We assume 1 VAI = 1 dollar
+// We assume the price of VAI to be $1
 const VAI_PRICE_CENTS = new BigNumber(100);
 
-export const AccountUi: React.FC<AccountUiProps> = ({ isFetching, vaults, pools }) => {
+const Account: React.FC = () => {
+  const { accountAddress } = useAccountAddress();
+  const { data: getPoolsData, isLoading: isGetPoolsLoading } = useGetPools({
+    accountAddress,
+  });
+
+  const { data: getVaultsData, isLoading: isGetVaultsLoading } = useGetVaults({
+    accountAddress,
+  });
+
+  const isFetching = isGetPoolsLoading || isGetVaultsLoading;
+
+  const pools = getPoolsData?.pools || [];
+  const vaults = getVaultsData || [];
+
   const styles = useStyles();
   const xvs = useGetToken({
     symbol: 'XVS',
@@ -95,27 +102,6 @@ export const AccountUi: React.FC<AccountUiProps> = ({ isFetching, vaults, pools 
 
       {filteredPools.length > 0 && <PoolsBreakdown css={styles.section} pools={filteredPools} />}
     </>
-  );
-};
-
-const Account: React.FC = () => {
-  const { accountAddress } = useAccountAddress();
-  const { data: getPoolsData, isLoading: isGetPoolsLoading } = useGetPools({
-    accountAddress,
-  });
-
-  const { data: getVaultsData, isLoading: isGetVaultsLoading } = useGetVaults({
-    accountAddress,
-  });
-
-  const isFetching = isGetPoolsLoading || isGetVaultsLoading;
-
-  return (
-    <AccountUi
-      isFetching={isFetching}
-      pools={getPoolsData?.pools || []}
-      vaults={getVaultsData || []}
-    />
   );
 };
 


### PR DESCRIPTION
## Changes

- fetch XVS and VAI prices from contracts on Account page
- create `useConvertDollarsToCents` hook
- disable `useGetTokenUsdPrice` when passed token is `undefined`
- remove split between UI and data fetching components in Account page
- add tests to Account page
