### PR TITLE
refactor: market snapshot types

### DIFF
--- a/.changeset/stupid-comics-join.md
+++ b/.changeset/stupid-comics-join.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+refactor market snapshot types into possible strings

--- a/apps/evm/src/pages/Market/Market/MarketHistory/useGetChartData.ts
+++ b/apps/evm/src/pages/Market/Market/MarketHistory/useGetChartData.ts
@@ -29,7 +29,7 @@ const useGetChartData = ({ vToken }: { vToken: VToken }) => {
     [...marketSnapshotsData.marketSnapshots]
       // Snapshots are already reversed, due to the negative slice
       .forEach(marketSnapshot => {
-        const timestampMs = marketSnapshot.blockTimestamp * 1000;
+        const timestampMs = Number(marketSnapshot.blockTimestamp) * 1000;
 
         supplyChartData.push({
           apyPercentage: +marketSnapshot.supplyApy,

--- a/apps/evm/src/types/index.ts
+++ b/apps/evm/src/types/index.ts
@@ -298,8 +298,9 @@ export interface Market {
 }
 
 export interface MarketSnapshot {
-  blockNumber: number;
-  blockTimestamp: number;
+  // we are migrating these values to strings, as they are bigints instead of numbers
+  blockNumber: string | number;
+  blockTimestamp: string | number;
   borrowApy: string;
   supplyApy: string;
   totalBorrowCents: string;


### PR DESCRIPTION
## Changes

- Refactor market snapshot types into possible strings as we are migrating these types to strings in the API
