### PR TITLE
fix: do not attempt to retry when the gas estimation fails

### DIFF
--- a/.changeset/good-zebras-cry.md
+++ b/.changeset/good-zebras-cry.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+do not attempt to retry when the gas estimation fails

--- a/apps/evm/src/libs/wallet/hooks/useSendContractTransaction/index.tsx
+++ b/apps/evm/src/libs/wallet/hooks/useSendContractTransaction/index.tsx
@@ -11,6 +11,8 @@ import { VError, logError } from 'libs/errors';
 import { ZYFI_SPONSORED_PAYMASTER_ENDPOINT } from 'libs/wallet/constants';
 import type { ChainId, ContractTxData } from 'types';
 
+const GAS_ESTIMATION_FAILED_ERROR = 'Gas estimation failed';
+
 interface ZyFiSponsoredTxResponse {
   txData: {
     chainId: number;
@@ -92,7 +94,14 @@ export const useSendContractTransaction = <
       ]);
 
       if (!response.ok) {
-        logError(response);
+        const body = await response.json();
+        logError({ response, body });
+
+        // when receiving a gas estimation failed error, there is no need to show
+        // the resend paying gas modal, as it would also fail to estimate the gas cost
+        if (body?.error === GAS_ESTIMATION_FAILED_ERROR) {
+          throw new Error(GAS_ESTIMATION_FAILED_ERROR);
+        }
 
         throw new VError({
           type: 'unexpected',


### PR DESCRIPTION
## Jira ticket(s)

VEN-2896

## Changes

- If we try to resend a gasless TX that originally errored because the gas estimation failed, it would just fail again for the same reason. So in this case we can skip the resend paying gas modal
