### PR TITLE
feat: disable zoom feature from mobile browsers

### DIFF
--- a/.changeset/nine-badgers-join.md
+++ b/.changeset/nine-badgers-join.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Disable zoom feature on mobile browsers

--- a/apps/evm/index.html
+++ b/apps/evm/index.html
@@ -4,7 +4,7 @@
     <meta name="robots" content="noindex" />
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, maximum-scale=1" />
     <meta name="format-detection" content="telephone=no" />
     <meta name="application-name" content="Venus Protocol" />
     <meta name="theme-color" content="#3A78FF" />


### PR DESCRIPTION
## Changes

- disable zoom feature from mobile browsers. This is to fix an issue with mobile browsers automatically zooming the page when focusing an input (due to the fact we use a small font size)
