### PR TITLE
feat: wire up execute button of remote proposals

### DIFF
--- a/.changeset/honest-items-lick.md
+++ b/.changeset/honest-items-lick.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+wire up execute button of remote proposals

--- a/apps/evm/package.json
+++ b/apps/evm/package.json
@@ -114,7 +114,7 @@
     "@types/recharts": "^1.8.23",
     "@types/redux-actions": "^2.6.2",
     "@types/styled-components": "^5.1.26",
-    "@venusprotocol/governance-contracts": "2.3.0",
+    "@venusprotocol/governance-contracts": "2.3.0-dev.3",
     "@venusprotocol/isolated-pools": "3.5.0",
     "@venusprotocol/oracle": "2.5.1",
     "@venusprotocol/protocol-reserve": "2.3.0",

--- a/apps/evm/src/clients/api/mutations/executeProposal/index.spec.ts
+++ b/apps/evm/src/clients/api/mutations/executeProposal/index.spec.ts
@@ -6,21 +6,21 @@ import executeProposal from '.';
 
 describe('executeProposal', () => {
   test('returns contract transaction when request succeeds', async () => {
-    const executeProposalMock = vi.fn(async () => fakeContractTransaction);
+    const executeMock = vi.fn(async () => fakeContractTransaction);
 
     const fakeContract = {
-      execute: executeProposalMock,
+      execute: executeMock,
     } as unknown as GovernorBravoDelegate;
 
     const fakeProposalId = 3816;
 
     const response = await executeProposal({
-      governorBravoDelegateContract: fakeContract,
+      contract: fakeContract,
       proposalId: fakeProposalId,
     });
 
     expect(response).toBe(fakeContractTransaction);
-    expect(executeProposalMock).toHaveBeenCalledTimes(1);
-    expect(executeProposalMock).toHaveBeenCalledWith(fakeProposalId);
+    expect(executeMock).toHaveBeenCalledTimes(1);
+    expect(executeMock).toHaveBeenCalledWith(fakeProposalId);
   });
 });

--- a/apps/evm/src/clients/api/mutations/executeProposal/index.ts
+++ b/apps/evm/src/clients/api/mutations/executeProposal/index.ts
@@ -1,18 +1,17 @@
 import type { ContractTransaction } from 'ethers';
 
-import type { GovernorBravoDelegate } from 'libs/contracts';
+import type { GovernorBravoDelegate, OmnichainGovernanceExecutor } from 'libs/contracts';
 
 export interface ExecuteProposalInput {
-  governorBravoDelegateContract: GovernorBravoDelegate;
+  contract: GovernorBravoDelegate | OmnichainGovernanceExecutor;
   proposalId: number;
 }
 
 export type ExecuteProposalOutput = ContractTransaction;
 
 const executeProposal = async ({
-  governorBravoDelegateContract,
+  contract,
   proposalId,
-}: ExecuteProposalInput): Promise<ExecuteProposalOutput> =>
-  governorBravoDelegateContract.execute(proposalId);
+}: ExecuteProposalInput): Promise<ExecuteProposalOutput> => contract.execute(proposalId);
 
 export default executeProposal;

--- a/apps/evm/src/clients/api/mutations/executeProposal/useExecuteProposal.ts
+++ b/apps/evm/src/clients/api/mutations/executeProposal/useExecuteProposal.ts
@@ -1,10 +1,19 @@
 import { type ExecuteProposalInput, executeProposal, queryClient } from 'clients/api';
 import FunctionKey from 'constants/functionKey';
 import { type UseSendTransactionOptions, useSendTransaction } from 'hooks/useSendTransaction';
-import { useGetGovernorBravoDelegateContract } from 'libs/contracts';
+import {
+  getOmnichainGovernanceExecutorContract,
+  useGetGovernorBravoDelegateContract,
+} from 'libs/contracts';
+import { VError } from 'libs/errors';
+import { governanceChain, useSigner } from 'libs/wallet';
+import type { ChainId } from 'types';
 import { callOrThrow } from 'utilities';
 
-type TrimmedExecuteProposalInput = Omit<ExecuteProposalInput, 'governorBravoDelegateContract'>;
+type TrimmedExecuteProposalInput = Omit<ExecuteProposalInput, 'contract'>;
+type Input = TrimmedExecuteProposalInput & {
+  chainId: ChainId;
+};
 type Options = UseSendTransactionOptions<TrimmedExecuteProposalInput>;
 
 const useExecuteProposal = (options?: Partial<Options>) => {
@@ -12,19 +21,35 @@ const useExecuteProposal = (options?: Partial<Options>) => {
     passSigner: true,
   });
 
+  const { signer } = useSigner();
+
   return useSendTransaction({
     fnKey: [FunctionKey.EXECUTE_PROPOSAL],
-    fn: (input: TrimmedExecuteProposalInput) =>
-      callOrThrow({ governorBravoDelegateContract }, params =>
+    fn: (input: Input) => {
+      if (!signer) {
+        throw new VError({ type: 'unexpected', code: 'somethingWentWrong' });
+      }
+
+      const contract =
+        input.chainId === governanceChain.id
+          ? governorBravoDelegateContract
+          : getOmnichainGovernanceExecutorContract({
+              signerOrProvider: signer,
+              chainId: input.chainId,
+            });
+
+      return callOrThrow({ contract }, params =>
         executeProposal({
           ...input,
           ...params,
         }),
-      ),
+      );
+    },
     onConfirmed: async ({ input }) => {
       queryClient.invalidateQueries({
         queryKey: [FunctionKey.GET_PROPOSALS],
       });
+
       queryClient.invalidateQueries({
         queryKey: [
           FunctionKey.GET_PROPOSAL,

--- a/apps/evm/src/libs/contracts/config/index.ts
+++ b/apps/evm/src/libs/contracts/config/index.ts
@@ -1,6 +1,16 @@
+import { abi as OmnichainGovernanceExecutorAbi } from '@venusprotocol/governance-contracts/artifacts/contracts/Cross-chain/OmnichainGovernanceExecutor.sol/OmnichainGovernanceExecutor.json';
 import { abi as GovernorBravoDelegateAbi } from '@venusprotocol/governance-contracts/artifacts/contracts/Governance/GovernorBravoDelegate.sol/GovernorBravoDelegate.json';
+import venusGovernanceArbitrumOneDeployments from '@venusprotocol/governance-contracts/deployments/arbitrumone_addresses.json';
+import venusGovernanceArbitrumSepoliaDeployments from '@venusprotocol/governance-contracts/deployments/arbitrumsepolia_addresses.json';
 import venusGovernanceBscMainnetDeployments from '@venusprotocol/governance-contracts/deployments/bscmainnet_addresses.json';
 import venusGovernanceBscTestnetDeployments from '@venusprotocol/governance-contracts/deployments/bsctestnet_addresses.json';
+import venusGovernanceEthereumDeployments from '@venusprotocol/governance-contracts/deployments/ethereum_addresses.json';
+import venusGovernanceOpBnbMainnetDeployments from '@venusprotocol/governance-contracts/deployments/opbnbmainnet_addresses.json';
+import venusGovernanceOpBnbTestnetDeployments from '@venusprotocol/governance-contracts/deployments/opbnbtestnet_addresses.json';
+import venusGovernanceSepoliaDeployments from '@venusprotocol/governance-contracts/deployments/sepolia_addresses.json';
+// import venusGovernanceZkSyncSepoliaDeployments from '@venusprotocol/governance-contracts/deployments/zksyncSepolia_addresses.json';
+// import venusGovernanceZkSyncMainnetDeployments from '@venusprotocol/governance-contracts/deployments/zksyncmainnet_addresses.json';
+venusGovernanceEthereumDeployments.addresses.OmnichainGovernanceExecutor;
 import { abi as IsolatedPoolComptrollerAbi } from '@venusprotocol/isolated-pools/artifacts/contracts/Comptroller.sol/Comptroller.json';
 import { abi as NativeTokenGatewayAbi } from '@venusprotocol/isolated-pools/artifacts/contracts/Gateway/NativeTokenGateway.sol/NativeTokenGateway.json';
 import { abi as JumpRateModelV2Abi } from '@venusprotocol/isolated-pools/artifacts/contracts/JumpRateModelV2.sol/JumpRateModelV2.json';
@@ -228,6 +238,28 @@ export const contracts: ContractConfig[] = [
         venusGovernanceBscTestnetDeployments.addresses.GovernorBravoDelegator_Proxy,
       [ChainId.BSC_MAINNET]:
         venusGovernanceBscMainnetDeployments.addresses.GovernorBravoDelegator_Proxy,
+    },
+  },
+  {
+    name: 'OmnichainGovernanceExecutor',
+    abi: OmnichainGovernanceExecutorAbi,
+    address: {
+      [ChainId.ETHEREUM]: venusGovernanceEthereumDeployments.addresses.OmnichainGovernanceExecutor,
+      [ChainId.SEPOLIA]: venusGovernanceSepoliaDeployments.addresses.OmnichainGovernanceExecutor,
+      [ChainId.OPBNB_MAINNET]:
+        venusGovernanceOpBnbMainnetDeployments.addresses.OmnichainGovernanceExecutor,
+      [ChainId.OPBNB_TESTNET]:
+        venusGovernanceOpBnbTestnetDeployments.addresses.OmnichainGovernanceExecutor,
+      [ChainId.ARBITRUM_SEPOLIA]:
+        venusGovernanceArbitrumSepoliaDeployments.addresses.OmnichainGovernanceExecutor,
+      [ChainId.ARBITRUM_ONE]:
+        venusGovernanceArbitrumOneDeployments.addresses.OmnichainGovernanceExecutor,
+      // TODO: uncomment below code when OmnichainGovernanceExecutor contract has been deployed on
+      // zkSync network
+      // [ChainId.ZKSYNC_SEPOLIA]:
+      // venusGovernanceZkSyncSepoliaDeployments.addresses.OmnichainGovernanceExecutor,
+      // [ChainId.ZKSYNC_MAINNET]:
+      // venusGovernanceZkSyncMainnetDeployments.addresses.OmnichainGovernanceExecutor,
     },
   },
   {

--- a/apps/evm/src/pages/Proposal/Commands/BscCommand/ActionButton/index.tsx
+++ b/apps/evm/src/pages/Proposal/Commands/BscCommand/ActionButton/index.tsx
@@ -83,7 +83,7 @@ export const ActionButton: React.FC<ActionButtonProps> = ({
     if (isExecutable) {
       const execute = async () => {
         try {
-          await executeProposal({ proposalId });
+          await executeProposal({ proposalId, chainId: governanceChain.id });
         } catch (error) {
           displayMutationError({ error });
         }

--- a/apps/evm/src/pages/Proposal/Commands/index.tsx
+++ b/apps/evm/src/pages/Proposal/Commands/index.tsx
@@ -63,6 +63,7 @@ export const Commands: React.FC<CommandsProps> = ({ proposal, ...otherProps }) =
         {proposal.remoteProposals.map(remoteProposal => (
           <NonBscCommand
             key={`non-bsc-command-${remoteProposal.chainId}-${remoteProposal.proposalId}`}
+            remoteProposalId={remoteProposal.remoteProposalId}
             chainId={remoteProposal.chainId}
             proposalActions={remoteProposal.proposalActions}
             state={remoteProposal.state}

--- a/apps/evm/src/pages/Proposal/ProposalSummary/index.tsx
+++ b/apps/evm/src/pages/Proposal/ProposalSummary/index.tsx
@@ -23,7 +23,7 @@ import { ChainExplorerLink } from 'containers/ChainExplorerLink';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { displayMutationError } from 'libs/errors';
 import { useTranslation } from 'libs/translations';
-import { useAccountAddress } from 'libs/wallet';
+import { governanceChain, useAccountAddress } from 'libs/wallet';
 import { ChainId, type Proposal, ProposalState, ProposalType } from 'types';
 import { areAddressesEqual } from 'utilities';
 
@@ -279,7 +279,7 @@ const ProposalSummary: React.FC<ProposalSummaryUiProps> = ({ className, proposal
   const { mutateAsync: queueProposal, isPending: isQueueProposalLoading } = useQueueProposal();
 
   const handleCancelProposal = () => cancelProposal({ proposalId });
-  const handleExecuteProposal = () => executeProposal({ proposalId });
+  const handleExecuteProposal = () => executeProposal({ proposalId, chainId: governanceChain.id });
   const handleQueueProposal = () => queueProposal({ proposalId });
 
   const { data: proposalThresholdData } = useGetProposalThreshold();

--- a/apps/evm/src/pages/Proposal/__tests__/__snapshots__/index.multichainGovernance.spec.tsx.snap
+++ b/apps/evm/src/pages/Proposal/__tests__/__snapshots__/index.multichainGovernance.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: +0 1`] = `"CommandsExecuted payloads0/1BNB testnetWaiting for the BNB chain payload to be executedPending20 Sep 2023 07:39 AMPending until 20 Sep 2023 07:47 AM"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 1 1`] = `"CommandsExecuted payloads0/1BNB testnetActive20 Sep 2023 07:47 AMQueueable at 20 Sep 2023 07:39 AM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 1 1`] = `"CommandsExecuted payloads0/1BNB testnetActive20 Sep 2023 07:47 AMQueueable at 20 Sep 2023 07:49 AM"`;
 
 exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 2 1`] = `"CommandsExecuted payloads0/1BNB testnetPayload execution cancelled by governance guardianCanceled"`;
 
@@ -10,26 +10,26 @@ exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC c
 
 exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 4 1`] = `"CommandsExecuted payloads0/1BNB testnetQueueQueue"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 5 1`] = `"CommandsExecuted payloads0/1BNB testnetWaiting for queueing period to endQueued20 Sep 2023 09:54 AMExecutable at 15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 5 1`] = `"CommandsExecuted payloads0/1BNB testnetWaiting for queueing period to endQueued20 Sep 2023 09:54 AMExecutable at 20 Sep 2023 07:49 AM"`;
 
 exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 5 2`] = `"CommandsExecuted payloads0/1BNB testnetExecuteExecute"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 6 1`] = `"CommandsExecuted payloads0/1BNB testnetExpired15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 6 1`] = `"CommandsExecuted payloads0/1BNB testnetExpired20 Sep 2023 07:49 AM"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 7 1`] = `"CommandsAll payloads executedBNB testnetExecuted15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders BSC command correctly. Proposal state: 7 1`] = `"CommandsAll payloads executedBNB testnetExecuted20 Sep 2023 07:49 AM"`;
 
 exports[`ProposalUi page - Feature enabled: multichainGovernance > renders description correctly 1`] = `"DescriptionThis vip implement diamond proxy for the comptroller to divide the comptroller logic into facets. The current implementation of the comptroller is exceeding the max limit of the contract size. To resolve this diamond proxy is implemented."`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: +0 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted15 Mar 2024 12:00 PMBNB testnetWaiting for the BNB chain payload to be executedPending"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: +0 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted20 Sep 2023 07:49 AMBNB testnetWaiting for the BNB chain payload to be executedPending"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 1 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted15 Mar 2024 12:00 PMBNB testnetWaiting for the bridge to propagate the transactionBridged15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 1 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted20 Sep 2023 07:49 AMBNB testnetWaiting for the bridge to propagate the transactionBridged20 Sep 2023 07:49 AM"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 2 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted15 Mar 2024 12:00 PMBNB testnetWaiting for queueing period to endQueued15 Mar 2024 12:00 PMExecutable at 15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 2 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted20 Sep 2023 07:49 AMBNB testnetWaiting for queueing period to endQueued20 Sep 2023 07:49 AMExecutable at 20 Sep 2023 07:49 AM"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 2 2`] = `"CommandsExecuted payloads1/2BNB testnetExecuted15 Mar 2024 12:00 PMBNB testnetConnect walletConnect wallet"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 2 2`] = `"CommandsExecuted payloads1/2BNB testnetExecuted20 Sep 2023 07:49 AMBNB testnetConnect walletConnect wallet"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 3 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted15 Mar 2024 12:00 PMBNB testnetPayload execution cancelled by governance guardianCanceled15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 3 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted20 Sep 2023 07:49 AMBNB testnetPayload execution cancelled by governance guardianCanceled20 Sep 2023 07:49 AM"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 4 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted15 Mar 2024 12:00 PMBNB testnetExpired15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 4 1`] = `"CommandsExecuted payloads1/2BNB testnetExecuted20 Sep 2023 07:49 AMBNB testnetExpired20 Sep 2023 07:49 AM"`;
 
-exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 5 1`] = `"CommandsAll payloads executedBNB testnetExecuted15 Mar 2024 12:00 PMBNB testnetExecuted15 Mar 2024 12:00 PM"`;
+exports[`ProposalUi page - Feature enabled: multichainGovernance > renders remote commands correctly. Remote proposal state: 5 1`] = `"CommandsAll payloads executedBNB testnetExecuted20 Sep 2023 07:49 AMBNB testnetExecuted20 Sep 2023 07:49 AM"`;

--- a/apps/evm/src/pages/Proposal/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Proposal/__tests__/index.spec.tsx
@@ -27,7 +27,7 @@ import { type UseIsFeatureEnabled, useIsFeatureEnabled } from 'hooks/useIsFeatur
 import useVote from 'hooks/useVote';
 import { VError } from 'libs/errors';
 import { en } from 'libs/translations';
-import { VoteSupport } from 'types';
+import { ChainId, VoteSupport } from 'types';
 
 import { REDIRECT_TEST_CONTENT } from 'components/Redirect/__mocks__';
 import Proposal from '..';
@@ -219,7 +219,11 @@ describe('Proposal page', () => {
     expect(castButton).toBeEnabled();
     fireEvent.click(castButton);
     await waitFor(() =>
-      expect(vote).toBeCalledWith({ proposalId: 97, voteReason: '', voteType: 1 }),
+      expect(vote).toHaveBeenCalledWith({
+        proposalId: activeProposal.proposalId,
+        voteReason: '',
+        voteType: 1,
+      }),
     );
   });
 
@@ -251,7 +255,11 @@ describe('Proposal page', () => {
     fireEvent.click(castButton);
 
     await waitFor(() =>
-      expect(vote).toBeCalledWith({ proposalId: 97, voteReason: comment, voteType: 0 }),
+      expect(vote).toHaveBeenCalledWith({
+        proposalId: activeProposal.proposalId,
+        voteReason: comment,
+        voteType: 0,
+      }),
     );
   });
 
@@ -278,7 +286,11 @@ describe('Proposal page', () => {
     expect(castButton).toBeEnabled();
     fireEvent.click(castButton);
     await waitFor(() =>
-      expect(vote).toBeCalledWith({ proposalId: 97, voteReason: '', voteType: 2 }),
+      expect(vote).toHaveBeenCalledWith({
+        proposalId: activeProposal.proposalId,
+        voteReason: '',
+        voteType: 2,
+      }),
     );
   });
 
@@ -315,7 +327,7 @@ describe('Proposal page', () => {
 
     fireEvent.click(cancelButton);
     await waitFor(() => expect(cancelButton).toBeEnabled());
-    expect(cancelProposal).toBeCalledWith({ proposalId: 97 });
+    expect(cancelProposal).toHaveBeenCalledWith({ proposalId: activeProposal.proposalId });
   });
 
   it('does not allow user to cancel if voting power of the proposer is greater than or equals threshold', async () => {
@@ -353,7 +365,7 @@ describe('Proposal page', () => {
     fireEvent.click(cancelButton);
 
     await waitFor(() => expect(cancelButton).toBeEnabled());
-    expect(cancelProposal).toBeCalledWith({ proposalId: 97 });
+    expect(cancelProposal).toHaveBeenCalledWith({ proposalId: activeProposal.proposalId });
   });
 
   it('user can queue succeeded proposal', async () => {
@@ -373,7 +385,9 @@ describe('Proposal page', () => {
     fireEvent.click(queueButton);
     await waitFor(() => expect(queueButton).toBeEnabled());
 
-    await waitFor(() => expect(queueProposal).toBeCalledWith({ proposalId: 94 }));
+    await waitFor(() =>
+      expect(queueProposal).toHaveBeenCalledWith({ proposalId: succeededProposal.proposalId }),
+    );
   });
 
   it('user can execute queued proposal', async () => {
@@ -392,6 +406,11 @@ describe('Proposal page', () => {
     fireEvent.click(executeButton);
     await waitFor(() => expect(executeButton).toBeEnabled());
 
-    await waitFor(() => expect(executeProposal).toBeCalledWith({ proposalId: 93 }));
+    await waitFor(() =>
+      expect(executeProposal).toHaveBeenCalledWith({
+        proposalId: queuedProposal.proposalId,
+        chainId: ChainId.BSC_TESTNET,
+      }),
+    );
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -7318,7 +7318,16 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
-"@venusprotocol/governance-contracts@2.3.0", "@venusprotocol/governance-contracts@^2.3.0":
+"@venusprotocol/governance-contracts@2.3.0-dev.3":
+  version "2.3.0-dev.3"
+  resolved "https://registry.yarnpkg.com/@venusprotocol/governance-contracts/-/governance-contracts-2.3.0-dev.3.tgz#6f22d60e6ec78758726cfebbd87e72847d9de5ab"
+  integrity sha512-VxvYTDTFQwYGr19ptDXPf18zYamYG6EIOppYAIgxzmXnget3GupWMzMIIbFarwkKBE+ewEDAr5IyXIFlox0Vhg==
+  dependencies:
+    "@venusprotocol/solidity-utilities" "2.0.0"
+    hardhat-deploy-ethers "^0.3.0-beta.13"
+    module-alias "^2.2.2"
+
+"@venusprotocol/governance-contracts@^2.3.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@venusprotocol/governance-contracts/-/governance-contracts-2.3.0.tgz#caa729f28a36df066ff02a799ac7394fae3ef996"
   integrity sha512-xMmjWUe8sMHEFcl1EGHMTD8UCSKtFCW6JsC6P9kELTSRTMrRFVAUWqhdv0wxHl3iHygyP9dpT+wR3/nUrAiA1w==
@@ -17975,7 +17984,7 @@ string-length@^6.0.0:
   dependencies:
     strip-ansi "^7.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -17991,15 +18000,6 @@ string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"


### PR DESCRIPTION
## Jira ticket(s)

VEN-2702

## Changes

- add `OmnichainGovernanceExecutor` contract record
- update `executeProposal` mutation function to support remote proposals
- wire up "Execute" button of remote proposals
