### PR TITLE
fix: format of USD values on landing page

### DIFF
--- a/apps/landing/src/api/utils.ts
+++ b/apps/landing/src/api/utils.ts
@@ -65,14 +65,12 @@ export const getMarketsToRender = (markets?: MarketMapped[]) => {
   return sortedMarkets.slice(0, 5).sort(sortBySupplyApy);
 };
 
-const addSpaceBeforeUSDSymbol = (string: string) => string.replace(/^(\D+)/, '$\u00a0');
-
 export const formatUsd = (value: number) => {
   const formattedValue = new Intl.NumberFormat('en-EN', {
     style: 'currency',
     currency: 'USD',
   }).format(value);
-  return addSpaceBeforeUSDSymbol(formattedValue);
+  return formattedValue;
 };
 
 export const nFormatter = (num: number, digits = 2) => {

--- a/apps/landing/src/components/Market/Market.tsx
+++ b/apps/landing/src/components/Market/Market.tsx
@@ -89,7 +89,7 @@ const Market: React.FC<IMarketProps> = ({ className }) => {
                 </div>
                 <div className={s.marketItemValuesWrapper}>
                   <p className={s.marketItemValue}>
-                    <span className={s.marketItemLabel}>Market size</span> ${' '}
+                    <span className={s.marketItemLabel}>Market size</span> $
                     {nFormatter(i.totalSupplyUsd)}
                   </p>
                   <p className={s.marketItemValue}>
@@ -97,7 +97,7 @@ const Market: React.FC<IMarketProps> = ({ className }) => {
                     {nFormatter(i.depositApy)}%
                   </p>
                   <p className={s.marketItemValue}>
-                    <span className={s.marketItemLabel}>Borrowed</span> ${' '}
+                    <span className={s.marketItemLabel}>Borrowed</span> $
                     {nFormatter(i.totalBorrowsUsd)}
                   </p>
                   <p className={s.marketItemValue}>


### PR DESCRIPTION
## Changes

- remove space between dollar sign and value when formatting dollar USD amount on landing page
