### PR TITLE
fix: avoid trying unecessary domain resolutions

### DIFF
--- a/.changeset/empty-ducks-lay.md
+++ b/.changeset/empty-ducks-lay.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+avoid trying to resolve names in unsupported chains

--- a/apps/evm/src/clients/api/queries/getAddressDomainName/useGetAddressDomainName.ts
+++ b/apps/evm/src/clients/api/queries/getAddressDomainName/useGetAddressDomainName.ts
@@ -5,6 +5,7 @@ import getAddressDomainName, {
   type GetAddressDomainNameOutput,
 } from 'clients/api/queries/getAddressDomainName';
 import FunctionKey from 'constants/functionKey';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 
 type UseGetAddressDomainNameInput = GetAddressDomainNameInput;
 
@@ -25,6 +26,7 @@ const useGetAddressDomainName = (
   { accountAddress, chainId }: UseGetAddressDomainNameInput,
   options?: Partial<Options>,
 ) => {
+  const isWeb3DomainNamesFeatureEnabled = useIsFeatureEnabled({ name: 'web3DomainNames' });
   const queryKey: UseGetAddressDomainNameQueryKey = [
     FunctionKey.GET_ADDRESS_DOMAIN_NAME,
     {
@@ -37,6 +39,7 @@ const useGetAddressDomainName = (
     queryKey: queryKey,
     queryFn: () => getAddressDomainName({ accountAddress, chainId }),
     ...options,
+    enabled: isWeb3DomainNamesFeatureEnabled && !!options?.enabled,
   });
 };
 

--- a/apps/evm/src/hooks/useIsFeatureEnabled/index.tsx
+++ b/apps/evm/src/hooks/useIsFeatureEnabled/index.tsx
@@ -122,6 +122,7 @@ export const featureFlags = {
     ChainId.OPTIMISM_SEPOLIA,
   ],
   gaslessTransactions: [ChainId.ZKSYNC_SEPOLIA, ChainId.ZKSYNC_MAINNET],
+  web3DomainNames: [ChainId.BSC_MAINNET, ChainId.ETHEREUM, ChainId.ARBITRUM_ONE],
 };
 
 export type FeatureFlag = keyof typeof featureFlags;


### PR DESCRIPTION
## Changes

- No need to try resolving names in chains other than BSC_MAINNET, ETHEREUM and ARBITRUM_ONE, it will just fail to validate
