### PR TITLE
chore: fix release workflow permission issue

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,6 +19,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v3
@@ -31,13 +32,15 @@ jobs:
 
       # Bump package versions based on changesets and commit changes to the main branch
       - name: Bump package versions
+        env:
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
         run: |
-          git config user.name github-actions[bot]
-          git config user.email github-actions[bot]@users.noreply.github.com
+          git config user.name toolsvenus
+          git config user.email tools@venus.io
           git fetch origin
           git rebase --strategy-option=theirs origin/main
           npx changeset version
           git add -A
           git status
           git commit --verbose -a -m "chore: bump package versions" || exit 0
-          git push --verbose
+          git push


### PR DESCRIPTION
## Changes

- fix `Release` workflow by using a personal access token to push package version changes
