### PR TITLE
feat: add median user averages for Prime estimations in Ethereum

### DIFF
--- a/.changeset/lemon-jeans-matter.md
+++ b/.changeset/lemon-jeans-matter.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+add median user averages for Prime estimations in Ethereum

--- a/apps/evm/src/clients/api/queries/getIsolatedPools/__tests__/__snapshots__/indexPrime.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getIsolatedPools/__tests__/__snapshots__/indexPrime.spec.ts.snap
@@ -123,9 +123,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > does not fetch Prime distri
             {
               "apyPercentage": "0.20019958435848473",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "11017.5",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -176,9 +176,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > does not fetch Prime distri
             {
               "apyPercentage": "0.23026397657694986",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "11017.5",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -447,9 +447,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > does not fetch Prime distri
             {
               "apyPercentage": "0.20019958435848473",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "101000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -500,9 +500,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > does not fetch Prime distri
             {
               "apyPercentage": "0.23026397657694986",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "101000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -575,9 +575,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > does not fetch Prime distri
             {
               "apyPercentage": "0.20019958435848473",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "1000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -628,9 +628,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > does not fetch Prime distri
             {
               "apyPercentage": "0.23026397657694986",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "1000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -807,9 +807,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > fetches and formats Prime d
             {
               "apyPercentage": "0.20019958435848473",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "11017.5",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -870,9 +870,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > fetches and formats Prime d
             {
               "apyPercentage": "0.23026397657694986",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "11017.5",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -1151,9 +1151,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > fetches and formats Prime d
             {
               "apyPercentage": "0.20019958435848473",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "101000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -1214,9 +1214,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > fetches and formats Prime d
             {
               "apyPercentage": "0.23026397657694986",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "101000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -1299,9 +1299,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > fetches and formats Prime d
             {
               "apyPercentage": "0.20019958435848473",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "1000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
@@ -1362,9 +1362,9 @@ exports[`getIsolatedPools - Feature enabled: Prime > fetches and formats Prime d
             {
               "apyPercentage": "0.23026397657694986",
               "referenceValues": {
-                "userBorrowBalanceTokens": "10009.21",
-                "userSupplyBalanceTokens": "5003.94",
-                "userXvsStakedTokens": "3731.33",
+                "userBorrowBalanceTokens": "0",
+                "userSupplyBalanceTokens": "1000",
+                "userXvsStakedTokens": "1000",
               },
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",

--- a/apps/evm/src/clients/api/queries/getIsolatedPools/index.ts
+++ b/apps/evm/src/clients/api/queries/getIsolatedPools/index.ts
@@ -272,6 +272,7 @@ const getIsolatedPools = async ({
       accountAddress,
       primeMinimumXvsToStakeMantissa: new BigNumber(primeMinimumXvsToStakeMantissa.toString()),
       xvs,
+      chainId,
     });
   }
 

--- a/apps/evm/src/clients/api/queries/getLegacyPool/index.ts
+++ b/apps/evm/src/clients/api/queries/getLegacyPool/index.ts
@@ -203,6 +203,7 @@ const getLegacyPool = async ({
       accountAddress,
       primeMinimumXvsToStakeMantissa: new BigNumber(primeMinimumXvsToStakeMantissa.toString()),
       xvs,
+      chainId,
     });
   }
 

--- a/apps/evm/src/constants/prime.ts
+++ b/apps/evm/src/constants/prime.ts
@@ -1,29 +1,94 @@
 import BigNumber from 'bignumber.js';
+import { ChainId } from 'types';
 
 export const PRIME_DOC_URL = 'https://docs-v4.venus.io/whats-new/prime-yield';
 
 export const PRIME_APY_DOC_URL =
   'https://docs-v4.venus.io/technical-reference/reference-technical-articles/prime#calculate-apr-associated-with-a-prime-market-and-user';
 
-// TODO: add other tokens and update to use vToken addresses instead
-
-export const supplyAveragesForToken: Record<string, BigNumber> = {
-  BTCB: new BigNumber('0.71'),
-  ETH: new BigNumber('9.86'),
-  USDT: new BigNumber('5003.94'),
-  USDC: new BigNumber('13068.75'),
+const bscPrimeMarketsAddresses = {
+  vBTCB: '0x882C173bC7Ff3b7786CA16dfeD3DFFfb9Ee7847B',
+  vUSDT: '0xfD5840Cd36d94D7229439859C0112a4185BC0255',
+  vUSDC: '0xecA88125a5ADbe82614ffC12D0DB554E2e2867C8',
+  vETH: '0xf508fCD89b8bd15579dc79A6827cB4686A3592c8',
 };
 
-export const borrowAveragesForToken: Record<string, BigNumber> = {
-  BTCB: new BigNumber('0.04'),
-  ETH: new BigNumber('0.49'),
-  USDT: new BigNumber('10009.21'),
-  USDC: new BigNumber('2405.43'),
+const ethPrimeMarketsAddresses = {
+  vUSDC_Core: '0x17C07e0c232f2f80DfDbd7a95b942D893A4C5ACb',
+  vUSDT_Core: '0x8C3e3821259B82fFb32B2450A95d2dcbf161C24E',
+  vWBTC_Core: '0x8716554364f20BCA783cb2BAA744d39361fd1D8d',
+  vWETH_LiquidStakedETH: '0xc82780Db1257C788F262FBbDA960B3706Dfdcaf2',
 };
 
-export const xvsStakedAveragesForToken: Record<string, BigNumber> = {
-  BTCB: new BigNumber('4124.59'),
-  ETH: new BigNumber('4788.05'),
-  USDT: new BigNumber('3731.33'),
-  USDC: new BigNumber('3265.30'),
+const bscSupplyAveragesForToken: Record<string, BigNumber> = {
+  [bscPrimeMarketsAddresses.vBTCB]: new BigNumber('0.71'),
+  [bscPrimeMarketsAddresses.vETH]: new BigNumber('9.86'),
+  [bscPrimeMarketsAddresses.vUSDT]: new BigNumber('5003.94'),
+  [bscPrimeMarketsAddresses.vUSDC]: new BigNumber('13068.75'),
+};
+
+const ethSupplyAveragesForToken: Record<string, BigNumber> = {
+  [ethPrimeMarketsAddresses.vUSDC_Core]: new BigNumber('15813.76'),
+  [ethPrimeMarketsAddresses.vUSDT_Core]: new BigNumber('21430.84'),
+  [ethPrimeMarketsAddresses.vWBTC_Core]: new BigNumber('2.02'),
+  [ethPrimeMarketsAddresses.vWETH_LiquidStakedETH]: new BigNumber('124.77'),
+};
+
+const bscBorrowAveragesForToken: Record<string, BigNumber> = {
+  [bscPrimeMarketsAddresses.vBTCB]: new BigNumber('0.04'),
+  [bscPrimeMarketsAddresses.vETH]: new BigNumber('0.49'),
+  [bscPrimeMarketsAddresses.vUSDT]: new BigNumber('10009.21'),
+  [bscPrimeMarketsAddresses.vUSDC]: new BigNumber('2405.43'),
+};
+
+const ethBorrowAveragesForToken: Record<string, BigNumber> = {
+  [ethPrimeMarketsAddresses.vUSDC_Core]: new BigNumber('11615.36'),
+  [ethPrimeMarketsAddresses.vUSDT_Core]: new BigNumber('3095.78'),
+  [ethPrimeMarketsAddresses.vWBTC_Core]: new BigNumber('1.48'),
+  [ethPrimeMarketsAddresses.vWETH_LiquidStakedETH]: new BigNumber('11.16'),
+};
+
+const bscXvsStakedAveragesForToken: Record<string, BigNumber> = {
+  [bscPrimeMarketsAddresses.vBTCB]: new BigNumber('4124.59'),
+  [bscPrimeMarketsAddresses.vETH]: new BigNumber('4788.05'),
+  [bscPrimeMarketsAddresses.vUSDT]: new BigNumber('3731.33'),
+  [bscPrimeMarketsAddresses.vUSDC]: new BigNumber('3265.30'),
+};
+
+const ethXvsStakedAveragesForToken: Record<string, BigNumber> = {
+  [ethPrimeMarketsAddresses.vUSDC_Core]: new BigNumber('7890.50'),
+  [ethPrimeMarketsAddresses.vUSDT_Core]: new BigNumber('6006.66'),
+  [ethPrimeMarketsAddresses.vWBTC_Core]: new BigNumber('6341.15'),
+  [ethPrimeMarketsAddresses.vWETH_LiquidStakedETH]: new BigNumber('7943.09'),
+};
+
+const bscPrimeAverages = {
+  supply: bscSupplyAveragesForToken,
+  borrow: bscBorrowAveragesForToken,
+  xvs: bscXvsStakedAveragesForToken,
+};
+
+const ethereumPrimeAverages = {
+  supply: ethSupplyAveragesForToken,
+  borrow: ethBorrowAveragesForToken,
+  xvs: ethXvsStakedAveragesForToken,
+};
+
+export const primeAveragesForNetwork: Record<
+  ChainId,
+  | {
+      supply: Record<string, BigNumber>;
+      borrow: Record<string, BigNumber>;
+      xvs: Record<string, BigNumber>;
+    }
+  | undefined
+> = {
+  [ChainId.BSC_MAINNET]: bscPrimeAverages,
+  [ChainId.BSC_TESTNET]: bscPrimeAverages,
+  [ChainId.ETHEREUM]: ethereumPrimeAverages,
+  [ChainId.SEPOLIA]: ethereumPrimeAverages,
+  [ChainId.OPBNB_MAINNET]: undefined,
+  [ChainId.OPBNB_TESTNET]: undefined,
+  [ChainId.ARBITRUM_ONE]: undefined,
+  [ChainId.ARBITRUM_SEPOLIA]: undefined,
 };

--- a/apps/evm/src/constants/prime.ts
+++ b/apps/evm/src/constants/prime.ts
@@ -6,7 +6,14 @@ export const PRIME_DOC_URL = 'https://docs-v4.venus.io/whats-new/prime-yield';
 export const PRIME_APY_DOC_URL =
   'https://docs-v4.venus.io/technical-reference/reference-technical-articles/prime#calculate-apr-associated-with-a-prime-market-and-user';
 
-const bscPrimeMarketsAddresses = {
+const bscTestnetPrimeMarketsAddresses = {
+  vBTCB: '0xb6e9322C49FD75a367Fcb17B0Fcd62C5070EbCBe',
+  vUSDT: '0xb7526572FFE56AB9D7489838Bf2E18e3323b441A',
+  vUSDC: '0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7',
+  vETH: '0x162D005F0Fff510E54958Cfc5CF32A3180A84aab',
+};
+
+const bscMainnetPrimeMarketsAddresses = {
   vBTCB: '0x882C173bC7Ff3b7786CA16dfeD3DFFfb9Ee7847B',
   vUSDT: '0xfD5840Cd36d94D7229439859C0112a4185BC0255',
   vUSDC: '0xecA88125a5ADbe82614ffC12D0DB554E2e2867C8',
@@ -20,11 +27,18 @@ const ethPrimeMarketsAddresses = {
   vWETH_LiquidStakedETH: '0xc82780Db1257C788F262FBbDA960B3706Dfdcaf2',
 };
 
-const bscSupplyAveragesForToken: Record<string, BigNumber> = {
-  [bscPrimeMarketsAddresses.vBTCB]: new BigNumber('0.71'),
-  [bscPrimeMarketsAddresses.vETH]: new BigNumber('9.86'),
-  [bscPrimeMarketsAddresses.vUSDT]: new BigNumber('5003.94'),
-  [bscPrimeMarketsAddresses.vUSDC]: new BigNumber('13068.75'),
+const bscTestnetSupplyAveragesForToken: Record<string, BigNumber> = {
+  [bscTestnetPrimeMarketsAddresses.vBTCB]: new BigNumber('0.71'),
+  [bscTestnetPrimeMarketsAddresses.vETH]: new BigNumber('9.86'),
+  [bscTestnetPrimeMarketsAddresses.vUSDT]: new BigNumber('5003.94'),
+  [bscTestnetPrimeMarketsAddresses.vUSDC]: new BigNumber('13068.75'),
+};
+
+const bscMainnetSupplyAveragesForToken: Record<string, BigNumber> = {
+  [bscMainnetPrimeMarketsAddresses.vBTCB]: new BigNumber('0.71'),
+  [bscMainnetPrimeMarketsAddresses.vETH]: new BigNumber('9.86'),
+  [bscMainnetPrimeMarketsAddresses.vUSDT]: new BigNumber('5003.94'),
+  [bscMainnetPrimeMarketsAddresses.vUSDC]: new BigNumber('13068.75'),
 };
 
 const ethSupplyAveragesForToken: Record<string, BigNumber> = {
@@ -34,11 +48,18 @@ const ethSupplyAveragesForToken: Record<string, BigNumber> = {
   [ethPrimeMarketsAddresses.vWETH_LiquidStakedETH]: new BigNumber('124.77'),
 };
 
-const bscBorrowAveragesForToken: Record<string, BigNumber> = {
-  [bscPrimeMarketsAddresses.vBTCB]: new BigNumber('0.04'),
-  [bscPrimeMarketsAddresses.vETH]: new BigNumber('0.49'),
-  [bscPrimeMarketsAddresses.vUSDT]: new BigNumber('10009.21'),
-  [bscPrimeMarketsAddresses.vUSDC]: new BigNumber('2405.43'),
+const bscTestnetBorrowAveragesForToken: Record<string, BigNumber> = {
+  [bscTestnetPrimeMarketsAddresses.vBTCB]: new BigNumber('0.04'),
+  [bscTestnetPrimeMarketsAddresses.vETH]: new BigNumber('0.49'),
+  [bscTestnetPrimeMarketsAddresses.vUSDT]: new BigNumber('10009.21'),
+  [bscTestnetPrimeMarketsAddresses.vUSDC]: new BigNumber('2405.43'),
+};
+
+const bscMainnetBorrowAveragesForToken: Record<string, BigNumber> = {
+  [bscMainnetPrimeMarketsAddresses.vBTCB]: new BigNumber('0.04'),
+  [bscMainnetPrimeMarketsAddresses.vETH]: new BigNumber('0.49'),
+  [bscMainnetPrimeMarketsAddresses.vUSDT]: new BigNumber('10009.21'),
+  [bscMainnetPrimeMarketsAddresses.vUSDC]: new BigNumber('2405.43'),
 };
 
 const ethBorrowAveragesForToken: Record<string, BigNumber> = {
@@ -48,11 +69,18 @@ const ethBorrowAveragesForToken: Record<string, BigNumber> = {
   [ethPrimeMarketsAddresses.vWETH_LiquidStakedETH]: new BigNumber('11.16'),
 };
 
-const bscXvsStakedAveragesForToken: Record<string, BigNumber> = {
-  [bscPrimeMarketsAddresses.vBTCB]: new BigNumber('4124.59'),
-  [bscPrimeMarketsAddresses.vETH]: new BigNumber('4788.05'),
-  [bscPrimeMarketsAddresses.vUSDT]: new BigNumber('3731.33'),
-  [bscPrimeMarketsAddresses.vUSDC]: new BigNumber('3265.30'),
+const bscTestnetXvsStakedAveragesForToken: Record<string, BigNumber> = {
+  [bscTestnetPrimeMarketsAddresses.vBTCB]: new BigNumber('4124.59'),
+  [bscTestnetPrimeMarketsAddresses.vETH]: new BigNumber('4788.05'),
+  [bscTestnetPrimeMarketsAddresses.vUSDT]: new BigNumber('3731.33'),
+  [bscTestnetPrimeMarketsAddresses.vUSDC]: new BigNumber('3265.30'),
+};
+
+const bscMainnetXvsStakedAveragesForToken: Record<string, BigNumber> = {
+  [bscMainnetPrimeMarketsAddresses.vBTCB]: new BigNumber('4124.59'),
+  [bscMainnetPrimeMarketsAddresses.vETH]: new BigNumber('4788.05'),
+  [bscMainnetPrimeMarketsAddresses.vUSDT]: new BigNumber('3731.33'),
+  [bscMainnetPrimeMarketsAddresses.vUSDC]: new BigNumber('3265.30'),
 };
 
 const ethXvsStakedAveragesForToken: Record<string, BigNumber> = {
@@ -62,10 +90,16 @@ const ethXvsStakedAveragesForToken: Record<string, BigNumber> = {
   [ethPrimeMarketsAddresses.vWETH_LiquidStakedETH]: new BigNumber('7943.09'),
 };
 
-const bscPrimeAverages = {
-  supply: bscSupplyAveragesForToken,
-  borrow: bscBorrowAveragesForToken,
-  xvs: bscXvsStakedAveragesForToken,
+const bscTestnetPrimeAverages = {
+  supply: bscTestnetSupplyAveragesForToken,
+  borrow: bscTestnetBorrowAveragesForToken,
+  xvs: bscTestnetXvsStakedAveragesForToken,
+};
+
+const bscMainnetPrimeAverages = {
+  supply: bscMainnetSupplyAveragesForToken,
+  borrow: bscMainnetBorrowAveragesForToken,
+  xvs: bscMainnetXvsStakedAveragesForToken,
 };
 
 const ethereumPrimeAverages = {
@@ -83,8 +117,8 @@ export const primeAveragesForNetwork: Record<
     }
   | undefined
 > = {
-  [ChainId.BSC_MAINNET]: bscPrimeAverages,
-  [ChainId.BSC_TESTNET]: bscPrimeAverages,
+  [ChainId.BSC_MAINNET]: bscMainnetPrimeAverages,
+  [ChainId.BSC_TESTNET]: bscTestnetPrimeAverages,
   [ChainId.ETHEREUM]: ethereumPrimeAverages,
   [ChainId.SEPOLIA]: ethereumPrimeAverages,
   [ChainId.OPBNB_MAINNET]: undefined,


### PR DESCRIPTION
## Changes

- Added specific amounts for the median user XVS staked, supply and borrow in Prime markets for the Ethereum network
- Refactored them to be found by the market's address instead of underlying symbol
