### PR TITLE
fix: Prime loss warning

### DIFF
--- a/.changeset/moody-paws-itch.md
+++ b/.changeset/moody-paws-itch.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+remove pending withdrawals when determining amount user can withdraw from XVS vault before losing their Prime token

--- a/apps/evm/src/pages/Vault/modals/WithdrawFromVestingVaultModal/RequestWithdrawal/__tests__/indexPrime.spec.tsx
+++ b/apps/evm/src/pages/Vault/modals/WithdrawFromVestingVaultModal/RequestWithdrawal/__tests__/indexPrime.spec.tsx
@@ -70,7 +70,9 @@ describe('RequestWithdrawal - Feature enabled: Prime', () => {
       data: {
         // Set minimum stake to the same value as user's current stake, so that entering any amount
         // should display a warning message regarding the loss of Prime token
-        primeMinimumStakedXvsMantissa: new BigNumber(xvsVaultResponses.userInfo.amount.toString()),
+        primeMinimumStakedXvsMantissa: new BigNumber(
+          xvsVaultResponses.userInfo.amount.toString(),
+        ).minus(xvsVaultResponses.userInfo.pendingWithdrawals.toString()),
         xvsVaultPoolId: fakePoolIndex,
       },
     }));
@@ -98,7 +100,7 @@ describe('RequestWithdrawal - Feature enabled: Prime', () => {
 
     await waitFor(() =>
       expect(getByTestId(TEST_IDS.noticeWarning).textContent).toMatchInlineSnapshot(
-        '"You will lose your Prime token if you withdraw this amount, as your stake in the XVS vault will go below the minimum required of 30.00 XVS to be eligible for Prime."',
+        '"You will lose your Prime token if you withdraw this amount, as your stake in the XVS vault will go below the minimum required of 29.00 XVS to be eligible for Prime."',
       ),
     );
 

--- a/apps/evm/src/pages/Vault/modals/WithdrawFromVestingVaultModal/RequestWithdrawal/index.tsx
+++ b/apps/evm/src/pages/Vault/modals/WithdrawFromVestingVaultModal/RequestWithdrawal/index.tsx
@@ -196,11 +196,12 @@ const RequestWithdrawal: React.FC<RequestWithdrawalProps> = ({
       return undefined;
     }
 
-    const primeLossDeltaWei = xvsVaultUserInfo.stakedAmountMantissa.minus(
-      getPrimeStatusData.primeMinimumStakedXvsMantissa,
-    );
+    const primeLossDeltaMantissa = xvsVaultUserInfo.stakedAmountMantissa
+      .minus(xvsVaultUserInfo.pendingWithdrawalsTotalAmountMantissa)
+      .minus(getPrimeStatusData.primeMinimumStakedXvsMantissa);
+
     const primeLossDeltaTokens = convertMantissaToTokens({
-      value: primeLossDeltaWei,
+      value: primeLossDeltaMantissa,
       token: xvs,
     });
 


### PR DESCRIPTION
## Changes

- remove pending withdrawals when determining amount user can withdraw from XVS vault before losing their Prime token
