### PR TITLE
feat: remove "new" label from Bridge nav item

### DIFF
--- a/.changeset/fast-peas-glow.md
+++ b/.changeset/fast-peas-glow.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+remove "new" label from Bridge nav item

--- a/apps/evm/src/containers/Layout/useGetMenuItems.tsx
+++ b/apps/evm/src/containers/Layout/useGetMenuItems.tsx
@@ -126,7 +126,6 @@ const useGetMenuItems = () => {
     if (bridgeRouteEnabled) {
       menuItems.push({
         to: routes.bridge.path,
-        isNew: true,
         // Translation key: do not remove this comment
         // t('layout.menuItems.bridge')
         i18nKey: 'layout.menuItems.bridge',


### PR DESCRIPTION
## Changes

- remove "new" label from Bridge nav item
