### PR TITLE
refactor: use static RPC provider

### DIFF
--- a/.changeset/heavy-balloons-tie.md
+++ b/.changeset/heavy-balloons-tie.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+use static RPC provider

--- a/apps/evm/src/libs/wallet/hooks/useProvider/getProvider.ts
+++ b/apps/evm/src/libs/wallet/hooks/useProvider/getProvider.ts
@@ -8,7 +8,11 @@ import { logError } from 'libs/errors';
 const MULTICALL_BATCH_SIZE = 100;
 
 // Convert a viem Public Client to an ethers.js Provider
-export const getProvider = ({ client }: { client: Client<Transport, Chain> }) => {
+export const getProvider = ({
+  client,
+}: {
+  client: Client<Transport, Chain>;
+}) => {
   const { chain, transport } = client;
   const network = {
     chainId: chain.id,
@@ -20,10 +24,10 @@ export const getProvider = ({ client }: { client: Client<Transport, Chain> }) =>
     transport.type === 'fallback'
       ? new ethersProviders.FallbackProvider(
           (transport.transports as ReturnType<HttpTransport>[]).map(
-            ({ value }) => new ethersProviders.JsonRpcProvider(value?.url, network),
+            ({ value }) => new ethersProviders.StaticJsonRpcProvider(value?.url, network),
           ),
         )
-      : new ethersProviders.JsonRpcProvider(transport.url, network);
+      : new ethersProviders.StaticJsonRpcProvider(transport.url, network);
 
   // We can't use the getter function for the 0xsequence multicall contract here because that
   // creates a dependency cycle


### PR DESCRIPTION
## Changes

- use `StaticJsonRpcProvider` class in `getProvider`, which greatly reduces the amount of `eth_chainid` calls made to retrieve the chain ID
