### PR TITLE
feat: enable the XVS bridge between all chains

### DIFF
--- a/.changeset/silly-worms-obey.md
+++ b/.changeset/silly-worms-obey.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+enabled the XVS bridge between all networks

--- a/apps/evm/src/pages/Bridge/index.tsx
+++ b/apps/evm/src/pages/Bridge/index.tsx
@@ -262,20 +262,11 @@ const BridgePage: React.FC = () => {
     xvs,
   ]);
 
-  // filter out which options to present when selecting chains
-  // either BSC mainnet or BSC testnet must be the origin or the destination
-  const [fromChainIdOptions, toChainIdOptions] = useMemo(() => {
-    const bscChainListOptions = getOptionsFromChainsList(
-      chains.filter(c => c.id === ChainId.BSC_MAINNET || c.id === ChainId.BSC_TESTNET),
-    );
-    const otherChainsListOptions = getOptionsFromChainsList(
-      chains.filter(c => c.id !== ChainId.BSC_MAINNET && c.id !== ChainId.BSC_TESTNET),
-    );
-    if (chainId === ChainId.BSC_MAINNET || chainId === ChainId.BSC_TESTNET) {
-      return [bscChainListOptions, otherChainsListOptions];
-    }
-    return [otherChainsListOptions, bscChainListOptions];
-  }, [chainId]);
+  // build the list of chains that can be selected
+  const availableChainsListOptions = useMemo(() => {
+    const allChains = getOptionsFromChainsList(chains);
+    return allChains;
+  }, []);
 
   if (!nativeToken || !xvs) {
     return <Spinner />;
@@ -300,7 +291,7 @@ const BridgePage: React.FC = () => {
                   label={t('bridgePage.fromChainSelect.label')}
                   className="mb-4 w-full min-w-0 grow md:mb-0"
                   testId={TEST_IDS.fromChainIdSelect}
-                  options={fromChainIdOptions}
+                  options={availableChainsListOptions}
                   {...field}
                   onChange={newChainId => {
                     handleChainFieldChange({
@@ -330,7 +321,7 @@ const BridgePage: React.FC = () => {
                   className="w-full min-w-0 grow"
                   label={t('bridgePage.toChainSelect.label')}
                   testId={TEST_IDS.toChainIdSelect}
-                  options={toChainIdOptions}
+                  options={availableChainsListOptions}
                   {...field}
                   onChange={newChainId => {
                     handleChainFieldChange({

--- a/apps/evm/src/pages/Bridge/index.tsx
+++ b/apps/evm/src/pages/Bridge/index.tsx
@@ -113,7 +113,7 @@ const BridgePage: React.FC = () => {
     xvs,
   });
 
-  const { toChainId } = watch();
+  const { fromChainId, toChainId } = watch();
 
   const { data: getXvsBridgeFeeEstimationData } = useGetXvsBridgeFeeEstimation(
     {
@@ -263,10 +263,11 @@ const BridgePage: React.FC = () => {
   ]);
 
   // build the list of chains that can be selected
-  const availableChainsListOptions = useMemo(() => {
-    const allChains = getOptionsFromChainsList(chains);
-    return allChains;
-  }, []);
+  const [fromChainIdOptions, toChainIdOptions] = useMemo(() => {
+    const fromChains = getOptionsFromChainsList(chains.filter(c => c.id !== toChainId));
+    const otherChains = getOptionsFromChainsList(chains.filter(c => c.id !== fromChainId));
+    return [fromChains, otherChains];
+  }, [fromChainId, toChainId]);
 
   if (!nativeToken || !xvs) {
     return <Spinner />;
@@ -291,7 +292,7 @@ const BridgePage: React.FC = () => {
                   label={t('bridgePage.fromChainSelect.label')}
                   className="mb-4 w-full min-w-0 grow md:mb-0"
                   testId={TEST_IDS.fromChainIdSelect}
-                  options={availableChainsListOptions}
+                  options={fromChainIdOptions}
                   {...field}
                   onChange={newChainId => {
                     handleChainFieldChange({
@@ -321,7 +322,7 @@ const BridgePage: React.FC = () => {
                   className="w-full min-w-0 grow"
                   label={t('bridgePage.toChainSelect.label')}
                   testId={TEST_IDS.toChainIdSelect}
-                  options={availableChainsListOptions}
+                  options={toChainIdOptions}
                   {...field}
                   onChange={newChainId => {
                     handleChainFieldChange({

--- a/apps/evm/src/pages/Bridge/useBridgeForm.ts
+++ b/apps/evm/src/pages/Bridge/useBridgeForm.ts
@@ -287,17 +287,11 @@ const useBridgeForm = ({ toChainIdRef, walletBalanceTokens, xvs }: UseBridgeForm
   }, [form, bridgeEstimatedFeeMantissa]);
 
   // the chain can be changed either by the form or the header dropdown
-  // we have to ensure a BNB chain is either the origin or the destination of a bridge operation
   useEffect(() => {
     const previousFromChainId = formFromChainId;
     if (chainId !== formFromChainId) {
       form.setValue('fromChainId', chainId);
-      if (chainId !== ChainId.BSC_MAINNET && chainId !== ChainId.BSC_TESTNET) {
-        const bscChainId = chains.find(c => c.nativeCurrency.name === 'BNB')?.id as ChainId;
-        form.setValue('toChainId', bscChainId);
-      } else {
-        form.setValue('toChainId', previousFromChainId);
-      }
+      form.setValue('toChainId', previousFromChainId);
     }
   }, [chainId, form, formFromChainId]);
 


### PR DESCRIPTION
## Jira ticket(s)

VEN-2576

## Changes

- Removed the logic that enforced one of the bridge options to be BSC, now any chain can be selected as "from" or "to"
