### PR TITLE
feat: show borrow and supply cap thresholds on Market page

### DIFF
--- a/.changeset/angry-otters-kick.md
+++ b/.changeset/angry-otters-kick.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+show borrow and supply cap thresholds on Market page

--- a/apps/evm/src/clients/api/queries/getXvsBridgeStatus/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getXvsBridgeStatus/__snapshots__/index.spec.ts.snap
@@ -8,12 +8,3 @@ exports[`getXvsBridgeStatus > returns the data describing the status of the XVS 
   "totalTransferredLast24HourUsd": "9.310366874",
 }
 `;
-
-exports[`getXvsBridgeStatus > returns the the data describing the status of the XVS bridge contract 1`] = `
-{
-  "dailyLimitResetTimestamp": "1705273290",
-  "maxDailyLimitUsd": "450",
-  "maxSingleTransactionLimitUsd": "9",
-  "totalTransferredLast24HourUsd": "9.310366874",
-}
-`;

--- a/apps/evm/src/components/ProgressCircle/index.stories.tsx
+++ b/apps/evm/src/components/ProgressCircle/index.stories.tsx
@@ -10,7 +10,15 @@ export default {
   decorators: [withCenterStory({ width: 600 })],
 } as ComponentMeta<typeof ProgressCircle>;
 
-export const HealthyProgressCircle = () => <ProgressCircle value={30} />;
-export const WarningProgressCircle = () => <ProgressCircle value={50} />;
-export const DangerProgressCircle = () => <ProgressCircle value={80} />;
-export const FullProgressCircle = () => <ProgressCircle value={100} />;
+export const HealthyProgressCircle = () => (
+  <ProgressCircle value={30} strokeWidthPx={3} sizePx={50} />
+);
+export const WarningProgressCircle = () => (
+  <ProgressCircle value={50} strokeWidthPx={3} sizePx={50} />
+);
+export const DangerProgressCircle = () => (
+  <ProgressCircle value={80} strokeWidthPx={3} sizePx={50} />
+);
+export const FullProgressCircle = () => (
+  <ProgressCircle value={100} strokeWidthPx={3} sizePx={50} />
+);

--- a/apps/evm/src/components/ProgressCircle/index.tsx
+++ b/apps/evm/src/components/ProgressCircle/index.tsx
@@ -5,61 +5,62 @@ import { cn } from 'utilities';
 
 export interface ProgressCircleProps extends React.HTMLAttributes<SVGElement> {
   value: number;
-  size?: 'sm' | 'md';
+  strokeWidthPx: number;
+  sizePx: number;
   fillColor?: string;
+  defs?: React.ReactNode;
 }
 
 export const ProgressCircle: React.FC<ProgressCircleProps> = ({
   value,
   fillColor,
-  size = 'md',
+  sizePx,
+  strokeWidthPx,
   className,
+  defs,
   ...otherProps
 }) => {
   const theme = useTheme();
 
-  const strokeWidthPx = size === 'sm' ? 3 : 4;
-  const sizePx = size === 'sm' ? 16 : 50;
-
   const { circumference, offset } = useMemo(() => {
     const radius = sizePx / 2;
-    const tmpRadius = size === 'sm' ? 6 : 18;
     const tmpCircumference = 2 * Math.PI * radius;
     const tmpOffset = tmpCircumference * ((100 - value) / 100);
 
     return {
-      radius: tmpRadius,
       circumference: tmpCircumference,
       offset: tmpOffset,
     };
-  }, [value, size, sizePx]);
+  }, [value, sizePx]);
 
   return (
     <svg
       width={sizePx}
       height={sizePx}
-      viewBox={`-${sizePx * 0.125} -${sizePx * 0.125} ${sizePx * 1.25} ${sizePx * 1.25}`}
       className={cn('rotate-90 scale-x-[-1]', className)}
       {...otherProps}
     >
+      {defs && <defs>{defs}</defs>}
+
       <circle
         stroke="rgba(255,255,255,0.12)"
         strokeWidth={strokeWidthPx}
         fill="transparent"
-        r={sizePx / 2}
-        cx={sizePx / 2}
-        cy={sizePx / 2}
+        r={sizePx / 2 - strokeWidthPx / 2}
+        cx="50%"
+        cy="50%"
       />
 
       <circle
         strokeDasharray={circumference}
         strokeDashoffset={offset}
+        strokeLinecap="round"
         stroke={fillColor || theme.palette.interactive.success}
         strokeWidth={strokeWidthPx}
         fill="transparent"
-        r={sizePx / 2}
-        cx={sizePx / 2}
-        cy={sizePx / 2}
+        r={sizePx / 2 - strokeWidthPx / 2}
+        cx="50%"
+        cy="50%"
       />
     </svg>
   );

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -371,6 +371,10 @@
     "previewTabLabel": "Preview"
   },
   "market": {
+    "borrowCapThreshold": {
+      "title": "Total borrowed",
+      "tooltip": "Maximum amount available to borrow is {{amountDollars}} ({{amountTokens}})"
+    },
     "borrowInfo": {
       "title": "Borrow info"
     },
@@ -384,7 +388,6 @@
     },
     "marketInfo": {
       "stats": {
-        "borrowCapLabel": "Borrow cap",
         "borrowerCountLabel": "# of borrowers",
         "collateralFactorLabel": "Collateral factor",
         "dailyBorrowingInterestsLabel": "Daily borrowing interests",
@@ -397,8 +400,7 @@
         "priceLabel": "Price",
         "reserveFactorLabel": "Reserve factor",
         "reserveTokensLabel": "Reserves",
-        "supplierCountLabel": "# of suppliers",
-        "supplyCapLabel": "Supply cap"
+        "supplierCountLabel": "# of suppliers"
       }
     },
     "periodOption": {
@@ -410,9 +412,11 @@
       "apy": "APY",
       "distributionApy": "Distribution APY",
       "liquidationPenalty": "Liquidation Penalty",
-      "liquidationThreshold": "Liquidation Threshold",
-      "totalBorrow": "Total borrow",
-      "totalSupply": "Total supply"
+      "liquidationThreshold": "Liquidation Threshold"
+    },
+    "supplyCapThreshold": {
+      "title": "Total supplied",
+      "tooltip": "Maximum amount available to supply is {{amountDollars}} ({{amountTokens}})"
     },
     "supplyInfo": {
       "title": "Supply info"

--- a/apps/evm/src/pages/Account/AccountBreakdown/PoolsBreakdown/PoolTagContent/index.tsx
+++ b/apps/evm/src/pages/Account/AccountBreakdown/PoolsBreakdown/PoolTagContent/index.tsx
@@ -36,7 +36,12 @@ export const PoolTagContent: React.FC<PoolTagContentProps> = ({ pool }) => {
           })}
           className="ml-1 inline-flex"
         >
-          <ProgressCircle value={borrowLimitUsedPercentage} fillColor={progressColor} size="sm" />
+          <ProgressCircle
+            value={borrowLimitUsedPercentage}
+            fillColor={progressColor}
+            strokeWidthPx={3}
+            sizePx={16}
+          />
         </Tooltip>
       )}
     </>

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`CorePoolMarket > fetches market details and displays them correctly 1`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`CorePoolMarket > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
+exports[`CorePoolMarket > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAPY0.05%Distribution APY0.11%"`;
 
-exports[`CorePoolMarket > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%"`;
+exports[`CorePoolMarket > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%"`;
 
-exports[`CorePoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MSupply cap> 100T XVSBorrow cap> 100T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;
+exports[`CorePoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexApyCharts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexApyCharts.spec.tsx.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 1`] = `"Supply info30D6M1YSupply APYTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
+exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 1`] = `"Supply info30D6M1Y0%Total supplied> $100T / > $100T> 100T / > 100T XVSAPY0.05%Distribution APY0.11%Supply APY"`;
 
-exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1YBorrow APYTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%"`;
+exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1Y0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%Borrow APY"`;
 
 exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MSupply cap> 100T XVSBorrow cap> 100T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;
+exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 1`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
+exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAPY0.05%Distribution APY0.11%"`;
 
-exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
-exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Supply cap> 100T XVSBorrow cap> 100T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;
+exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Daily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/index.spec.tsx
@@ -57,10 +57,10 @@ describe('CorePoolMarket', () => {
       routePath: '/:vTokenAddress',
     });
 
+    await waitFor(() => expect(getByTestId(TEST_IDS.interestRateModel)).toBeInTheDocument());
+
     // Check interest rate model displays correctly
-    await waitFor(() =>
-      expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot(),
-    );
+    expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot();
     // Check supply info displays correctly
     expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot();
     // Check borrow info displays correctly

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/indexApyCharts.spec.tsx
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/indexApyCharts.spec.tsx
@@ -61,8 +61,10 @@ describe('CorePoolMarket - Feature flag enabled: apyCharts', () => {
       routePath: '/:vTokenAddress',
     });
 
+    await waitFor(() => expect(getByTestId(TEST_IDS.supplyInfo)).toBeInTheDocument());
+
     // Check supply info displays correctly
-    await waitFor(() => expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot());
+    expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot();
     // Check borrow info displays correctly
     expect(getByTestId(TEST_IDS.borrowInfo).textContent).toMatchSnapshot();
     // Check interest rate model displays correctly

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/indexMarketParticipantCounts.spec.tsx
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/indexMarketParticipantCounts.spec.tsx
@@ -36,10 +36,10 @@ describe('CorePoolMarket - Feature flag enabled: marketParticipantCounts', () =>
       routePath: '/:vTokenAddress',
     });
 
+    await waitFor(() => expect(getByTestId(TEST_IDS.interestRateModel)).toBeInTheDocument());
+
     // Check interest rate model displays correctly
-    await waitFor(() =>
-      expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot(),
-    );
+    expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot();
     // Check supply info displays correctly
     expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot();
     // Check borrow info displays correctly

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`IsolatedPoolMarket > fetches market details and displays them correctly 1`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`IsolatedPoolMarket > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
+exports[`IsolatedPoolMarket > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAPY0.05%Distribution APY0.11%"`;
 
-exports[`IsolatedPoolMarket > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
-exports[`IsolatedPoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MSupply cap> 100T XVSBorrow cap> 100T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;
+exports[`IsolatedPoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketHistory.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketHistory.spec.tsx.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 1`] = `"Supply info30D6M1YSupply APYTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 1`] = `"Supply info30D6M1Y0%Total supplied> $100T / > $100T> 100T / > 100T XVSAPY0.05%Distribution APY0.11%Supply APY"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1YBorrow APYTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1Y0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-Borrow APY"`;
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MSupply cap> 100T XVSBorrow cap> 100T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 1`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply infoTotal supply$2.78MAPY0.05%Distribution APY0.11%"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAPY0.05%Distribution APY0.11%"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow infoTotal borrow$709.25KAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAPY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Supply cap> 100T XVSBorrow cap> 100T XVSDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Daily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/index.spec.tsx
@@ -39,10 +39,10 @@ describe('IsolatedPoolMarket', () => {
       routePath: '/:vTokenAddress/:poolComptrollerAddress',
     });
 
+    await waitFor(() => expect(getByTestId(TEST_IDS.interestRateModel)).toBeInTheDocument());
+
     // Check interest rate model displays correctly
-    await waitFor(() =>
-      expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot(),
-    );
+    expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot();
     // Check supply info displays correctly
     expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot();
     // Check borrow info displays correctly

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/indexMarketHistory.spec.tsx
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/indexMarketHistory.spec.tsx
@@ -49,8 +49,10 @@ describe('IsolatedPoolMarket - Feature flag enabled: marketHistory', () => {
       routePath: '/:vTokenAddress/:poolComptrollerAddress',
     });
 
+    await waitFor(() => expect(getByTestId(TEST_IDS.supplyInfo)).toBeInTheDocument());
+
     // Check supply info displays correctly
-    await waitFor(() => expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot());
+    expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot();
     // Check borrow info displays correctly
     expect(getByTestId(TEST_IDS.borrowInfo).textContent).toMatchSnapshot();
     // Check interest rate model displays correctly

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/indexMarketParticipantCounts.spec.tsx
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/indexMarketParticipantCounts.spec.tsx
@@ -44,10 +44,10 @@ describe('IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts', (
       routePath: '/:vTokenAddress/:poolComptrollerAddress',
     });
 
+    await waitFor(() => expect(getByTestId(TEST_IDS.interestRateModel)).toBeInTheDocument());
+
     // Check interest rate model displays correctly
-    await waitFor(() =>
-      expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot(),
-    );
+    expect(getByTestId(TEST_IDS.interestRateModel).textContent).toMatchSnapshot();
     // Check supply info displays correctly
     expect(getByTestId(TEST_IDS.supplyInfo).textContent).toMatchSnapshot();
     // Check borrow info displays correctly

--- a/apps/evm/src/pages/Market/Market/MarketCard/index.tsx
+++ b/apps/evm/src/pages/Market/Market/MarketCard/index.tsx
@@ -10,7 +10,8 @@ export interface Legend {
 
 export interface MarketCardProps {
   title: string;
-  rightLabel?: string | React.ReactNode;
+  topContent?: React.ReactNode;
+  rightContent?: React.ReactNode;
   legends?: Legend[];
   stats?: Stat[];
   className?: string;
@@ -21,44 +22,29 @@ export interface MarketCardProps {
 export const MarketCard: React.FC<MarketCardProps> = ({
   children,
   title,
-  rightLabel,
+  topContent,
+  rightContent,
   legends = [],
   stats = [],
   className,
   testId,
 }) => (
-  <Card className={cn(className, 'space-y-8')} data-testid={testId}>
-    <div className="space-y-6">
+  <Card className={cn(className, 'space-y-5 md:space-y-8')} data-testid={testId}>
+    <div className="space-y-5 md:space-y-6">
       <div
         className={cn(
           'space-y-6',
-          !rightLabel && 'lg:space-y-0 lg:flex lg:items-center lg:justify-between',
+          !rightContent && 'lg:space-y-0 lg:flex lg:items-center lg:justify-between',
         )}
       >
         <div className="flex items-center justify-between">
           <h4 className="mr-4 text-lg md:mb-0">{title}</h4>
 
-          {!!rightLabel && <div>{rightLabel}</div>}
+          {!!rightContent && <div>{rightContent}</div>}
         </div>
-
-        {legends.length > 0 && (
-          <div className="flex items-center space-x-6">
-            {legends.map(legend => (
-              <div className="flex items-center" key={`card-${title}-legend-${legend.label}`}>
-                <div
-                  className={cn('mr-1 h-2 w-2 shrink-0 rounded-full', {
-                    'bg-red': legend.color === 'red',
-                    'bg-blue': legend.color === 'blue',
-                    'bg-green': legend.color === 'green',
-                  })}
-                />
-
-                <p className="text-sm">{legend.label}</p>
-              </div>
-            ))}
-          </div>
-        )}
       </div>
+
+      {topContent}
 
       {stats.length > 0 && (
         <div className="flex space-x-6 -mx-4 px-4 sm:-mx-6 sm:px-6 lg:mx-0 lg:px-0 overflow-x-auto scrollbar-hidden text-nowrap lg:text-wrap">
@@ -70,6 +56,24 @@ export const MarketCard: React.FC<MarketCardProps> = ({
               <p className="text-grey mb-1 text-sm">{stat.label}</p>
 
               <p className="text-sm font-semibold sm:text-lg">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {legends.length > 0 && (
+        <div className="flex items-center space-x-6">
+          {legends.map(legend => (
+            <div className="flex items-center" key={`card-${title}-legend-${legend.label}`}>
+              <div
+                className={cn('mr-1 h-2 w-2 shrink-0 rounded-full', {
+                  'bg-red': legend.color === 'red',
+                  'bg-blue': legend.color === 'blue',
+                  'bg-green': legend.color === 'green',
+                })}
+              />
+
+              <p className="text-sm">{legend.label}</p>
             </div>
           ))}
         </div>

--- a/apps/evm/src/pages/Market/Market/MarketHistory/Card/CapThreshold/index.tsx
+++ b/apps/evm/src/pages/Market/Market/MarketHistory/Card/CapThreshold/index.tsx
@@ -1,0 +1,150 @@
+import BigNumber from 'bignumber.js';
+import { ProgressCircle, Tooltip } from 'components';
+import { useTranslation } from 'libs/translations';
+import { useMemo } from 'react';
+import { theme } from 'theme';
+import type { Token } from 'types';
+
+import {
+  formatCentsToReadableValue,
+  formatPercentageToReadableValue,
+  formatTokensToReadableValue,
+} from 'utilities';
+
+const THRESHOLD_GRADIENT_ID = 'cap-threshold-gradient';
+
+export interface CapThresholdProps {
+  token: Token;
+  type: 'supply' | 'borrow';
+  tokenPriceCents: BigNumber;
+  capTokens: BigNumber;
+  balanceTokens: BigNumber;
+}
+
+export const CapThreshold: React.FC<CapThresholdProps> = ({
+  type,
+  tokenPriceCents,
+  capTokens,
+  balanceTokens,
+  token,
+}) => {
+  const { t } = useTranslation();
+
+  const {
+    readableBalanceDollars,
+    readableBalanceTokens,
+    readableCapDollars,
+    readableCapTokens,
+    readableDeltaDollars,
+    readableDeltaTokens,
+    readableThresholdPercentage,
+    thresholdPercentage,
+  } = useMemo(() => {
+    const tmpBalanceCents = balanceTokens.multipliedBy(tokenPriceCents);
+    const tmpCapCents = capTokens.multipliedBy(tokenPriceCents);
+
+    const tmpReadableBalanceDollars = formatCentsToReadableValue({
+      value: tmpBalanceCents,
+    });
+
+    const tmpReadableBalanceTokens = formatTokensToReadableValue({
+      value: balanceTokens,
+      token,
+      addSymbol: false,
+    });
+
+    const tmpReadableCapDollars = formatCentsToReadableValue({
+      value: tmpCapCents,
+    });
+
+    const tmpReadableCapTokens = formatTokensToReadableValue({
+      value: capTokens,
+      token,
+    });
+
+    const tmpReadableDeltaDollars = formatCentsToReadableValue({
+      value: tmpCapCents.minus(tmpBalanceCents),
+    });
+
+    const tmpReadableDeltaTokens = formatTokensToReadableValue({
+      value: capTokens.isEqualTo(0) ? new BigNumber(0) : capTokens.minus(balanceTokens),
+      token,
+    });
+
+    const thresholdPercentage = capTokens.isEqualTo(0)
+      ? 100
+      : balanceTokens.multipliedBy(100).div(capTokens).toNumber();
+
+    const tmpReadableThresholdPercentage = formatPercentageToReadableValue(thresholdPercentage);
+
+    return {
+      readableBalanceDollars: tmpReadableBalanceDollars,
+      readableBalanceTokens: tmpReadableBalanceTokens,
+      readableCapDollars: tmpReadableCapDollars,
+      readableCapTokens: tmpReadableCapTokens,
+      readableDeltaDollars: tmpReadableDeltaDollars,
+      readableDeltaTokens: tmpReadableDeltaTokens,
+      readableThresholdPercentage: tmpReadableThresholdPercentage,
+      thresholdPercentage,
+    };
+  }, [balanceTokens, capTokens, tokenPriceCents, token]);
+
+  return (
+    <div className="flex items-center space-x-4">
+      <Tooltip
+        title={
+          type === 'supply'
+            ? t('market.supplyCapThreshold.tooltip', {
+                amountDollars: readableDeltaDollars,
+                amountTokens: readableDeltaTokens,
+              })
+            : t('market.borrowCapThreshold.tooltip', {
+                amountDollars: readableDeltaDollars,
+                amountTokens: readableDeltaTokens,
+              })
+        }
+      >
+        <div className="relative flex items-center justify-center w-20 h-20">
+          <ProgressCircle
+            value={thresholdPercentage}
+            sizePx={80}
+            strokeWidthPx={5}
+            className="absolute inset"
+            fillColor={`url(#${THRESHOLD_GRADIENT_ID})`}
+            defs={
+              <linearGradient
+                id={THRESHOLD_GRADIENT_ID}
+                x1="68.5998"
+                y1="55.4944"
+                x2="-13.4919"
+                y2="6.11727"
+                gradientUnits="userSpaceOnUse"
+              >
+                <stop stop-color={theme.colors.blue} />
+                <stop offset="1" stop-color="#5CFFA2" />
+              </linearGradient>
+            }
+          />
+
+          <p className="text-sm text-center font-bold">{readableThresholdPercentage}</p>
+        </div>
+      </Tooltip>
+
+      <div>
+        <p className="text-grey mb-1 text-sm">
+          {type === 'supply'
+            ? t('market.supplyCapThreshold.title')
+            : t('market.borrowCapThreshold.title')}
+        </p>
+
+        <p className="text-sm font-semibold sm:text-lg">
+          {readableBalanceDollars} / {readableCapDollars}
+        </p>
+
+        <p className="text-grey text-xs">
+          {readableBalanceTokens} / {readableCapTokens}
+        </p>
+      </div>
+    </div>
+  );
+};

--- a/apps/evm/src/pages/Market/Market/MarketHistory/Card/index.tsx
+++ b/apps/evm/src/pages/Market/Market/MarketHistory/Card/index.tsx
@@ -4,15 +4,12 @@ import { ButtonGroup, Spinner } from 'components';
 import { ApyChart, type ApyChartProps } from 'components/charts/ApyChart';
 import { useTranslation } from 'libs/translations';
 import type { Asset } from 'types';
-import {
-  formatCentsToReadableValue,
-  formatPercentageToReadableValue,
-  getCombinedDistributionApys,
-} from 'utilities';
+import { formatPercentageToReadableValue, getCombinedDistributionApys } from 'utilities';
 
 import { type MarketHistoryPeriodType, useGetPoolLiquidationIncentive } from 'clients/api';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { MarketCard, type MarketCardProps } from '../../MarketCard';
+import { CapThreshold } from './CapThreshold';
 import { useGetLiquidationThresholdPercentage } from './useGetLiquidationThresholdPercentage';
 
 export interface CardProps {
@@ -89,12 +86,6 @@ export const Card: React.FC<CardProps> = ({
 
     const tmpStats: MarketCardProps['stats'] = [
       {
-        label: type === 'supply' ? t('market.stats.totalSupply') : t('market.stats.totalBorrow'),
-        value: formatCentsToReadableValue({
-          value: type === 'supply' ? asset.supplyBalanceCents : asset.borrowBalanceCents,
-        }),
-      },
-      {
         label: t('market.stats.apy'),
         value: formatPercentageToReadableValue(
           type === 'supply' ? asset.supplyApyPercentage : asset.borrowApyPercentage,
@@ -150,7 +141,16 @@ export const Card: React.FC<CardProps> = ({
       title={type === 'supply' ? t('market.supplyInfo.title') : t('market.borrowInfo.title')}
       stats={stats}
       legends={isApyChartsFeatureEnabled ? legends : undefined}
-      rightLabel={
+      topContent={
+        <CapThreshold
+          type={type}
+          tokenPriceCents={asset.tokenPriceCents}
+          capTokens={type === 'supply' ? asset.supplyCapTokens : asset.borrowCapTokens}
+          balanceTokens={type === 'supply' ? asset.supplyBalanceTokens : asset.borrowBalanceTokens}
+          token={asset.vToken.underlyingToken}
+        />
+      }
+      rightContent={
         isApyChartsFeatureEnabled ? (
           <ButtonGroup
             buttonLabels={periodOptions.map(p => p.label)}

--- a/apps/evm/src/pages/Market/Market/MarketInfo/index.tsx
+++ b/apps/evm/src/pages/Market/Market/MarketInfo/index.tsx
@@ -126,20 +126,6 @@ const MarketInfo: React.FC<MarketInfoProps> = ({ asset }) => {
       },
       ...participantCountRows,
       {
-        label: t('market.marketInfo.stats.supplyCapLabel'),
-        value: formatTokensToReadableValue({
-          value: asset.supplyCapTokens,
-          token: asset.vToken.underlyingToken,
-        }),
-      },
-      {
-        label: t('market.marketInfo.stats.borrowCapLabel'),
-        value: formatTokensToReadableValue({
-          value: asset.borrowCapTokens,
-          token: asset.vToken.underlyingToken,
-        }),
-      },
-      {
         label: t('market.marketInfo.stats.dailySupplyingInterestsLabel'),
         value: formatCentsToReadableValue({
           value: dailySupplyInterestsCents,

--- a/apps/evm/src/pages/Proposal/Commands/Progress/index.tsx
+++ b/apps/evm/src/pages/Proposal/Commands/Progress/index.tsx
@@ -29,6 +29,8 @@ export const Progress: React.FC<ProgressProps> = ({
       ) : (
         <div className="relative ml-3 w-12 h-12 flex items-center justify-center">
           <ProgressCircle
+            strokeWidthPx={4}
+            sizePx={50}
             className="absolute inset"
             value={(successfulPayloadsCount * 100) / totalPayloadsCount}
           />

--- a/apps/landing/package.json
+++ b/apps/landing/package.json
@@ -7,7 +7,7 @@
     "start": "vite",
     "build": "vite build",
     "serve": "vite preview",
-    "lint": "yarn lint:styles && biome check .  --diagnostic-level=error",
+    "lint": "yarn lint:styles && biome check . --diagnostic-level=error",
     "lint:styles": "stylelint 'src/**/*.{css,scss,ts,tsx,js,jsx}'",
     "tsc": "tsc --noEmit",
     "clean": "rm -rf .turbo && rm -rf node_modules"
@@ -50,16 +50,8 @@
     "vite-tsconfig-paths": "^4.2.0"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   },
   "resolutions": {
     "postcss": "^8.4.8"


### PR DESCRIPTION
## Jira ticket(s)

VEN-2894

## Changes

- fix viewbox issues on `ProgressCircle` component
- update `ProgressCircle` props to offer more modularity with sizes and colors
- show borrow and supply cap thresholds on Market page
