### PR TITLE
fix: border color of RhfSubmitButton when there is an error

### DIFF
--- a/.changeset/good-clocks-tickle.md
+++ b/.changeset/good-clocks-tickle.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix border color of RhfSubmitButton when there is an error

--- a/apps/evm/src/containers/Form/RhfSubmitButton/index.tsx
+++ b/apps/evm/src/containers/Form/RhfSubmitButton/index.tsx
@@ -34,7 +34,7 @@ export const RhfSubmitButton: React.FC<RhfSubmitButtonProps> = ({
       type="submit"
       loading={formState.isSubmitting || loading}
       disabled={!formState.isValid || formState.isSubmitting || disabled}
-      className={cn('w-full', isDangerousSubmission && 'bg-red')}
+      className={cn('w-full', isDangerousSubmission && 'bg-red border-red')}
       {...otherButtonProps}
     >
       {formState.isValid ? enabledLabel : disabledLabel}


### PR DESCRIPTION
## Changes

- fix border color of `RhfSubmitButton` when there is an error
