### PR TITLE
feat: add indicator on proposals with remote commands awaiting execution

### DIFF
--- a/.changeset/fifty-readers-type.md
+++ b/.changeset/fifty-readers-type.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+add indicator on proposals with remote commands awaiting execution

--- a/apps/evm/src/hooks/useIsProposalExecutable/index.tsx
+++ b/apps/evm/src/hooks/useIsProposalExecutable/index.tsx
@@ -1,6 +1,6 @@
-import { isBefore } from 'date-fns/isBefore';
 import { useNow } from 'hooks/useNow';
 import { useMemo } from 'react';
+import { isProposalExecutable } from 'utilities/isProposalExecutable';
 
 export type UseIsProposalExecutableProps = {
   executionEtaDate?: Date;
@@ -14,7 +14,12 @@ export const useIsProposalExecutable = ({
   const now = useNow();
 
   const isExecutable = useMemo(
-    () => isQueued && !!(executionEtaDate && isBefore(executionEtaDate, now)),
+    () =>
+      isProposalExecutable({
+        executionEtaDate,
+        isQueued,
+        now,
+      }),
     [executionEtaDate, isQueued, now],
   );
 

--- a/apps/evm/src/pages/Governance/ProposalList/GovernanceProposal/index.tsx
+++ b/apps/evm/src/pages/Governance/ProposalList/GovernanceProposal/index.tsx
@@ -5,14 +5,7 @@ import { useMemo } from 'react';
 import { ActiveVotingProgress, Countdown, ProposalTypeChip } from 'components';
 import { routes } from 'constants/routing';
 import { useTranslation } from 'libs/translations';
-import {
-  type Proposal,
-  ProposalState,
-  ProposalType,
-  RemoteProposalState,
-  type Token,
-  VoteSupport,
-} from 'types';
+import { type Proposal, ProposalState, ProposalType, type Token, VoteSupport } from 'types';
 
 import { ProposalCard } from 'containers/ProposalCard';
 import { useGetToken } from 'libs/tokens';
@@ -102,20 +95,7 @@ const GovernanceProposalUi: React.FC<GovernanceProposalProps> = ({
       );
     }
 
-    const totalPayloadsCount = 1 + remoteProposals.length; // BSC proposal + remote proposals
-    const executedPayloadsCount =
-      (state === ProposalState.Executed ? 1 : 0) +
-      remoteProposals.filter(
-        remoteProposal => remoteProposal.state === RemoteProposalState.Executed,
-      ).length;
-
-    return (
-      <Status
-        state={state}
-        totalPayloadsCount={totalPayloadsCount}
-        executedPayloadsCount={executedPayloadsCount}
-      />
-    );
+    return <Status state={state} remoteProposals={remoteProposals} />;
   }, [state, remoteProposals, forVotesMantissa, againstVotesMantissa, abstainedVotesMantissa, xvs]);
 
   return (

--- a/apps/evm/src/pages/Proposal/Commands/BscCommand/ActionButton/index.tsx
+++ b/apps/evm/src/pages/Proposal/Commands/BscCommand/ActionButton/index.tsx
@@ -2,6 +2,7 @@ import { useCancelProposal, useExecuteProposal, useQueueProposal } from 'clients
 import { Button } from 'components';
 import type { ConnectWalletProps } from 'containers/ConnectWallet';
 import { ConnectWallet } from 'containers/ConnectWallet';
+import { useIsProposalExecutable } from 'hooks/useIsProposalExecutable';
 import { handleError } from 'libs/errors';
 import { useTranslation } from 'libs/translations';
 import { governanceChain, useAccountAddress } from 'libs/wallet';
@@ -9,7 +10,6 @@ import { useMemo } from 'react';
 import { ProposalState } from 'types';
 import { cn } from 'utilities';
 import { useIsProposalCancelableByUser } from '../../useIsProposalCancelableByUser';
-import { useIsProposalExecutable } from '../../useIsProposalExecutable';
 
 export interface ActionButtonProps extends Omit<ConnectWalletProps, 'onClick'> {
   proposalId: number;

--- a/apps/evm/src/pages/Proposal/Commands/BscCommand/index.tsx
+++ b/apps/evm/src/pages/Proposal/Commands/BscCommand/index.tsx
@@ -1,4 +1,5 @@
 import { chainMetadata } from '@venusprotocol/chains';
+import { useIsProposalExecutable } from 'hooks/useIsProposalExecutable';
 import { useTranslation } from 'libs/translations';
 import { governanceChain, useChainId } from 'libs/wallet';
 import { useAccountAddress } from 'libs/wallet';
@@ -7,7 +8,6 @@ import { type Proposal, ProposalState } from 'types';
 import { Command } from '../Command';
 import { Description } from '../Description';
 import { useIsProposalCancelableByUser } from '../useIsProposalCancelableByUser';
-import { useIsProposalExecutable } from '../useIsProposalExecutable';
 import { ActionButton } from './ActionButton';
 import { CurrentStep } from './CurrentStep';
 

--- a/apps/evm/src/pages/Proposal/Commands/NonBscCommand/index.tsx
+++ b/apps/evm/src/pages/Proposal/Commands/NonBscCommand/index.tsx
@@ -2,8 +2,7 @@ import { chainMetadata } from '@venusprotocol/chains';
 import { useExecuteProposal } from 'clients/api';
 import { Button } from 'components';
 import { ConnectWallet } from 'containers/ConnectWallet';
-import { isAfter } from 'date-fns/isAfter';
-import { useNow } from 'hooks/useNow';
+import { useIsProposalExecutable } from 'hooks/useIsProposalExecutable';
 import { VError, handleError } from 'libs/errors';
 import { useTranslation } from 'libs/translations';
 import { governanceChain, useChainId } from 'libs/wallet';
@@ -11,7 +10,6 @@ import { useMemo } from 'react';
 import { type RemoteProposal, RemoteProposalState } from 'types';
 import { Command } from '../Command';
 import { Description } from '../Description';
-import { useIsProposalExecutable } from '../useIsProposalExecutable';
 import { CurrentStep } from './CurrentStep';
 
 const governanceChainMetadata = chainMetadata[governanceChain.id];
@@ -27,7 +25,6 @@ export const NonBscCommand: React.FC<NonBscCommand> = ({
   ...otherProps
 }) => {
   const { t } = useTranslation();
-  const now = useNow();
   const { chainId: currentChainId } = useChainId();
 
   const chain = chainMetadata[remoteProposal.chainId];
@@ -67,7 +64,7 @@ export const NonBscCommand: React.FC<NonBscCommand> = ({
       case RemoteProposalState.Canceled:
         return t('voteProposalUi.command.description.canceled');
       case RemoteProposalState.Queued:
-        if (!remoteProposal.executionEtaDate || isAfter(remoteProposal.executionEtaDate, now)) {
+        if (!isExecutable) {
           return t('voteProposalUi.command.description.waitingToBeExecutable');
         }
 
@@ -78,7 +75,7 @@ export const NonBscCommand: React.FC<NonBscCommand> = ({
         }
         break;
     }
-  }, [t, remoteProposal.state, remoteProposal.executionEtaDate, now, chain, isOnWrongChain]);
+  }, [t, remoteProposal.state, chain, isOnWrongChain, isExecutable]);
 
   return (
     <Command

--- a/apps/evm/src/utilities/index.ts
+++ b/apps/evm/src/utilities/index.ts
@@ -55,3 +55,4 @@ export * from './getProposalType';
 export * from './getProposalState';
 export * from './getUserVoteSupport';
 export * from './getProposalStateLabel';
+export * from './isProposalExecutable';

--- a/apps/evm/src/utilities/isProposalExecutable/index.ts
+++ b/apps/evm/src/utilities/isProposalExecutable/index.ts
@@ -1,0 +1,14 @@
+import { isBefore } from 'date-fns/isBefore';
+
+export type IsProposalExecutableInput = {
+  now: Date;
+  isQueued: boolean;
+  executionEtaDate?: Date;
+};
+
+export const isProposalExecutable = ({
+  now,
+  isQueued,
+  executionEtaDate,
+}: IsProposalExecutableInput) =>
+  isQueued && !!(executionEtaDate && isBefore(executionEtaDate, now));


### PR DESCRIPTION
## Changes

- create reusable `isProposalExecutable` utility function
- create reusable `useIsProposalExecutable` hook
- display indicator in proposal list on proposals with remote commands awaiting execution
