### PR TITLE
fix: max button on repay form

### DIFF
--- a/.changeset/tame-timers-leave.md
+++ b/.changeset/tame-timers-leave.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix initial value used when clicking on max button or repay form

--- a/apps/evm/src/pages/Market/Market/OperationForm/RepayForm/index.tsx
+++ b/apps/evm/src/pages/Market/Market/OperationForm/RepayForm/index.tsx
@@ -172,7 +172,6 @@ export const RepayFormUi: React.FC<RepayFormUiProps> = ({
   const handleRightMaxButtonClick = useCallback(() => {
     const updatedValues: Partial<FormValues> = {
       fixedRepayPercentage: undefined,
-      amountTokens: '',
     };
 
     if (asset.userBorrowBalanceTokens.isEqualTo(0)) {


### PR DESCRIPTION
## Changes

- do not set initial value when clicking on max button on repay form
