### PR TITLE
refactor: use correct address for native token

### DIFF
--- a/.changeset/tasty-birds-refuse.md
+++ b/.changeset/tasty-birds-refuse.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+use correct address for native token

--- a/apps/evm/src/__mocks__/contracts/venusLens.ts
+++ b/apps/evm/src/__mocks__/contracts/venusLens.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import { BigNumber as BN } from 'ethers';
 
 import type { VenusLens } from 'libs/contracts';
@@ -103,7 +104,7 @@ const venusLensResponses: {
       isListed: true,
       pausedActions: BN.from('0x00'),
       collateralFactorMantissa: BN.from('0x0b1a2bc2ec500000'),
-      underlyingAssetAddress: '0x0000000000000000000000000000000000000000',
+      underlyingAssetAddress: NATIVE_TOKEN_ADDRESS,
       vTokenDecimals: BN.from('0x08'),
       underlyingDecimals: BN.from('0x12'),
       venusBorrowSpeed: BN.from('0xb90983f22ef200'),

--- a/apps/evm/src/__mocks__/models/tokens.ts
+++ b/apps/evm/src/__mocks__/models/tokens.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import bnbLogo from 'libs/tokens/img/bnb.svg';
 import busdLogo from 'libs/tokens/img/busd.svg';
 import ethLogo from 'libs/tokens/img/eth.svg';
@@ -35,7 +36,7 @@ export const vrt: Token = {
 };
 
 export const bnb: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   isNative: true,
   decimals: 18,
   symbol: 'BNB',

--- a/apps/evm/src/clients/api/queries/getIsolatedPools/formatOutput/index.ts
+++ b/apps/evm/src/clients/api/queries/getIsolatedPools/formatOutput/index.ts
@@ -15,6 +15,7 @@ import convertMantissaToTokens from 'utilities/convertMantissaToTokens';
 import findTokenByAddress from 'utilities/findTokenByAddress';
 import { getDisabledTokenActions } from 'utilities/getDisabledTokenActions';
 
+import { NATIVE_TOKEN_ADDRESS, NULL_ADDRESS } from 'constants/address';
 import type { GetTokenBalancesOutput } from '../../getTokenBalances';
 import type { GetRewardsDistributorSettingsMappingOutput } from '../getRewardsDistributorSettingsMapping';
 import type { GetTokenPriceDollarsMappingOutput } from '../getTokenPriceDollarsMapping';
@@ -62,10 +63,17 @@ const formatToPools = ({
         return acc;
       }
 
+      const underlyingTokenAddress =
+        // If underlying asset address is the null address, this means the VToken has no underlying
+        // token because it is a native token
+        areAddressesEqual(vTokenMetaData.underlyingAssetAddress, NULL_ADDRESS)
+          ? NATIVE_TOKEN_ADDRESS
+          : vTokenMetaData.underlyingAssetAddress;
+
       // Retrieve underlying token record
       const underlyingToken = findTokenByAddress({
         tokens,
-        address: vTokenMetaData.underlyingAssetAddress,
+        address: underlyingTokenAddress,
       });
 
       if (!underlyingToken) {

--- a/apps/evm/src/clients/api/queries/getLegacyPool/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getLegacyPool/__tests__/__snapshots__/index.spec.ts.snap
@@ -257,7 +257,7 @@ exports[`getLegacyPool > returns core pool in the correct format 1`] = `
           "decimals": 8,
           "symbol": "vBNB",
           "underlyingToken": {
-            "address": "0x0000000000000000000000000000000000000000",
+            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
             "asset": "/src/libs/tokens/img/bnb.svg",
             "decimals": 18,
             "isNative": true,

--- a/apps/evm/src/clients/api/queries/getLegacyPool/__tests__/__snapshots__/indexPrime.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getLegacyPool/__tests__/__snapshots__/indexPrime.spec.ts.snap
@@ -347,7 +347,7 @@ exports[`getLegacyPool - Feature enabled: Prime > does not fetch Prime distribut
           "decimals": 8,
           "symbol": "vBNB",
           "underlyingToken": {
-            "address": "0x0000000000000000000000000000000000000000",
+            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
             "asset": "/src/libs/tokens/img/bnb.svg",
             "decimals": 18,
             "isNative": true,
@@ -905,7 +905,7 @@ exports[`getLegacyPool - Feature enabled: Prime > fetches and formats Prime dist
           "decimals": 8,
           "symbol": "vBNB",
           "underlyingToken": {
-            "address": "0x0000000000000000000000000000000000000000",
+            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
             "asset": "/src/libs/tokens/img/bnb.svg",
             "decimals": 18,
             "isNative": true,
@@ -1373,7 +1373,7 @@ exports[`getLegacyPool - Feature enabled: Prime > filters out Prime distribution
           "decimals": 8,
           "symbol": "vBNB",
           "underlyingToken": {
-            "address": "0x0000000000000000000000000000000000000000",
+            "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
             "asset": "/src/libs/tokens/img/bnb.svg",
             "decimals": 18,
             "isNative": true,

--- a/apps/evm/src/clients/api/queries/getLegacyPool/formatToPool/index.ts
+++ b/apps/evm/src/clients/api/queries/getLegacyPool/formatToPool/index.ts
@@ -4,6 +4,8 @@ import type { GetTokenBalancesOutput } from 'clients/api';
 import {
   BSC_MAINNET_UNLISTED_TOKEN_ADDRESSES,
   BSC_TESTNET_UNLISTED_TOKEN_ADDRESSES,
+  NATIVE_TOKEN_ADDRESS,
+  NULL_ADDRESS,
 } from 'constants/address';
 import { COMPOUND_DECIMALS, COMPOUND_MANTISSA } from 'constants/compoundMantissa';
 import MAX_UINT256 from 'constants/maxUint256';
@@ -116,9 +118,16 @@ export const formatToPool = ({
       return;
     }
 
+    const underlyingTokenAddress =
+      // If underlying asset address is the null address, this means the VToken has no underlying
+      // token because it is a native token
+      areAddressesEqual(vTokenMetaData.underlyingAssetAddress, NULL_ADDRESS)
+        ? NATIVE_TOKEN_ADDRESS
+        : vTokenMetaData.underlyingAssetAddress;
+
     const underlyingToken = findTokenByAddress({
       tokens,
-      address: vTokenMetaData.underlyingAssetAddress,
+      address: underlyingTokenAddress,
     });
 
     if (!underlyingToken) {

--- a/apps/evm/src/clients/api/queries/getTokenBalances/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getTokenBalances/__snapshots__/index.spec.ts.snap
@@ -49,7 +49,7 @@ exports[`api/queries/getTokenBalances > returns token balances, including BNB, i
     {
       "balanceMantissa": "1000000000000000000",
       "token": {
-        "address": "0x0000000000000000000000000000000000000000",
+        "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         "asset": "/src/libs/tokens/img/bnb.svg",
         "decimals": 18,
         "isNative": true,

--- a/apps/evm/src/clients/api/queries/getVTokens/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getVTokens/__tests__/__snapshots__/index.spec.ts.snap
@@ -107,7 +107,7 @@ exports[`api/queries/getVTokens > returns the vTokens on success 1`] = `
       "decimals": 8,
       "symbol": "vBNB",
       "underlyingToken": {
-        "address": "0x0000000000000000000000000000000000000000",
+        "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
         "asset": "/src/libs/tokens/img/bnb.svg",
         "decimals": 18,
         "isNative": true,

--- a/apps/evm/src/constants/address.ts
+++ b/apps/evm/src/constants/address.ts
@@ -1,4 +1,5 @@
 export const NULL_ADDRESS = '0x0000000000000000000000000000000000000000';
+export const NATIVE_TOKEN_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 
 // We do not list the following tokens in the tokens package because they are not meant to be listed
 // on Venus. TODO: remove these once the tokens have been unlisted from contracts

--- a/apps/evm/src/hooks/useGetSwapInfo/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/hooks/useGetSwapInfo/__tests__/__snapshots__/index.spec.tsx.snap
@@ -9,7 +9,7 @@ exports[`pages/Swap/useGetSwapInfo > exactAmountIn > returns swap in correct for
     "exchangeRate": "0.499374217772215269",
     "expectedToTokenAmountReceivedMantissa": "499374217772215269",
     "fromToken": {
-      "address": "0x0000000000000000000000000000000000000000",
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       "asset": "/src/libs/tokens/img/bnb.svg",
       "decimals": 18,
       "isNative": true,
@@ -41,7 +41,7 @@ exports[`pages/Swap/useGetSwapInfo > exactAmountOut > returns swap in correct fo
     "exchangeRate": "0.49875",
     "expectedFromTokenAmountSoldMantissa": "1002506265664160402",
     "fromToken": {
-      "address": "0x0000000000000000000000000000000000000000",
+      "address": "0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE",
       "asset": "/src/libs/tokens/img/bnb.svg",
       "decimals": 18,
       "isNative": true,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/arbitrumOne.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/arbitrumOne.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import arbLogo from 'libs/tokens/img/arb.svg';
 import ethLogo from 'libs/tokens/img/eth.svg';
 import usdcLogo from 'libs/tokens/img/usdc.svg';
@@ -8,7 +9,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const ethToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'ETH',
   asset: ethLogo,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/arbitrumSepolia.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/arbitrumSepolia.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import arbLogo from 'libs/tokens/img/arb.svg';
 import ethLogo from 'libs/tokens/img/eth.svg';
 import usdcLogo from 'libs/tokens/img/usdc.svg';
@@ -8,7 +9,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const ethToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'ETH',
   asset: ethLogo,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/bscMainnet.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/bscMainnet.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import aaveLogo from 'libs/tokens/img/aave.svg';
 import adaLogo from 'libs/tokens/img/ada.svg';
 import alpacaLogo from 'libs/tokens/img/alpaca.png';
@@ -52,7 +53,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const bnbToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'BNB',
   asset: bnbLogo,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/bscTestnet.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/bscTestnet.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import aaveLogo from 'libs/tokens/img/aave.svg';
 import adaLogo from 'libs/tokens/img/ada.svg';
 import alpacaLogo from 'libs/tokens/img/alpaca.png';
@@ -47,7 +48,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const bnbToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'BNB',
   asset: bnbLogo,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/ethereum.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/ethereum.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import crvLogo from 'libs/tokens/img/crv.svg';
 import crvUsdLogo from 'libs/tokens/img/crvUsd.svg';
 import daiLogo from 'libs/tokens/img/dai.svg';
@@ -18,7 +19,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const ethToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'ETH',
   asset: ethLogo,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/opBnbMainnet.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/opBnbMainnet.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import bnbLogo from 'libs/tokens/img/bnb.svg';
 import btcbLogo from 'libs/tokens/img/btcb.svg';
 import ethLogo from 'libs/tokens/img/eth.svg';
@@ -8,7 +9,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const bnbToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'BNB',
   asset: bnbLogo,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/opBnbTestnet.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/opBnbTestnet.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import bnbLogo from 'libs/tokens/img/bnb.svg';
 import btcbLogo from 'libs/tokens/img/btcb.svg';
 import ethLogo from 'libs/tokens/img/eth.svg';
@@ -7,7 +8,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const bnbToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'BNB',
   asset: bnbLogo,

--- a/apps/evm/src/libs/tokens/infos/commonTokens/sepolia.ts
+++ b/apps/evm/src/libs/tokens/infos/commonTokens/sepolia.ts
@@ -1,3 +1,4 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import crvLogo from 'libs/tokens/img/crv.svg';
 import crvUsdLogo from 'libs/tokens/img/crvUsd.svg';
 import daiLogo from 'libs/tokens/img/dai.svg';
@@ -18,7 +19,7 @@ import xvsLogo from 'libs/tokens/img/xvs.svg';
 import type { Token } from 'types';
 
 const ethToken: Token = {
-  address: '0x0000000000000000000000000000000000000000',
+  address: NATIVE_TOKEN_ADDRESS,
   decimals: 18,
   symbol: 'ETH',
   asset: ethLogo,

--- a/apps/evm/src/libs/tokens/infos/disabledTokenActions/bscMainnet.ts
+++ b/apps/evm/src/libs/tokens/infos/disabledTokenActions/bscMainnet.ts
@@ -1,9 +1,10 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import type { DisabledTokenAction } from '../../types';
 
 export const disabledTokenActions: DisabledTokenAction[] = [
   // BNB
   {
-    address: '0x0000000000000000000000000000000000000000',
+    address: NATIVE_TOKEN_ADDRESS,
     disabledActions: ['swapAndSupply'],
   },
   // vAAVE - Core pool

--- a/apps/evm/src/libs/tokens/infos/disabledTokenActions/bscTestnet.ts
+++ b/apps/evm/src/libs/tokens/infos/disabledTokenActions/bscTestnet.ts
@@ -1,9 +1,10 @@
+import { NATIVE_TOKEN_ADDRESS } from 'constants/address';
 import type { DisabledTokenAction } from '../../types';
 
 export const disabledTokenActions: DisabledTokenAction[] = [
   // BNB
   {
-    address: '0x0000000000000000000000000000000000000000',
+    address: NATIVE_TOKEN_ADDRESS,
     disabledActions: ['swapAndSupply'],
   },
 ];


### PR DESCRIPTION
## Changes

- add `NATIVE_TOKEN_ADDRESS` constant
- add logic to detect market with no underlying token and set native token instead
