### PR TITLE
fix: alignment of the borrow percentage of limit bars

### DIFF
--- a/.changeset/real-buckets-cry.md
+++ b/.changeset/real-buckets-cry.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix the alignment of the borrow percentage of limit bars

--- a/apps/evm/src/containers/MarketTable/useGenerateColumns.tsx
+++ b/apps/evm/src/containers/MarketTable/useGenerateColumns.tsx
@@ -303,6 +303,10 @@ const useGenerateColumns = ({
             if (column === 'userPercentOfLimit') {
               return (
                 <div css={styles.userPercentOfLimit}>
+                  <span className={cn(isPaused ? 'text-grey' : 'text-offWhite')}>
+                    {formatPercentageToReadableValue(poolAsset.userPercentOfLimit)}
+                  </span>
+
                   <ProgressBar
                     min={0}
                     max={100}
@@ -311,10 +315,6 @@ const useGenerateColumns = ({
                     ariaLabel={t('marketTable.columnKeys.userPercentOfLimit')}
                     css={styles.percentOfLimitProgressBar}
                   />
-
-                  <span className={cn(isPaused ? 'text-grey' : 'text-offWhite')}>
-                    {formatPercentageToReadableValue(poolAsset.userPercentOfLimit)}
-                  </span>
                 </div>
               );
             }


### PR DESCRIPTION
## Changes

- Percentages are now to the left of the bars, so that they keep being aligned
