### PR TITLE
fix: links to markets in Liquid Staked ETH pool

### DIFF
--- a/.changeset/fair-fans-relax.md
+++ b/.changeset/fair-fans-relax.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix links to markets in Liquid Staked ETH pool

--- a/apps/evm/src/constants/chainMetadata.ts
+++ b/apps/evm/src/constants/chainMetadata.ts
@@ -73,6 +73,7 @@ export const CHAIN_METADATA: {
     blocksPerDay: 7200,
     corePoolComptrollerContractAddress: '0x7Aa39ab4BcA897F403425C9C6FDbd0f882Be0D70',
     stakedEthPoolComptrollerContractAddress: '0xd79CeB8EF8188E44b7Eb899094e8A3A4d7A1e236',
+    wstEthContractAddress: '0x0a95088403229331FeF1EB26a11F9d6C8E73f23D',
     nativeToken: getToken({ chainId: ChainId.SEPOLIA, symbol: 'ETH' })!,
   },
   [ChainId.ARBITRUM_ONE]: {

--- a/apps/evm/src/containers/MarketTable/index.tsx
+++ b/apps/evm/src/containers/MarketTable/index.tsx
@@ -37,8 +37,11 @@ export const MarketTable: React.FC<MarketTableProps> = ({
 }) => {
   const styles = useStyles();
 
-  const { corePoolComptrollerContractAddress, stakedEthPoolComptrollerContractAddress } =
-    useGetChainMetadata();
+  const {
+    corePoolComptrollerContractAddress,
+    stakedEthPoolComptrollerContractAddress,
+    wstEthContractAddress,
+  } = useGetChainMetadata();
   const { toggleCollateral } = useCollateral();
 
   const handleCollateralChange = async (poolAssetToUpdate: PoolAsset) => {
@@ -94,7 +97,9 @@ export const MarketTable: React.FC<MarketTableProps> = ({
 
       if (
         stakedEthPoolComptrollerContractAddress &&
-        areAddressesEqual(row.pool.comptrollerAddress, stakedEthPoolComptrollerContractAddress)
+        wstEthContractAddress &&
+        areAddressesEqual(row.pool.comptrollerAddress, stakedEthPoolComptrollerContractAddress) &&
+        areAddressesEqual(row.vToken.address, wstEthContractAddress)
       ) {
         return routes.lidoMarket.path.replace(':vTokenAddress', row.vToken.address);
       }
@@ -105,6 +110,7 @@ export const MarketTable: React.FC<MarketTableProps> = ({
     },
     [
       corePoolComptrollerContractAddress,
+      wstEthContractAddress,
       stakedEthPoolComptrollerContractAddress,
       stakedEthPoolComptrollerContractAddress,
     ],


### PR DESCRIPTION
## Changes

- fix links to markets in Liquid Staked ETH pool
- add `wstEthContractAddress` property to Sepolia chain metadata
