### PR TITLE
feat: update how borrow cap is displayed on Market page

### DIFF
--- a/.changeset/slow-mice-guess.md
+++ b/.changeset/slow-mice-guess.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+update how borrow cap is displayed on Market page

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -378,7 +378,7 @@
   "market": {
     "borrowCapThreshold": {
       "title": "Total borrowed",
-      "tooltip": "Maximum amount available to borrow is {{amountDollars}} ({{amountTokens}})"
+      "tooltip": "Maximum amount available to borrow is {{amountDollars}} ({{amountTokens}})<br />Borrow cap: {{capTokens}}"
     },
     "borrowInfo": {
       "title": "Borrow info"

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`CorePoolMarket > fetches market details and displays them correctly 1`]
 
 exports[`CorePoolMarket > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAverage APY-Current APY0.05%Distribution APY0.11%"`;
 
-exports[`CorePoolMarket > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%"`;
+exports[`CorePoolMarket > fetches market details and displays them correctly 3`] = `"Borrow info< 0.01%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%"`;
 
 exports[`CorePoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexApyCharts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexApyCharts.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 1`] = `"Supply info30D6M1Y0%Total supplied> $100T / > $100T> 100T / > 100T XVSAverage APY-Current APY0.05%Distribution APY0.11%Supply APY"`;
 
-exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1Y0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%Borrow APY"`;
+exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1Y< 0.01%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty10%Borrow APY"`;
 
 exports[`CorePoolMarket - Feature flag enabled: apyCharts > fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 

--- a/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/CorePoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetche
 
 exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAverage APY-Current APY0.05%Distribution APY0.11%"`;
 
-exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow info< 0.01%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
 exports[`CorePoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Daily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/index.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`IsolatedPoolMarket > fetches market details and displays them correctly
 
 exports[`IsolatedPoolMarket > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAverage APY-Current APY0.05%Distribution APY0.11%"`;
 
-exports[`IsolatedPoolMarket > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket > fetches market details and displays them correctly 3`] = `"Borrow info< 0.01%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
 exports[`IsolatedPoolMarket > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36MDaily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketHistory.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketHistory.spec.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 1`] = `"Supply info30D6M1Y0%Total supplied> $100T / > $100T> 100T / > 100T XVSAverage APY-Current APY0.05%Distribution APY0.11%Supply APY"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1Y0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-Borrow APY"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 2`] = `"Borrow info30D6M1Y< 0.01%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-Borrow APY"`;
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketHistory > fetches market details and displays them correctly 3`] = `"Interest Rate ModelUtilization rateBorrow APYSupply APY"`;
 

--- a/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
+++ b/apps/evm/src/pages/Market/IsolatedPoolMarket/__tests__/__snapshots__/indexMarketParticipantCounts.spec.tsx.snap
@@ -4,6 +4,6 @@ exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fe
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 2`] = `"Supply info0%Total supplied> $100T / > $100T> 100T / > 100T XVSAverage APY-Current APY0.05%Distribution APY0.11%"`;
 
-exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow info0%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
+exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 3`] = `"Borrow info< 0.01%Total borrowed$2.36M / > $100T1.85M / > 100T XVSAverage APY-Current APY-2.3%Distribution APY4.17%Liquidation Threshold50%Liquidation Penalty-"`;
 
 exports[`IsolatedPoolMarket - Feature flag enabled: marketParticipantCounts > fetches market details and displays them correctly 4`] = `"Market infoPrice$1.278673Market liquidity$80.36M# of suppliers100# of borrowers10Daily supplying interests$3.98Daily borrowing interests-$44.81Daily XVS distributed19.99MReserves1K XVSReserve factor25%Collateral factor50%vXVS minted> 100TExchange rate1 XVS=49.589181 vXVS"`;

--- a/apps/evm/src/pages/Market/Page/MarketHistory/Card/index.tsx
+++ b/apps/evm/src/pages/Market/Page/MarketHistory/Card/index.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'libs/translations';
 import type { Asset } from 'types';
 import { formatPercentageToReadableValue, getCombinedDistributionApys } from 'utilities';
 
+import BigNumber from 'bignumber.js';
 import { type MarketHistoryPeriodType, useGetPoolLiquidationIncentive } from 'clients/api';
 import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { MarketCard, type MarketCardProps } from '../../MarketCard';
@@ -154,8 +155,13 @@ export const Card: React.FC<CardProps> = ({
         <CapThreshold
           type={type}
           tokenPriceCents={asset.tokenPriceCents}
-          capTokens={type === 'supply' ? asset.supplyCapTokens : asset.borrowCapTokens}
           balanceTokens={type === 'supply' ? asset.supplyBalanceTokens : asset.borrowBalanceTokens}
+          capTokens={type === 'supply' ? asset.supplyCapTokens : asset.borrowCapTokens}
+          limitTokens={
+            type === 'supply'
+              ? asset.supplyCapTokens
+              : BigNumber.min(asset.supplyBalanceTokens, asset.borrowCapTokens)
+          }
           token={asset.vToken.underlyingToken}
         />
       }


### PR DESCRIPTION
## Jira ticket(s)

VEN-2971

## Changes

- update how the borrow cap is displayed on the Market page. If the supply balance is smaller than the borrow cap, then the former is used to determine how close a market is to the threshold
