### PR TITLE
refactor: prevent sending errors from old releases to Sentry

### DIFF
--- a/.changeset/orange-poems-beam.md
+++ b/.changeset/orange-poems-beam.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+Prevent sending errors from old releases

--- a/apps/evm/package.json
+++ b/apps/evm/package.json
@@ -9,7 +9,7 @@
     "start": "vite",
     "build": "NODE_OPTIONS=\"--max-old-space-size=16384\" && vite build",
     "serve": "vite preview",
-    "test": "TZ=UTC VITE_NETWORK=testnet vitest run",
+    "test": "TZ=UTC VITE_NETWORK=testnet VITE_ENV=ci vitest run",
     "test:regression": "reg-suit run",
     "clean": "rm -rf .turbo && rm -rf node_modules",
     "lint": "yarn lint:styles && biome check . --diagnostic-level=error",
@@ -157,15 +157,7 @@
     "whatwg-fetch": "^3.6.18"
   },
   "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
+    "production": [">0.2%", "not dead", "not op_mini all"],
+    "development": ["last 1 chrome version", "last 1 firefox version", "last 1 safari version"]
   }
 }

--- a/apps/evm/src/App/index.tsx
+++ b/apps/evm/src/App/index.tsx
@@ -33,10 +33,10 @@ const App = () => (
       )
     }
 
-    <ErrorBoundary>
-      <HashRouter>
-        <MuiThemeProvider>
-          <QueryClientProvider client={queryClient}>
+    <HashRouter>
+      <MuiThemeProvider>
+        <QueryClientProvider client={queryClient}>
+          <ErrorBoundary>
             <Web3Wrapper>
               <AnalyticProvider>
                 <Routes />
@@ -60,10 +60,10 @@ const App = () => (
                 <SentryErrorInfo />
               </AnalyticProvider>
             </Web3Wrapper>
-          </QueryClientProvider>
-        </MuiThemeProvider>
-      </HashRouter>
-    </ErrorBoundary>
+          </ErrorBoundary>
+        </QueryClientProvider>
+      </MuiThemeProvider>
+    </HashRouter>
   </>
 );
 

--- a/apps/evm/src/libs/errors/logError.ts
+++ b/apps/evm/src/libs/errors/logError.ts
@@ -3,8 +3,8 @@ import * as Sentry from '@sentry/react';
 import config from 'config';
 
 export const logError = (error: string | unknown) => {
-  // Only send errors to Sentry in hosted environments
-  if (config.environment !== 'preview' && config.environment !== 'production') {
+  // Only send errors to Sentry in production
+  if (config.environment !== 'production') {
     console.error(`[Logger]: ${error}`);
     return;
   }


### PR DESCRIPTION
## Jira ticket(s)

VEN-2948

## Changes

- prevent sending errors from old releases to Sentry
