### PR TITLE
feat: finalize new Market page

### DIFF
--- a/.changeset/silver-mayflies-prove.md
+++ b/.changeset/silver-mayflies-prove.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Final tweaks following feedbacks on the new Market page before release

--- a/apps/evm/src/components/AddTokenToWalletButton/index.tsx
+++ b/apps/evm/src/components/AddTokenToWalletButton/index.tsx
@@ -4,7 +4,7 @@ import { cn } from 'utilities';
 import { type ButtonProps, TertiaryButton } from '../Button';
 import { Icon } from '../Icon';
 
-export interface AddTokenToWalletButtonProps extends Omit<ButtonProps, 'onClick'> {
+export interface AddTokenToWalletButtonProps extends Omit<ButtonProps, 'onClick' | 'variant'> {
   token: Token;
 }
 
@@ -15,7 +15,8 @@ export const AddTokenToWalletButton: React.FC<AddTokenToWalletButtonProps> = ({
 }) => (
   <TertiaryButton
     className={cn(
-      'border-cards bg-background text-blue hover:text-offWhite p-1 h-8 w-8',
+      'p-1 h-8 w-8',
+      'border-transparent hover:border-transparent active:border-transparent bg-background/40 hover:bg-background/40 active:bg-background/40 text-grey hover:text-offWhite active:text-blue',
       className,
     )}
     onClick={() => addTokenToWallet(token)}

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/index.tsx
@@ -7,7 +7,7 @@ import { useGetChainMetadata } from 'hooks/useGetChainMetadata';
 import { VError, displayMutationError } from 'libs/errors';
 import { useTranslation } from 'libs/translations';
 import { useAccountAddress } from 'libs/wallet';
-import { formatCentsToReadableValue } from 'utilities';
+import { cn, formatCentsToReadableValue } from 'utilities';
 
 import TEST_IDS from '../testIds';
 import { RewardGroup } from './RewardGroup';
@@ -38,6 +38,8 @@ export const ClaimRewardButtonUi: React.FC<ClaimRewardButtonUiProps> = ({
   groups,
   chainLogoSrc,
   chainName,
+  variant,
+  className,
   ...otherButtonProps
 }) => {
   const { t } = useTranslation();
@@ -77,6 +79,11 @@ export const ClaimRewardButtonUi: React.FC<ClaimRewardButtonUiProps> = ({
       <PrimaryButton
         data-testid={TEST_IDS.claimRewardOpenModalButton}
         onClick={onOpenModal}
+        className={cn(
+          className,
+          variant === 'secondary' &&
+            'border-transparent bg-offWhite text-background hover:border-transparent hover:bg-grey active:bg-grey active:border-transparent',
+        )}
         {...otherButtonProps}
       >
         {t('claimReward.openModalButton.label', {
@@ -137,7 +144,9 @@ export const ClaimRewardButtonUi: React.FC<ClaimRewardButtonUiProps> = ({
   );
 };
 
-export type ClaimRewardButtonProps = Omit<ButtonProps, 'onClick'>;
+export interface ClaimRewardButtonProps extends Omit<ButtonProps, 'onClick' | 'variant'> {
+  variant?: 'primary' | 'secondary';
+}
 
 export const ClaimRewardButton: React.FC<ClaimRewardButtonProps> = props => {
   const { accountAddress } = useAccountAddress();

--- a/apps/evm/src/containers/Layout/ConnectButton/index.tsx
+++ b/apps/evm/src/containers/Layout/ConnectButton/index.tsx
@@ -6,9 +6,23 @@ import { cn, truncateAddress } from 'utilities';
 
 import { PrimeButton } from './PrimeButton';
 
-export const ConnectButton: React.FC<
-  Omit<ButtonProps, 'isAccountPrime' | 'accountAddress' | 'loading' | 'onClick'>
-> = ({ className, ...otherProps }) => {
+export interface ConnectButtonProps
+  extends Omit<
+    ButtonProps,
+    'isAccountPrime' | 'accountAddress' | 'loading' | 'onClick' | 'variant'
+  > {
+  variant?: 'primary' | 'secondary';
+}
+
+const connectedAccountButtonClasses = cn(
+  'border-offWhite hover:bg-offWhite hover:border-transparent hover:text-background active:bg-grey active:border-transparent',
+);
+
+export const ConnectButton: React.FC<ConnectButtonProps> = ({
+  className,
+  variant = 'primary',
+  ...otherProps
+}) => {
   const { accountAddress } = useAccountAddress();
   const { openAuthModal } = useAuthModal();
   const { t } = useTranslation();
@@ -22,17 +36,30 @@ export const ConnectButton: React.FC<
     return null;
   }
 
-  const props = {
-    onClick: openAuthModal,
-    className: cn('', className),
-  };
-
   if (accountAddress && isAccountPrime) {
-    return <PrimeButton accountAddress={accountAddress} {...props} {...otherProps} />;
+    return (
+      <PrimeButton
+        accountAddress={accountAddress}
+        onClick={openAuthModal}
+        className={cn(variant === 'secondary' && connectedAccountButtonClasses, className)}
+        {...otherProps}
+      />
+    );
   }
 
   return (
-    <Button variant={accountAddress ? 'secondary' : 'primary'} {...props} {...otherProps}>
+    <Button
+      variant={accountAddress ? 'secondary' : 'primary'}
+      onClick={openAuthModal}
+      className={cn(
+        className,
+        variant === 'secondary' && accountAddress && connectedAccountButtonClasses,
+        variant === 'secondary' &&
+          !accountAddress &&
+          'border-transparent bg-offWhite text-background hover:border-transparent hover:bg-grey active:bg-grey active:border-transparent',
+      )}
+      {...otherProps}
+    >
       {accountAddress ? <>{truncateAddress(accountAddress)}</> : t('connectButton.title')}
     </Button>
   );

--- a/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
@@ -122,7 +122,7 @@ export const MarketInfo = () => {
             )}
           </div>
         ) : (
-          <Spinner className="h-full" />
+          <Spinner className="h-full w-auto" />
         )}
       </div>
 

--- a/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/MarketInfo/index.tsx
@@ -10,13 +10,12 @@ import {
 } from 'components';
 import PLACEHOLDER_KEY from 'constants/placeholderKey';
 import { routes } from 'constants/routing';
-import { Link } from 'containers/Link';
 import { useGetChainMetadata } from 'hooks/useGetChainMetadata';
 import { useTranslation } from 'libs/translations';
 import { canAddTokenToWallet, useAccountAddress } from 'libs/wallet';
 import { useMemo } from 'react';
 import { matchPath, useLocation, useParams } from 'react-router';
-import { areAddressesEqual, formatCentsToReadableValue } from 'utilities';
+import { formatCentsToReadableValue } from 'utilities';
 import { UtilizationRate } from './UtilizationRate';
 
 export const MarketInfo = () => {
@@ -62,24 +61,7 @@ export const MarketInfo = () => {
   });
   const pool = getPoolData?.pool;
 
-  const goBackTo = useMemo(() => {
-    if (areAddressesEqual(poolComptrollerAddress, corePoolComptrollerContractAddress)) {
-      return routes.corePool.path;
-    }
-
-    if (
-      stakedEthPoolComptrollerContractAddress &&
-      areAddressesEqual(poolComptrollerAddress, stakedEthPoolComptrollerContractAddress)
-    ) {
-      return routes.stakedEthPool.path;
-    }
-
-    return routes.isolatedPool.path.replace(':poolComptrollerAddress', poolComptrollerAddress);
-  }, [
-    corePoolComptrollerContractAddress,
-    stakedEthPoolComptrollerContractAddress,
-    poolComptrollerAddress,
-  ]);
+  const handleGoBack = () => window.history.back();
 
   const cells: Cell[] = useMemo(() => {
     return [
@@ -116,9 +98,9 @@ export const MarketInfo = () => {
   return (
     <div className="pt-4 pb-12 md:pb-10 border-b-lightGrey border-b space-y-8">
       <div className="flex items-center h-8 px-4 md:px-6 xl:px-10 max-w-[1360px] mx-auto">
-        <Link to={goBackTo} className="h-full pr-3 flex items-center">
+        <button type="button" onClick={handleGoBack} className="h-full pr-3 flex items-center">
           <Icon name="chevronLeft" className="w-6 h-6 text-offWhite" />
-        </Link>
+        </button>
 
         {asset && pool ? (
           <div className="flex items-center gap-3">

--- a/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
@@ -20,14 +20,9 @@ const options: SelectOption<ChainId>[] = chains.map(chain => {
       <div className="flex items-center">
         <img src={metadata.logoSrc} alt={metadata.name} className="w-5 max-w-none flex-none" />
 
-        <span
-          className={cn(
-            'ml-2 grow overflow-hidden text-ellipsis',
-            isRenderedInButton && 'hidden lg:block',
-          )}
-        >
-          {metadata.name}
-        </span>
+        {!isRenderedInButton && (
+          <span className={cn('ml-2 grow overflow-hidden text-ellipsis')}>{metadata.name}</span>
+        )}
       </div>
     ),
     value: chain.id,
@@ -51,7 +46,7 @@ export const ChainSelect: React.FC<ChainSelectProps> = ({ className, buttonClass
       variant={shouldUseNewMarketFeature ? 'tertiary' : 'primary'}
       menuTitle={t('layout.chainSelect.label')}
       buttonClassName={buttonClassName}
-      className={cn('lg:min-w-[200px]', className)}
+      className={className}
     />
   );
 };

--- a/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
@@ -1,14 +1,11 @@
-import { Select, type SelectOption } from 'components';
+import { Select, type SelectProps, type SelectOption } from 'components';
 import { CHAIN_METADATA } from 'constants/chainMetadata';
-import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { useTranslation } from 'libs/translations';
 import { chains, useChainId, useSwitchChain } from 'libs/wallet';
 import type { ChainId } from 'types';
 import { cn } from 'utilities';
-import { useIsOnMarketPage } from '../../useIsOnMarketPage';
 
-export interface ChainSelectProps {
-  className?: string;
+export interface ChainSelectProps extends Omit<SelectProps, 'value' | 'onChange' | 'options'> {
   buttonClassName?: string;
 }
 
@@ -29,13 +26,10 @@ const options: SelectOption<ChainId>[] = chains.map(chain => {
   };
 });
 
-export const ChainSelect: React.FC<ChainSelectProps> = ({ className, buttonClassName }) => {
+export const ChainSelect: React.FC<ChainSelectProps> = ({ buttonClassName, ...otherProps }) => {
   const { t } = useTranslation();
   const { chainId } = useChainId();
   const { switchChain } = useSwitchChain();
-  const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });
-  const isOnMarketPage = useIsOnMarketPage();
-  const shouldUseNewMarketFeature = isNewMarketPageEnabled && isOnMarketPage;
 
   return (
     <Select
@@ -43,10 +37,9 @@ export const ChainSelect: React.FC<ChainSelectProps> = ({ className, buttonClass
       onChange={newChainId => switchChain({ chainId: Number(newChainId) })}
       options={options}
       menuPosition="right"
-      variant={shouldUseNewMarketFeature ? 'tertiary' : 'primary'}
       menuTitle={t('layout.chainSelect.label')}
       buttonClassName={buttonClassName}
-      className={className}
+      {...otherProps}
     />
   );
 };

--- a/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/ChainSelect/index.tsx
@@ -1,4 +1,4 @@
-import { Select, type SelectProps, type SelectOption } from 'components';
+import { Select, type SelectOption, type SelectProps } from 'components';
 import { CHAIN_METADATA } from 'constants/chainMetadata';
 import { useTranslation } from 'libs/translations';
 import { chains, useChainId, useSwitchChain } from 'libs/wallet';

--- a/apps/evm/src/containers/Layout/Header/TopBar/MdUpControls/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/MdUpControls/index.tsx
@@ -1,13 +1,27 @@
 import ClaimRewardButton from 'containers/Layout/ClaimRewardButton';
 import { ConnectButton } from 'containers/Layout/ConnectButton';
 import { ChainSelect } from '../ChainSelect';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
+import { useIsOnMarketPage } from '../../useIsOnMarketPage';
 
-export const MdUpControls: React.FC = () => (
-  <div className="hidden md:flex md:h-12 md:items-center md:space-x-4 md:pl-6">
-    <ClaimRewardButton className="flex-none md:whitespace-nowrap" />
+export const MdUpControls: React.FC = () => {
+  const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });
+  const isOnMarketPage = useIsOnMarketPage();
+  const shouldUseNewMarketPageFeature = isNewMarketPageEnabled && isOnMarketPage;
 
-    <ChainSelect />
+  return (
+    <div className="hidden md:flex md:h-12 md:items-center md:space-x-4 md:pl-6">
+      <ClaimRewardButton
+        variant={shouldUseNewMarketPageFeature ? 'secondary' : 'primary'}
+        className="flex-none md:whitespace-nowrap"
+      />
 
-    <ConnectButton className="flex-none" />
-  </div>
-);
+      <ChainSelect variant={shouldUseNewMarketPageFeature ? 'tertiary' : 'primary'} />
+
+      <ConnectButton
+        className="flex-none"
+        variant={shouldUseNewMarketPageFeature ? 'secondary' : 'primary'}
+      />
+    </div>
+  );
+};

--- a/apps/evm/src/containers/Layout/Header/TopBar/MdUpControls/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/MdUpControls/index.tsx
@@ -1,8 +1,8 @@
 import ClaimRewardButton from 'containers/Layout/ClaimRewardButton';
 import { ConnectButton } from 'containers/Layout/ConnectButton';
-import { ChainSelect } from '../ChainSelect';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { useIsOnMarketPage } from '../../useIsOnMarketPage';
+import { ChainSelect } from '../ChainSelect';
 
 export const MdUpControls: React.FC = () => {
   const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });

--- a/apps/evm/src/containers/Layout/Header/TopBar/XsControls/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/XsControls/index.tsx
@@ -11,10 +11,10 @@ import { cn } from 'utilities';
 import ClaimRewardButton from 'containers/Layout/ClaimRewardButton';
 import { ConnectButton } from 'containers/Layout/ConnectButton';
 import useGetMenuItems from 'containers/Layout/useGetMenuItems';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
+import { useIsOnMarketPage } from '../../useIsOnMarketPage';
 import { ChainSelect } from '../ChainSelect';
 import { NavLink } from './NavLink';
-import { useIsOnMarketPage } from '../../useIsOnMarketPage';
-import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 export const XsControls: React.FC = () => {
   const { t } = useTranslation();

--- a/apps/evm/src/containers/Layout/Header/TopBar/XsControls/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/XsControls/index.tsx
@@ -11,20 +11,19 @@ import { cn } from 'utilities';
 import ClaimRewardButton from 'containers/Layout/ClaimRewardButton';
 import { ConnectButton } from 'containers/Layout/ConnectButton';
 import useGetMenuItems from 'containers/Layout/useGetMenuItems';
-import { useGetCurrentRoutePath } from 'hooks/useGetCurrentRoutePath';
 import { ChainSelect } from '../ChainSelect';
 import { NavLink } from './NavLink';
+import { useIsOnMarketPage } from '../../useIsOnMarketPage';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 export const XsControls: React.FC = () => {
   const { t } = useTranslation();
   const [isMobileMenuOpened, setIsMobileMenuOpened] = useState<boolean>(false);
   const menuItems = useGetMenuItems();
 
-  const currentRoutePath = useGetCurrentRoutePath();
-  const isOnMarketPage =
-    currentRoutePath === routes.corePoolMarket.path ||
-    currentRoutePath === routes.stakedEthPoolMarket.path ||
-    currentRoutePath === routes.isolatedPoolMarket.path;
+  const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });
+  const isOnMarketPage = useIsOnMarketPage();
+  const shouldUseNewMarketPageFeature = isNewMarketPageEnabled && isOnMarketPage;
 
   const toggleMobileMenu = () => {
     // Toggle scroll on page container and body tags
@@ -46,9 +45,16 @@ export const XsControls: React.FC = () => {
         </Link>
 
         <div className="flex flex-1 items-center justify-center">
-          <ChainSelect className="mr-4" buttonClassName="h-9" />
+          <ChainSelect
+            className="mr-4"
+            buttonClassName="h-9"
+            variant={shouldUseNewMarketPageFeature && !isMobileMenuOpened ? 'tertiary' : 'primary'}
+          />
 
-          <ConnectButton className="h-9 max-w-xs flex-1 px-1" />
+          <ConnectButton
+            className="h-9 max-w-xs flex-1 px-1"
+            variant={shouldUseNewMarketPageFeature && !isMobileMenuOpened ? 'secondary' : 'primary'}
+          />
         </div>
 
         <button
@@ -79,7 +85,10 @@ export const XsControls: React.FC = () => {
         </div>
 
         <div className="px-4">
-          <ClaimRewardButton className="w-full" />
+          <ClaimRewardButton
+            className="w-full"
+            variant={shouldUseNewMarketPageFeature && !isMobileMenuOpened ? 'secondary' : 'primary'}
+          />
         </div>
       </div>
     </div>

--- a/apps/evm/src/containers/OperationForm/AssetInfo/index.tsx
+++ b/apps/evm/src/containers/OperationForm/AssetInfo/index.tsx
@@ -107,7 +107,11 @@ export const AssetInfo: React.FC<AssetInfoProps> = ({
         : asset.supplyDistributions
     )
       .filter(distribution => distribution.type !== 'primeSimulation')
-      .map<LabeledInlineContentProps>(distribution => {
+      .reduce<LabeledInlineContentProps[]>((acc, distribution) => {
+        if (distribution.type !== 'prime' && distribution.apyPercentage.isEqualTo(0)) {
+          return acc;
+        }
+
         const children =
           distribution.type === 'prime' ? (
             <ValueUpdate
@@ -123,7 +127,7 @@ export const AssetInfo: React.FC<AssetInfoProps> = ({
             formatPercentageToReadableValue(distribution.apyPercentage)
           );
 
-        return {
+        const row: LabeledInlineContentProps = {
           label:
             distribution.type === 'prime'
               ? t('assetInfo.primeApy', { tokenSymbol: distribution.token.symbol })
@@ -135,7 +139,9 @@ export const AssetInfo: React.FC<AssetInfoProps> = ({
               : undefined,
           children,
         };
-      });
+
+        return [...acc, row];
+      }, []);
 
     return apyBreakdownRows.concat(distributionRows);
   }, [asset, action, t, hypotheticalUserPrimeApys]);

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -396,7 +396,7 @@
   },
   "legacyPool": {
     "description": "Venus’ primary pool is composed of large-cap tokens that meet minimum liquidity requirements.",
-    "name": "Venus Core Pool"
+    "name": "Core Pool"
   },
   "markdownEditor": {
     "markdownTabLabel": "Write",

--- a/apps/evm/src/pages/Bridge/ChainSelect/index.tsx
+++ b/apps/evm/src/pages/Bridge/ChainSelect/index.tsx
@@ -9,7 +9,6 @@ export const getOptionsFromChainsList = (chainsList: typeof chains) =>
   chainsList.map(chain => {
     const metadata = CHAIN_METADATA[chain.id as ChainId];
     const option: SelectOption<ChainId> = {
-      // TODO: display wallet balance for each token
       label: (
         <div className="flex items-center">
           <img src={metadata.logoSrc} alt={metadata.name} className="w-5 max-w-none flex-none" />

--- a/apps/evm/src/pages/Market/Market/MarketHistory/index.tsx
+++ b/apps/evm/src/pages/Market/Market/MarketHistory/index.tsx
@@ -28,6 +28,7 @@ export const MarketHistory: React.FC<MarketHistoryProps> = ({
 }) => {
   const { t } = useTranslation();
   const isNewMarketPageEnabled = useIsFeatureEnabled({ name: 'newMarketPage' });
+  const isApyChartsFeatureEnabled = useIsFeatureEnabled({ name: 'apyCharts' });
 
   const { data: chartData, isLoading: isChartDataLoading } = useGetChartData({
     vToken: asset.vToken,
@@ -148,7 +149,7 @@ export const MarketHistory: React.FC<MarketHistoryProps> = ({
         testId={TEST_IDS.supplyInfo}
         title={t('market.supplyInfo.title')}
         stats={supplyInfoStats}
-        legends={supplyInfoLegends}
+        legends={isApyChartsFeatureEnabled ? supplyInfoLegends : undefined}
       >
         {isChartDataLoading && chartData.supplyChartData.length === 0 && <Spinner />}
         {chartData.supplyChartData.length > 0 && (
@@ -162,7 +163,7 @@ export const MarketHistory: React.FC<MarketHistoryProps> = ({
         testId={TEST_IDS.borrowInfo}
         title={t('market.borrowInfo.title')}
         stats={borrowInfoStats}
-        legends={borrowInfoLegends}
+        legends={isApyChartsFeatureEnabled ? borrowInfoLegends : undefined}
       >
         {isChartDataLoading && chartData.supplyChartData.length === 0 && <Spinner />}
         {chartData.borrowChartData.length > 0 && (

--- a/apps/evm/src/pages/Market/Market/index.tsx
+++ b/apps/evm/src/pages/Market/Market/index.tsx
@@ -21,7 +21,7 @@ export const Market: React.FC<MarketProps> = ({ asset, pool }) => {
       />
 
       <div className="space-y-6 lg:flex lg:space-y-0 lg:gap-x-6">
-        <Card className="lg:order-2 lg:sticky lg:top-6 w-auto lg:w-[400px] self-start shrink-0 overflow-x-auto max-h-[calc(100vh-40px)]">
+        <Card className="w-auto self-start shrink-0 overflow-x-auto lg:order-2 lg:sticky lg:w-[400px] lg:top-6 lg:max-h-[calc(100vh-48px)]">
           <OperationForm poolComptrollerAddress={pool.comptrollerAddress} vToken={asset.vToken} />
         </Card>
 

--- a/apps/evm/src/pages/Market/Market/index.tsx
+++ b/apps/evm/src/pages/Market/Market/index.tsx
@@ -26,7 +26,7 @@ export const Market: React.FC<MarketProps> = ({ asset, pool }) => {
         </Card>
 
         {/* w-0 is a hotfix to force the charts to adapt their size when resizing the window (see https://github.com/recharts/recharts/issues/172#issuecomment-307858843) */}
-        <div className="space-y-6 lg:grow lg:order-1 w-0">
+        <div className="space-y-6 lg:grow lg:order-1 lg:w-0">
           <MarketHistory asset={asset} poolComptrollerContractAddress={pool.comptrollerAddress} />
 
           <InterestRateChart asset={asset} isIsolatedPoolMarket={pool.isIsolated} />

--- a/apps/evm/src/pages/Market/Market/index.tsx
+++ b/apps/evm/src/pages/Market/Market/index.tsx
@@ -25,7 +25,8 @@ export const Market: React.FC<MarketProps> = ({ asset, pool }) => {
           <OperationForm poolComptrollerAddress={pool.comptrollerAddress} vToken={asset.vToken} />
         </Card>
 
-        <div className="space-y-6 lg:grow lg:order-1">
+        {/* w-0 is a hotfix to force the charts to adapt their size when resizing the window (see https://github.com/recharts/recharts/issues/172#issuecomment-307858843) */}
+        <div className="space-y-6 lg:grow lg:order-1 w-0">
           <MarketHistory asset={asset} poolComptrollerContractAddress={pool.comptrollerAddress} />
 
           <InterestRateChart asset={asset} isIsolatedPoolMarket={pool.isIsolated} />


### PR DESCRIPTION
## Jira ticket(s)

VEN-2545

## Changes

- update design of header on the new Market page
- add hotfix to force charts to resize when resizing the window
- update behavior of back arrow to redirect to always redirect to previous page
- enable new Market page for all networks
- hide 0% non-Prime distribution APYs on Operation form
- hide legends on market history cards when "apyCharts" feature is disabled
