### PR TITLE
fix: user vote fetching on proposals

### DIFF
--- a/.changeset/metal-kids-deliver.md
+++ b/.changeset/metal-kids-deliver.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+Fix user vote fetching on proposals

--- a/apps/evm/src/clients/api/queries/getProposalPreviews/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getProposalPreviews/__tests__/__snapshots__/index.spec.ts.snap
@@ -275,7 +275,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -289,7 +289,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -303,7 +303,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -317,7 +317,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -346,7 +346,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -365,7 +365,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -382,7 +382,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -399,7 +399,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {
@@ -413,7 +413,7 @@ exports[`getProposalPreviews > sets "where" parameter correctly based on passed 
 {
   "chainId": 97,
   "variables": {
-    "accountAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
+    "accountAddress": "0x3d759121234cd36f8124c21afe1c6852d2bed848",
     "limit": 10,
     "skip": 0,
     "where": {

--- a/apps/evm/src/clients/api/queries/getProposalPreviews/index.ts
+++ b/apps/evm/src/clients/api/queries/getProposalPreviews/index.ts
@@ -108,7 +108,7 @@ export const getProposalPreviews = async ({
     const variables: GetGqlProposalPreviewsInput['variables'] = {
       skip: page * limit,
       limit,
-      accountAddress,
+      accountAddress: accountAddress?.toLocaleLowerCase(),
       where,
     };
 

--- a/apps/evm/src/pages/Governance/ProposalList/index.tsx
+++ b/apps/evm/src/pages/Governance/ProposalList/index.tsx
@@ -160,7 +160,7 @@ const ProposalList: React.FC<ProposalListPageProps> = ({
 
   const { data: latestProposalStateData } = useGetProposalState(
     { proposalId: latestProposalData?.proposalId || '' },
-    { enabled: !!latestProposalData?.proposalId },
+    { enabled: !!latestProposalData?.proposalId && !!+latestProposalData?.proposalId },
   );
 
   const createProposalEnabled = useIsFeatureEnabled({ name: 'createProposal' });


### PR DESCRIPTION
## Changes

- fix an issue where not all inputs were passed to `getProposalPreviews` in `useGetProposalPreviews`
- prevent the state of the last proposal created by the user from being fetched when user has not submitted any proposal