### PR TITLE
refactor: use env variable to determine environment

### DIFF
--- a/.changeset/hot-walls-nail.md
+++ b/.changeset/hot-walls-nail.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+use env variable to determine environment

--- a/apps/evm/src/config/index.ts
+++ b/apps/evm/src/config/index.ts
@@ -1,6 +1,5 @@
 import { apiUrls } from 'constants/api';
 import { CHAIN_METADATA } from 'constants/chainMetadata';
-import { productionHosts } from 'constants/production';
 import { ChainId, type Environment, type Network } from 'types';
 import { extractEnumValues } from 'utilities/extractEnumValues';
 
@@ -27,16 +26,7 @@ export interface Config {
   zyFiApiKey: string;
 }
 
-let environment: Environment = 'preview';
-
-if (ENV_VARIABLES.VITE_ENV) {
-  environment = ENV_VARIABLES.VITE_ENV;
-} else if (typeof window !== 'undefined' && productionHosts.includes(window.location.host)) {
-  environment = 'production';
-} else if (import.meta.env.DEV) {
-  environment = 'local';
-}
-
+const environment: Environment = ENV_VARIABLES.VITE_ENV || 'preview';
 const network: Network = ENV_VARIABLES.VITE_NETWORK || 'mainnet';
 
 const chainIds = extractEnumValues(ChainId);

--- a/apps/evm/src/constants/production.ts
+++ b/apps/evm/src/constants/production.ts
@@ -1,3 +1,1 @@
 export const MAIN_PRODUCTION_HOST = 'app.venus.io';
-export const ALT_PRODUCTION_HOST = 'app-alt.venus.io';
-export const productionHosts = [MAIN_PRODUCTION_HOST, ALT_PRODUCTION_HOST];


### PR DESCRIPTION
## Changes

- use `VITE_ENV` env variable to determine environment
