### PR TITLE
fix: bridge daily transaction limit logic

### DIFF
--- a/.changeset/strange-toys-divide.md
+++ b/.changeset/strange-toys-divide.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix bridge max daily limit when the last transaction happened 24 hours in the past


### PR DESCRIPTION
## Jira ticket(s)

VEN-2517

## Changes

- If the last successful transaction happened 24 hours ago or more, the next possible transaction will belong to a new window, meaning the amount that can be bridged is the maxDailyLimitUsd
- If the last successful transaction happened in the current 24 hour window, use the current logic of calculating the remainingUsdValue when validating how much a user can bridge
