### PR TITLE
fix: title of Prime promotional banner on Account page

### DIFF
--- a/.changeset/serious-vans-move.md
+++ b/.changeset/serious-vans-move.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix title of Prime promotional banner on Account page

--- a/apps/evm/src/containers/PrimeStatusBanner/__tests__/index.spec.tsx
+++ b/apps/evm/src/containers/PrimeStatusBanner/__tests__/index.spec.tsx
@@ -5,7 +5,7 @@ import type Vi from 'vitest';
 import { renderComponent } from 'testUtils/render';
 
 import {
-  useGetLegacyPool,
+  useGetPools,
   useGetPrimeStatus,
   useGetPrimeToken,
   useGetXvsVaultUserInfo,
@@ -32,9 +32,9 @@ describe('PrimeStatusBanner', () => {
   };
 
   beforeEach(() => {
-    (useGetLegacyPool as Vi.Mock).mockImplementation(() => ({
+    (useGetPools as Vi.Mock).mockImplementation(() => ({
       data: {
-        pool: poolData[0],
+        pools: poolData,
       },
     }));
     (useGetPrimeStatus as Vi.Mock).mockImplementation(() => ({


### PR DESCRIPTION
## Changes

- consider Prime simulations from all pools when looking for highest Prime APY to display on Prime promotional banner
- fix `hidePromotionalTitle` prop logic
