### PR TITLE
fix: value for borrow rewards APY above chart

### DIFF
--- a/.changeset/stale-sheep-cover.md
+++ b/.changeset/stale-sheep-cover.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+Fixed the borrow distribution APY value above the chart

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`CorePoolMarket > fetches market details and displays them correctly 1`]
 
 exports[`CorePoolMarket > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
 
-exports[`CorePoolMarket > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY0.11%Liquidation Threshold50%Liquidation Penalty10%"`;
+exports[`CorePoolMarket > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%"`;
 
 exports[`CorePoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MSupply cap> 100.00T XVSBorrow cap> 100.00T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1.00K XVSReserve factor25%Collateral factor50%vXVS minted> 100.00TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexApyCharts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexApyCharts.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 1`] = `"Supply info30D6M1YSupply APYTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
 
-exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1YBorrow APYTotal borrow$709.25KAPY-2.3%Distribution APY0.11%Liquidation Threshold50%Liquidation Penalty10%"`;
+exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1YBorrow APYTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%"`;
 
 exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetche
 
 exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
 
-exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY0.11%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
 exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Supply cap> 100.00T XVSBorrow cap> 100.00T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1.00K XVSReserve factor25%Collateral factor50%vXVS minted> 100.00TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`IsolatedPoolMarket > fetches market details and displays them correctly
 
 exports[`IsolatedPoolMarket > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
 
-exports[`IsolatedPoolMarket > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY0.11%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
 exports[`IsolatedPoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MSupply cap> 100.00T XVSBorrow cap> 100.00T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1.00K XVSReserve factor25%Collateral factor50%vXVS minted> 100.00TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketHistory.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketHistory.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 1`] = `"Supply info30D6M1YSupply APYTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1YBorrow APYTotal borrow$709.25KAPY-2.3%Distribution APY0.11%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1YBorrow APYTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fe
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY0.11%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Supply cap> 100.00T XVSBorrow cap> 100.00T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1.00K XVSReserve factor25%Collateral factor50%vXVS minted> 100.00TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/Market/MarketHistory/Card/index.tsx
+++ b/apps/evm/src/pages/Market/Market/MarketHistory/Card/index.tsx
@@ -102,7 +102,11 @@ export const Card: React.FC<CardProps> = ({
       },
       {
         label: t('market.stats.distributionApy'),
-        value: formatPercentageToReadableValue(distributionApys.supplyApyRewardsPercentage),
+        value: formatPercentageToReadableValue(
+          type === 'supply'
+            ? distributionApys.supplyApyRewardsPercentage
+            : distributionApys.borrowApyRewardsPercentage,
+        ),
       },
     ];
 


### PR DESCRIPTION
## Jira ticket(s)

VEN-2840

## Changes

- Use the correct value for borrow rewards APY above the borrow chart
