### PR TITLE
fix: breakpoint prop not being passed to Table component in MarketTable

### DIFF
--- a/.changeset/great-fireants-lay.md
+++ b/.changeset/great-fireants-lay.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix breakpoint prop not being passed to Table component in MarketTable

--- a/apps/evm/src/containers/MarketTable/index.tsx
+++ b/apps/evm/src/containers/MarketTable/index.tsx
@@ -35,7 +35,6 @@ export const MarketTable: React.FC<MarketTableProps> = ({
   columns: columnKeys,
   clickableRows = true,
   initialOrder,
-  breakpoint,
   ...otherTableProps
 }) => {
   const styles = useStyles();


### PR DESCRIPTION
## Changes

- fix breakpoint prop not being passed to Table component in MarketTable
