### PR TITLE
feat: enable apyCharts for all chains

### DIFF
--- a/.changeset/mean-countries-end.md
+++ b/.changeset/mean-countries-end.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+enable apyCharts for all chains

--- a/apps/evm/src/hooks/useIsFeatureEnabled/index.tsx
+++ b/apps/evm/src/hooks/useIsFeatureEnabled/index.tsx
@@ -29,7 +29,15 @@ export const featureFlags = {
   xvsRoute: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   createProposal: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
   voteProposal: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
-  apyCharts: [ChainId.BSC_MAINNET, ChainId.BSC_TESTNET],
+  apyCharts: [
+    ChainId.BSC_MAINNET,
+    ChainId.BSC_TESTNET,
+    ChainId.ETHEREUM,
+    ChainId.SEPOLIA,
+    ChainId.OPBNB_MAINNET,
+    ChainId.OPBNB_TESTNET,
+    ChainId.ARBITRUM_ONE,
+  ],
   marketParticipantCounts: [
     ChainId.BSC_MAINNET,
     ChainId.BSC_TESTNET,


### PR DESCRIPTION
## Changes

- Enable `apyCharts` for all chains except Arbitrum Sepolia, as the API has no support for it yet
