### PR TITLE
fix: reload dApp when lazy load fails

### DIFF
--- a/.changeset/hip-dolls-hang.md
+++ b/.changeset/hip-dolls-hang.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+reload dApp when lazy load fails

--- a/apps/evm/src/App/Routes/index.tsx
+++ b/apps/evm/src/App/Routes/index.tsx
@@ -1,4 +1,4 @@
-import { lazy, useEffect } from 'react';
+import { useEffect } from 'react';
 import { Route, Routes, useLocation } from 'react-router-dom';
 
 import { PAGE_CONTAINER_ID } from 'constants/layout';
@@ -9,26 +9,27 @@ import { useAccountAddress } from 'libs/wallet';
 
 import { Redirect } from 'components';
 import { useGetChainMetadata } from 'hooks/useGetChainMetadata';
+import { safeLazyLoad } from 'utilities';
 import PageSuspense from './PageSuspense';
 
-const Dashboard = lazy(() => import('pages/Dashboard'));
-const Account = lazy(() => import('pages/Account'));
-const CorePoolMarket = lazy(() => import('pages/Market/CorePoolMarket'));
-const IsolatedPoolMarket = lazy(() => import('pages/Market/IsolatedPoolMarket'));
-const CorePool = lazy(() => import('pages/Pool/CorePool'));
-const IsolatedPool = lazy(() => import('pages/Pool/IsolatedPool'));
-const LidoMarket = lazy(() => import('pages/Market/LidoMarket'));
-const ConvertVrt = lazy(() => import('pages/ConvertVrt'));
-const Governance = lazy(() => import('pages/Governance'));
-const IsolatedPools = lazy(() => import('pages/IsolatedPools'));
-const Proposal = lazy(() => import('pages/Proposal'));
-const Swap = lazy(() => import('pages/Swap'));
-const Vai = lazy(() => import('pages/Vai'));
-const Vaults = lazy(() => import('pages/Vault'));
-const Voter = lazy(() => import('pages/Voter'));
-const VoterLeaderboard = lazy(() => import('pages/VoterLeaderboard'));
-const PrimeCalculator = lazy(() => import('pages/PrimeCalculator'));
-const Bridge = lazy(() => import('pages/Bridge'));
+const Dashboard = safeLazyLoad(() => import('pages/Dashboard'));
+const Account = safeLazyLoad(() => import('pages/Account'));
+const CorePoolMarket = safeLazyLoad(() => import('pages/Market/CorePoolMarket'));
+const IsolatedPoolMarket = safeLazyLoad(() => import('pages/Market/IsolatedPoolMarket'));
+const CorePool = safeLazyLoad(() => import('pages/Pool/CorePool'));
+const IsolatedPool = safeLazyLoad(() => import('pages/Pool/IsolatedPool'));
+const LidoMarket = safeLazyLoad(() => import('pages/Market/LidoMarket'));
+const ConvertVrt = safeLazyLoad(() => import('pages/ConvertVrt'));
+const Governance = safeLazyLoad(() => import('pages/Governance'));
+const IsolatedPools = safeLazyLoad(() => import('pages/IsolatedPools'));
+const Proposal = safeLazyLoad(() => import('pages/Proposal'));
+const Swap = safeLazyLoad(() => import('pages/Swap'));
+const Vai = safeLazyLoad(() => import('pages/Vai'));
+const Vaults = safeLazyLoad(() => import('pages/Vault'));
+const Voter = safeLazyLoad(() => import('pages/Voter'));
+const VoterLeaderboard = safeLazyLoad(() => import('pages/VoterLeaderboard'));
+const PrimeCalculator = safeLazyLoad(() => import('pages/PrimeCalculator'));
+const Bridge = safeLazyLoad(() => import('pages/Bridge'));
 
 const AppRoutes = () => {
   const { accountAddress } = useAccountAddress();

--- a/apps/evm/src/App/index.tsx
+++ b/apps/evm/src/App/index.tsx
@@ -1,5 +1,5 @@
 import { QueryClientProvider } from '@tanstack/react-query';
-import { Suspense, lazy } from 'react';
+import { Suspense } from 'react';
 import { HashRouter } from 'react-router-dom';
 
 import { queryClient } from 'clients/api';
@@ -9,10 +9,11 @@ import { SentryErrorInfo } from 'libs/errors/SentryErrorInfo';
 import { Web3Wrapper } from 'libs/wallet';
 import { MuiThemeProvider } from 'theme/MuiThemeProvider';
 
+import { safeLazyLoad } from 'utilities';
 import Routes from './Routes';
 
-const NotificationCenter = lazy(() => import('libs/notifications/NotificationCenter'));
-const AppVersionChecker = lazy(() => import('containers/AppVersionChecker'));
+const NotificationCenter = safeLazyLoad(() => import('libs/notifications/NotificationCenter'));
+const AppVersionChecker = safeLazyLoad(() => import('containers/AppVersionChecker'));
 
 const App = () => (
   <ErrorBoundary>

--- a/apps/evm/src/utilities/index.ts
+++ b/apps/evm/src/utilities/index.ts
@@ -49,3 +49,4 @@ export * from './convertToDate';
 export * from './formatToProposalDescription';
 export * from './getSwapToTokenAmountReceived';
 export * from './calculateDailyTokenRate';
+export * from './safeLazyLoad';

--- a/apps/evm/src/utilities/safeLazyLoad/__tests__/index.spec.tsx
+++ b/apps/evm/src/utilities/safeLazyLoad/__tests__/index.spec.tsx
@@ -1,0 +1,46 @@
+import { act, render, screen } from '@testing-library/react';
+import { Suspense, createElement } from 'react';
+import { safeLazyLoad } from '..';
+
+describe('safeLazyLoad', () => {
+  // Mock window.location.reload
+  const mockReload = vi.fn();
+  Object.defineProperty(window, 'location', {
+    value: { reload: mockReload },
+    writable: true,
+  });
+
+  beforeEach(() => {
+    mockReload.mockClear();
+  });
+
+  it('successfully loads and renders a component', async () => {
+    const TestComponent = () => <div>Test Component</div>;
+    const lazyComponent = safeLazyLoad(() => Promise.resolve({ default: TestComponent }));
+
+    render(<Suspense fallback={<div>Loading...</div>}>{createElement(lazyComponent)}</Suspense>);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(screen.getByText('Test Component')).toBeInTheDocument();
+    expect(mockReload).not.toHaveBeenCalled();
+  });
+
+  it('reloads the page when component fails to load', async () => {
+    const lazyComponent = safeLazyLoad(() => Promise.reject(new Error('Failed to load')));
+
+    render(<Suspense fallback={<div>Loading...</div>}>{createElement(lazyComponent)}</Suspense>);
+
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 0));
+    });
+
+    expect(mockReload).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/evm/src/utilities/safeLazyLoad/index.tsx
+++ b/apps/evm/src/utilities/safeLazyLoad/index.tsx
@@ -1,0 +1,19 @@
+import { type FC, lazy } from 'react';
+
+export const safeLazyLoad = (
+  load: () => Promise<{
+    default: FC<{ [k: string]: never }>;
+  }>,
+) =>
+  lazy(async () => {
+    try {
+      const result = await load();
+      return result;
+    } catch (_e) {
+      // Reload the page if the module fails to load, as this indicates a new version of the dApp
+      // has been deployed
+      window.location.reload();
+
+      return { default: () => <></> };
+    }
+  });


### PR DESCRIPTION
## Changes

- create `safeLazyLoad` utility function that reloads the dApp when a file fails to be dynamically imported. This is a fix for a bug where if a user keeps a session active and a new release is deployed during that time, then the dApp won't be able to lazy load chunks whose content changed, as the build process would have generated different file names for those (by changing the hash in their suffix)