### PR TITLE
refactor: update logic to display market info in page header

### DIFF
--- a/.changeset/eleven-panthers-lick.md
+++ b/.changeset/eleven-panthers-lick.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Update logic to display market info in page header

--- a/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
@@ -129,7 +129,10 @@ export const MarketInfo = () => {
                 {asset.vToken.underlyingToken.symbol} ({pool?.name})
               </span>
 
-              {pool.isIsolated && <Pill>{t('layout.header.isolated')}</Pill>}
+              {pool.isIsolated &&
+                pool.comptrollerAddress !== corePoolComptrollerContractAddress && (
+                  <Pill>{t('layout.header.isolated')}</Pill>
+                )}
             </div>
 
             {isUserConnected && canAddTokenToWallet() && (

--- a/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
@@ -125,7 +125,7 @@ export const MarketInfo = () => {
             <TokenIcon token={asset.vToken.underlyingToken} className="h-full w-8 shrink-0" />
 
             <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-              <span className="font-bold">
+              <span className="font-bold text-lg">
                 {asset.vToken.underlyingToken.symbol} ({pool?.name})
               </span>
 

--- a/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
@@ -1,11 +1,11 @@
 import { Select, type SelectOption } from 'components';
 import { CHAIN_METADATA } from 'constants/chainMetadata';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { useTranslation } from 'libs/translations';
 import { chains, useChainId, useSwitchChain } from 'libs/wallet';
 import type { ChainId } from 'types';
 import { cn } from 'utilities';
 import { useIsOnMarketPage } from '../../useIsOnMarketPage';
-import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 export interface ChainSelectProps {
   className?: string;

--- a/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
@@ -4,7 +4,8 @@ import { useTranslation } from 'libs/translations';
 import { chains, useChainId, useSwitchChain } from 'libs/wallet';
 import type { ChainId } from 'types';
 import { cn } from 'utilities';
-import { useNewMarketFeature } from '../../useNewMarketFeature';
+import { useIsOnMarketPage } from '../../useIsOnMarketPage';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 export interface ChainSelectProps {
   className?: string;
@@ -37,7 +38,9 @@ export const ChainSelect: React.FC<ChainSelectProps> = ({ className, buttonClass
   const { t } = useTranslation();
   const { chainId } = useChainId();
   const { switchChain } = useSwitchChain();
-  const shouldUseNewMarketFeature = useNewMarketFeature();
+  const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });
+  const isOnMarketPage = useIsOnMarketPage();
+  const shouldUseNewMarketFeature = isNewMarketPageEnabled && isOnMarketPage;
 
   return (
     <Select

--- a/apps/evm/src/containers/Layout/Header/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/index.tsx
@@ -5,10 +5,13 @@ import { useImageAccentColor } from 'hooks/useImageAccentColor';
 import { cn } from 'utilities';
 import { MarketInfo } from './MarketInfo';
 import { TopBar } from './TopBar';
-import { useNewMarketFeature } from './useNewMarketFeature';
+import { useIsOnMarketPage } from './useIsOnMarketPage';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 export const Header: React.FC = () => {
-  const shouldUseNewMarketFeature = useNewMarketFeature();
+  const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });
+  const isOnMarketPage = useIsOnMarketPage();
+  const shouldUseNewMarketFeature = isNewMarketPageEnabled && isOnMarketPage;
 
   const { vTokenAddress = '' } = useParams();
   const { data: getAssetData } = useGetAsset({

--- a/apps/evm/src/containers/Layout/Header/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/index.tsx
@@ -2,11 +2,11 @@ import { useParams } from 'react-router';
 
 import { useGetAsset } from 'clients/api';
 import { useImageAccentColor } from 'hooks/useImageAccentColor';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { cn } from 'utilities';
 import { MarketInfo } from './MarketInfo';
 import { TopBar } from './TopBar';
 import { useIsOnMarketPage } from './useIsOnMarketPage';
-import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 export const Header: React.FC = () => {
   const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });

--- a/apps/evm/src/containers/Layout/Header/useIsOnMarketPage/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/useIsOnMarketPage/index.tsx
@@ -1,14 +1,12 @@
 import { routes } from 'constants/routing';
 import { useGetCurrentRoutePath } from 'hooks/useGetCurrentRoutePath';
-import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
-export const useNewMarketFeature = () => {
+export const useIsOnMarketPage = () => {
   const currentRoutePath = useGetCurrentRoutePath();
-  const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });
   const isOnMarketPage =
     currentRoutePath === routes.corePoolMarket.path ||
     currentRoutePath === routes.stakedEthPoolMarket.path ||
     currentRoutePath === routes.isolatedPoolMarket.path;
 
-  return isNewMarketPageEnabled && isOnMarketPage;
+  return isOnMarketPage;
 };


### PR DESCRIPTION
## Changes

- hide "isolated" tag on Market page when viewing market from the core pool, on chains where the core pool is actually an isolated pool
- fix font size of market name in layout header
- refactor `useNewMarketFeature` into `useIsOnMarketPage` so that we will be able to keep the latter once the feature flag has been removed
