### PR TITLE
feat: use custom account details modal

### DIFF
--- a/.changeset/silver-bears-explain.md
+++ b/.changeset/silver-bears-explain.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+use custom account details modal

--- a/apps/evm/package.json
+++ b/apps/evm/package.json
@@ -12,7 +12,7 @@
     "test": "TZ=UTC VITE_NETWORK=testnet vitest run",
     "test:regression": "reg-suit run",
     "clean": "rm -rf .turbo && rm -rf node_modules",
-    "lint": "yarn lint:styles && biome check .",
+    "lint": "yarn lint:styles && biome check . --diagnostic-level=error",
     "lint:styles": "stylelint 'src/**/*.{css,scss,ts,tsx,js,jsx}'",
     "tsc": "tsc --noEmit",
     "extract-translations": "yarn i18next",
@@ -157,15 +157,7 @@
     "whatwg-fetch": "^3.6.18"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   }
 }

--- a/apps/evm/src/containers/CopyAddressButton/index.tsx
+++ b/apps/evm/src/containers/CopyAddressButton/index.tsx
@@ -1,0 +1,32 @@
+import { Icon } from 'components';
+import useCopyToClipboard from 'hooks/useCopyToClipboard';
+import { useTranslation } from 'libs/translations';
+import { cn } from 'utilities';
+
+export interface CopyAddressButtonProps
+  extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'onClick'> {
+  address: string;
+}
+
+export const CopyAddressButton: React.FC<CopyAddressButtonProps> = ({
+  address,
+  className,
+  ...otherProps
+}) => {
+  const { t } = useTranslation();
+  const copyToClipboard = useCopyToClipboard(t('interactive.copy.walletAddress'));
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'text-blue hover:text-darkBlue active:text-darkBlue cursor-pointer transition-colors',
+        className,
+      )}
+      onClick={() => copyToClipboard(address)}
+      {...otherProps}
+    >
+      <Icon name="copy" className="h-4 w-4 text-inherit" />
+    </button>
+  );
+};

--- a/apps/evm/src/containers/Layout/ConnectButton/index.tsx
+++ b/apps/evm/src/containers/Layout/ConnectButton/index.tsx
@@ -1,9 +1,12 @@
 import { useGetPrimeToken } from 'clients/api';
-import { Button, type ButtonProps } from 'components';
+import { Button, type ButtonProps, Modal, SecondaryButton } from 'components';
 import { useTranslation } from 'libs/translations';
 import { useAccountAddress, useAuthModal } from 'libs/wallet';
 import { cn, truncateAddress } from 'utilities';
 
+import { CopyAddressButton } from 'containers/CopyAddressButton';
+import { useState } from 'react';
+import { useDisconnect } from 'wagmi';
 import { PrimeButton } from './PrimeButton';
 
 export interface ConnectButtonProps
@@ -23,9 +26,26 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
   variant = 'primary',
   ...otherProps
 }) => {
+  const { disconnect } = useDisconnect();
   const { accountAddress } = useAccountAddress();
   const { openAuthModal } = useAuthModal();
   const { t } = useTranslation();
+  const [isAccountModalOpen, setIsAccountModalOpen] = useState(false);
+  const openAccountModal = () => setIsAccountModalOpen(true);
+  const closeAccountModal = () => setIsAccountModalOpen(false);
+
+  const handleConnectButtonClick = () => {
+    if (accountAddress) {
+      openAccountModal();
+    } else {
+      openAuthModal();
+    }
+  };
+
+  const handleDisconnect = () => {
+    disconnect();
+    closeAccountModal();
+  };
 
   const { data: getPrimeTokenData, isLoading: isGetPrimeTokenLoading } = useGetPrimeToken({
     accountAddress,
@@ -36,31 +56,47 @@ export const ConnectButton: React.FC<ConnectButtonProps> = ({
     return null;
   }
 
-  if (accountAddress && isAccountPrime) {
-    return (
-      <PrimeButton
-        accountAddress={accountAddress}
-        onClick={openAuthModal}
-        className={cn(variant === 'secondary' && connectedAccountButtonClasses, className)}
-        {...otherProps}
-      />
-    );
-  }
-
   return (
-    <Button
-      variant={accountAddress ? 'secondary' : 'primary'}
-      onClick={openAuthModal}
-      className={cn(
-        className,
-        variant === 'secondary' && accountAddress && connectedAccountButtonClasses,
-        variant === 'secondary' &&
-          !accountAddress &&
-          'border-transparent bg-offWhite text-background hover:border-transparent hover:bg-grey active:bg-grey active:border-transparent',
+    <>
+      {accountAddress && isAccountPrime ? (
+        <PrimeButton
+          accountAddress={accountAddress}
+          onClick={handleConnectButtonClick}
+          className={cn(variant === 'secondary' && connectedAccountButtonClasses, className)}
+          {...otherProps}
+        />
+      ) : (
+        <Button
+          variant={accountAddress ? 'secondary' : 'primary'}
+          onClick={handleConnectButtonClick}
+          className={cn(
+            className,
+            variant === 'secondary' && accountAddress && connectedAccountButtonClasses,
+            variant === 'secondary' &&
+              !accountAddress &&
+              'border-transparent bg-offWhite text-background hover:border-transparent hover:bg-grey active:bg-grey active:border-transparent',
+          )}
+          {...otherProps}
+        >
+          {accountAddress ? <>{truncateAddress(accountAddress)}</> : t('connectButton.connect')}
+        </Button>
       )}
-      {...otherProps}
-    >
-      {accountAddress ? <>{truncateAddress(accountAddress)}</> : t('connectButton.title')}
-    </Button>
+
+      <Modal isOpen={isAccountModalOpen} handleClose={closeAccountModal}>
+        <div className="space-y-10">
+          {!!accountAddress && (
+            <div className="flex items-center space-x-2 break-all">
+              <span className="flex-1">{accountAddress}</span>
+
+              <CopyAddressButton className="shrink-0" address={accountAddress} />
+            </div>
+          )}
+
+          <SecondaryButton onClick={handleDisconnect} className="w-full">
+            {t('connectButton.disconnect')}
+          </SecondaryButton>
+        </div>
+      </Modal>
+    </>
   );
 };

--- a/apps/evm/src/containers/Layout/Header/TopBar/Breadcrumbs/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TopBar/Breadcrumbs/index.tsx
@@ -1,10 +1,10 @@
 import { useMemo } from 'react';
 import { type Params, matchPath, useLocation } from 'react-router-dom';
 
-import { EllipseAddress, Icon } from 'components';
+import { EllipseAddress } from 'components';
 import { Subdirectory, routes } from 'constants/routing';
+import { CopyAddressButton } from 'containers/CopyAddressButton';
 import { Link } from 'containers/Link';
-import useCopyToClipboard from 'hooks/useCopyToClipboard';
 import { useTranslation } from 'libs/translations';
 import { cn } from 'utilities';
 import PoolName from './PoolName';
@@ -18,7 +18,6 @@ export interface PathNode {
 export const Breadcrumbs: React.FC = () => {
   const { t } = useTranslation();
   const { pathname } = useLocation();
-  const copyToClipboard = useCopyToClipboard(t('interactive.copy.walletAddress'));
 
   const pathNodes = useMemo(() => {
     // Get active route
@@ -103,16 +102,7 @@ export const Breadcrumbs: React.FC = () => {
             <div className="inline-flex items-center gap-x-2">
               <EllipseAddress address={params.address || ''} ellipseBreakpoint="xxl" />
 
-              <button
-                type="button"
-                className="text-blue hover:text-darkBlue active:text-darkBlue cursor-pointer transition-colors"
-              >
-                <Icon
-                  name="copy"
-                  className="h-4 w-4 text-inherit"
-                  onClick={() => params.address && copyToClipboard(params.address)}
-                />
-              </button>
+              {!!params.address && <CopyAddressButton address={params.address} />}
             </div>
           );
           break;
@@ -154,7 +144,7 @@ export const Breadcrumbs: React.FC = () => {
           ]
         : acc;
     }, []);
-  }, [pathname, t, copyToClipboard]);
+  }, [pathname, t]);
 
   const pathNodeDom = useMemo(
     () =>

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -217,7 +217,8 @@
     }
   },
   "connectButton": {
-    "title": "Connect wallet"
+    "disconnect": "Disconnect",
+    "connect": "Connect wallet"
   },
   "connectWallet": {
     "connectButton": "Connect wallet"
@@ -284,13 +285,12 @@
     }
   },
   "gaslessTransactions": {
-    "gas": "Gas",
     "chainLabel": "Free",
     "errorModal": {
-      "title": "Gas-free transactions are not available at the moment",
+      "cancel": "Cancel",
       "description": "You can still send this transaction by paying for the gas yourself",
       "resendButtonLabel": "Resend with gas",
-      "cancel": "Cancel"
+      "title": "Gas-free transactions are not available at the moment"
     },
     "tooltip": "Transactions on this network are gas-free, with no fees required. More info <Link>here</Link>"
   },

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -7,7 +7,7 @@
     "start": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "lint": "yarn lint:styles && biome check .",
+    "lint": "yarn lint:styles && biome check .  --diagnostic-level=error",
     "lint:styles": "stylelint 'src/**/*.{css,scss,ts,tsx,js,jsx}'",
     "tsc": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules"
@@ -50,16 +50,8 @@
     "vite-tsconfig-paths": "^4.2.0"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   },
   "resolutions": {
     "postcss": "^8.4.8"


### PR DESCRIPTION
## Changes

- create `CopyAddressButton` container component
- replace ConnectKit modal with custom account details modal when wallet is connected
- update `lint` scripts to only output errors in console

