### PR TITLE
fix: stop event propagation when clicking on collateral toggle

### DIFF
--- a/.changeset/old-laws-share.md
+++ b/.changeset/old-laws-share.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+Stop event propagation when clicking on collateral toggle

--- a/apps/evm/src/components/Toggle/index.tsx
+++ b/apps/evm/src/components/Toggle/index.tsx
@@ -43,6 +43,7 @@ export const Toggle = ({
         focusVisibleClassName=".Mui-focusVisible"
         disableRipple
         onChange={onChange}
+        onClick={e => e.stopPropagation()}
         checked={value}
         {...otherSwitchProps}
       />


### PR DESCRIPTION
## Changes

- stop event propagation when clicking on collateral toggle
