### PR TITLE
refactor: update contracts library to support viem

### DIFF
--- a/.changeset/young-mails-bake.md
+++ b/.changeset/young-mails-bake.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+update contracts library to support viem

--- a/apps/evm/src/clients/api/queries/getAllowance/index.ts
+++ b/apps/evm/src/clients/api/queries/getAllowance/index.ts
@@ -1,9 +1,12 @@
-import BigNumber from 'bignumber.js';
+import type { Address, PublicClient } from 'viem';
 
-import type { Bep20, Vai, Vrt, Xvs } from 'libs/contracts';
+import BigNumber from 'bignumber.js';
+import { Bep20Abi } from 'libs/contracts';
+import type { Token } from 'types';
 
 export interface GetAllowanceInput {
-  tokenContract: Vai | Bep20 | Vrt | Xvs;
+  publicClient: PublicClient;
+  token: Token;
   accountAddress: string;
   spenderAddress: string;
 }
@@ -13,14 +16,20 @@ export type GetAllowanceOutput = {
 };
 
 const getAllowance = async ({
-  tokenContract,
+  publicClient,
+  token,
   accountAddress,
   spenderAddress,
 }: GetAllowanceInput): Promise<GetAllowanceOutput> => {
-  const res = await tokenContract.allowance(accountAddress, spenderAddress);
+  const allowanceMantissa = await publicClient.readContract({
+    abi: Bep20Abi,
+    address: token.address as Address,
+    functionName: 'allowance',
+    args: [accountAddress as Address, spenderAddress as Address],
+  });
 
   return {
-    allowanceMantissa: new BigNumber(res.toString()),
+    allowanceMantissa: new BigNumber(allowanceMantissa.toString()),
   };
 };
 

--- a/apps/evm/src/clients/api/queries/getAllowance/useGetAllowance.ts
+++ b/apps/evm/src/clients/api/queries/getAllowance/useGetAllowance.ts
@@ -5,12 +5,13 @@ import getAllowance, {
   type GetAllowanceOutput,
 } from 'clients/api/queries/getAllowance';
 import FunctionKey from 'constants/functionKey';
-import { useGetTokenContract } from 'libs/contracts';
 import { useChainId } from 'libs/wallet';
 import type { ChainId, Token } from 'types';
-import { callOrThrow } from 'utilities';
+import { usePublicClient } from 'wagmi';
 
-type TrimmedGetAllowanceInput = Omit<GetAllowanceInput, 'tokenContract'> & { token: Token };
+type TrimmedGetAllowanceInput = Omit<GetAllowanceInput, 'publicClient'> & {
+  token: Token;
+};
 
 export type UseGetAllowanceQueryKey = [
   FunctionKey.GET_TOKEN_ALLOWANCE,
@@ -33,7 +34,7 @@ const useGetAllowance = (
   options?: Partial<Options>,
 ) => {
   const { chainId } = useChainId();
-  const tokenContract = useGetTokenContract({ token });
+  const publicClient = usePublicClient();
 
   const queryKey: UseGetAllowanceQueryKey = [
     FunctionKey.GET_TOKEN_ALLOWANCE,
@@ -47,16 +48,13 @@ const useGetAllowance = (
 
   return useQuery({
     queryKey: queryKey,
-
     queryFn: () =>
-      callOrThrow({ tokenContract }, params =>
-        getAllowance({
-          spenderAddress,
-          accountAddress,
-          ...params,
-        }),
-      ),
-
+      getAllowance({
+        publicClient,
+        spenderAddress,
+        accountAddress,
+        token,
+      }),
     ...options,
   });
 };

--- a/apps/evm/src/clients/api/queries/getCurrentVotes/index.spec.ts
+++ b/apps/evm/src/clients/api/queries/getCurrentVotes/index.spec.ts
@@ -1,7 +1,5 @@
 import BigNumber from 'bignumber.js';
-import { BigNumber as BN } from 'ethers';
-
-import type { XvsVault } from 'libs/contracts';
+import type { PublicClient } from 'viem';
 
 import getCurrentVotes from '.';
 
@@ -9,21 +7,28 @@ const fakeAccountAddress = '0x000000000000000000000000000000000AcCoUnt';
 
 describe('api/queries/getCurrentVotes', () => {
   test('returns current votes on success', async () => {
-    const fakeOutput = BN.from(10000);
+    const fakeOutput = 10000n;
+    const fakeXvsVaultContractAddress = '0x00000000000000000000000000000000XVsVault';
 
-    const getCurrentVotesMock = vi.fn(async () => fakeOutput);
+    const readContractMock = vi.fn(async () => fakeOutput);
 
-    const fakeContract = {
-      getCurrentVotes: getCurrentVotesMock,
-    } as unknown as XvsVault;
+    const fakePublicClient = {
+      readContract: readContractMock,
+    } as unknown as PublicClient;
 
     const response = await getCurrentVotes({
-      xvsVaultContract: fakeContract,
+      xvsVaultContractAddress: fakeXvsVaultContractAddress,
+      publicClient: fakePublicClient,
       accountAddress: fakeAccountAddress,
     });
 
-    expect(getCurrentVotesMock).toHaveBeenCalledTimes(1);
-    expect(getCurrentVotesMock).toHaveBeenCalledWith(fakeAccountAddress);
+    expect(readContractMock).toHaveBeenCalledTimes(1);
+    expect(readContractMock).toHaveBeenCalledWith({
+      abi: expect.any(Object),
+      address: fakeXvsVaultContractAddress,
+      functionName: 'getCurrentVotes',
+      args: [fakeAccountAddress],
+    });
     expect(response).toEqual({
       votesMantissa: new BigNumber(fakeOutput.toString()),
     });

--- a/apps/evm/src/clients/api/queries/getCurrentVotes/index.ts
+++ b/apps/evm/src/clients/api/queries/getCurrentVotes/index.ts
@@ -1,9 +1,11 @@
 import BigNumber from 'bignumber.js';
+import { XvsVaultAbi } from 'libs/contracts';
 
-import type { XvsVault } from 'libs/contracts';
+import type { Address, PublicClient } from 'viem';
 
 export interface GetCurrentVotesInput {
-  xvsVaultContract: XvsVault;
+  publicClient: PublicClient;
+  xvsVaultContractAddress: string;
   accountAddress: string;
 }
 
@@ -12,13 +14,19 @@ export type GetCurrentVotesOutput = {
 };
 
 const getCurrentVotes = async ({
-  xvsVaultContract,
+  publicClient,
+  xvsVaultContractAddress,
   accountAddress,
 }: GetCurrentVotesInput): Promise<GetCurrentVotesOutput> => {
-  const resp = await xvsVaultContract.getCurrentVotes(accountAddress);
+  const votesMantissa = await publicClient.readContract({
+    address: xvsVaultContractAddress as Address,
+    abi: XvsVaultAbi,
+    functionName: 'getCurrentVotes',
+    args: [accountAddress as Address],
+  });
 
   return {
-    votesMantissa: new BigNumber(resp.toString()),
+    votesMantissa: new BigNumber(votesMantissa.toString()),
   };
 };
 

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/__tests__/__snapshots__/index.spec.ts.snap
@@ -12,8 +12,8 @@ exports[`generateAbis > calls writeFile with the right arguments 1`] = `
 exports[`generateAbis > calls writeFile with the right arguments 2`] = `
 [
   {
-    "content": "[{"inputs":[{"internalType":"address","name":"market","type":"address"},{"internalType":"enum ComptrollerStorage.Action","name":"action","type":"uint8"}],"name":"ActionPaused","type":"error"}]",
-    "outputPath": "fake/output/director/path/IsolatedPoolComptroller.json",
+    "content": "export const abi = [{"inputs":[{"internalType":"address","name":"poolRegistryAddress","type":"address"},{"internalType":"address","name":"asset","type":"address"}],"name":"getPoolsSupportedByAsset","outputs":[{"internalType":"address[]","name":"","type":"address[]"}],"stateMutability":"view","type":"function"}] as const;",
+    "outputPath": "fake/output/director/path/PoolLens.ts",
   },
 ]
 `;
@@ -21,8 +21,8 @@ exports[`generateAbis > calls writeFile with the right arguments 2`] = `
 exports[`generateAbis > calls writeFile with the right arguments 3`] = `
 [
   {
-    "content": "[{"inputs":[{"internalType":"uint256","name":"amount","type":"uint256"},{"internalType":"uint256","name":"amountMax","type":"uint256"}],"name":"ExcessiveInputAmount","type":"error"}]",
-    "outputPath": "fake/output/director/path/SwapRouter.json",
+    "content": "[{"inputs":[{"internalType":"address","name":"market","type":"address"},{"internalType":"enum ComptrollerStorage.Action","name":"action","type":"uint8"}],"name":"ActionPaused","type":"error"}]",
+    "outputPath": "fake/output/director/path/IsolatedPoolComptroller.json",
   },
 ]
 `;

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/__tests__/index.spec.ts
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/__tests__/index.spec.ts
@@ -14,7 +14,7 @@ describe('generateAbis', () => {
       contractConfigs: fakeContractConfigs,
     });
 
-    expect(writeFile).toHaveBeenCalledTimes(fakeContractConfigs.length);
+    expect(writeFile).toHaveBeenCalledTimes(fakeContractConfigs.length * 2);
 
     fakeContractConfigs.forEach((_fakeContractConfig, index) =>
       expect((writeFile as Vi.Mock).mock.calls[index]).toMatchSnapshot(),

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/abiTemplate.hbs
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/abiTemplate.hbs
@@ -1,0 +1,1 @@
+export const abi = {{{abi}}} as const;

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/index.ts
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAbis/index.ts
@@ -1,5 +1,12 @@
+import { readFileSync } from 'node:fs';
+import { compile } from 'handlebars';
 import type { ContractConfig } from 'libs/contracts/config';
 import writeFile from 'utilities/writeFile';
+
+const ABI_TEMPLATE_FILE_PATH = `${__dirname}/abiTemplate.hbs`;
+
+const abiTemplateBuffer = readFileSync(ABI_TEMPLATE_FILE_PATH);
+const abiTemplate = compile(abiTemplateBuffer.toString());
 
 export interface GenerateTypesInput {
   contractConfigs: ContractConfig[];
@@ -9,8 +16,15 @@ export interface GenerateTypesInput {
 export const generateAbis = ({ contractConfigs, outputDirectoryPath }: GenerateTypesInput) =>
   // Go through config and extract ABIs into separate files
   contractConfigs.forEach(contractConfig => {
+    const abi = JSON.stringify(contractConfig.abi);
+
     writeFile({
       outputPath: `${outputDirectoryPath}/${contractConfig.name}.json`,
-      content: JSON.stringify(contractConfig.abi),
+      content: abi,
+    });
+
+    writeFile({
+      outputPath: `${outputDirectoryPath}/${contractConfig.name}.ts`,
+      content: abiTemplate({ abi }),
     });
   });

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/__tests__/__snapshots__/index.spec.ts.snap
@@ -13,6 +13,8 @@ import { getUniqueContractAddress } from 'libs/contracts/utilities/getUniqueCont
 import { useChainId, useProvider, useSigner } from 'libs/wallet';
 import { ChainId } from 'types';
 
+export { abi as PoolLensAbi } from 'libs/contracts/generated/infos/abis/PoolLens';
+
 interface GetPoolLensContractAddressInput {
   chainId: ChainId;
 }
@@ -89,6 +91,8 @@ import { IsolatedPoolComptroller } from 'libs/contracts/generated/infos/contract
 import { useProvider, useSigner } from 'libs/wallet';
 import { ChainId } from 'types';
 
+export { abi as IsolatedPoolComptrollerAbi } from 'libs/contracts/generated/infos/abis/IsolatedPoolComptroller';
+
 interface GetIsolatedPoolComptrollerContractInput {
   address: string;
   signerOrProvider: Signer | Provider;
@@ -141,6 +145,8 @@ import addresses from 'libs/contracts/generated/infos/addresses';
 import { SwapRouter } from 'libs/contracts/generated/infos/contractTypes';
 import { useChainId, useProvider, useSigner } from 'libs/wallet';
 import { ChainId } from 'types';
+
+export { abi as SwapRouterAbi } from 'libs/contracts/generated/infos/abis/SwapRouter';
 
 interface GetSwapRouterContractAddressInput {
   comptrollerContractAddress: string;

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/genericContractGettersTemplate.hbs
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/genericContractGettersTemplate.hbs
@@ -7,6 +7,8 @@ import { {{contractName}} } from 'libs/contracts/generated/infos/contractTypes';
 import { useProvider, useSigner } from 'libs/wallet';
 import { ChainId } from 'types';
 
+export { abi as {{contractName}}Abi } from 'libs/contracts/generated/infos/abis/{{contractName}}';
+
 interface Get{{contractName}}ContractInput {
   address: string;
   signerOrProvider: Signer | Provider;

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniqueContractGettersTemplate.hbs
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniqueContractGettersTemplate.hbs
@@ -8,6 +8,8 @@ import { getUniqueContractAddress } from 'libs/contracts/utilities/getUniqueCont
 import { useChainId, useProvider, useSigner } from 'libs/wallet';
 import { ChainId } from 'types';
 
+export { abi as {{contractName}}Abi } from 'libs/contracts/generated/infos/abis/{{contractName}}';
+
 interface Get{{contractName}}ContractAddressInput {
   chainId: ChainId;
 }

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniquePerPoolContractGettersTemplate.hbs
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateGetters/templates/uniquePerPoolContractGettersTemplate.hbs
@@ -8,6 +8,8 @@ import { {{contractName}} } from 'libs/contracts/generated/infos/contractTypes';
 import { useChainId, useProvider, useSigner } from 'libs/wallet';
 import { ChainId } from 'types';
 
+export { abi as {{contractName}}Abi } from 'libs/contracts/generated/infos/abis/{{contractName}}';
+
 interface Get{{contractName}}ContractAddressInput {
   comptrollerContractAddress: string;
   chainId: ChainId;

--- a/apps/evm/src/libs/contracts/utilities/getUniqueContractAddress/index.ts
+++ b/apps/evm/src/libs/contracts/utilities/getUniqueContractAddress/index.ts
@@ -1,13 +1,17 @@
 import addresses from 'libs/contracts/generated/infos/addresses';
 import type { UniqueContractName } from 'libs/contracts/generated/infos/types';
 import type { ChainId } from 'types';
+import type { Address } from 'viem';
 
 export type GetUniqueContractAddressInput = {
   name: UniqueContractName;
   chainId: ChainId;
 };
 
-export const getUniqueContractAddress = ({ name, chainId }: GetUniqueContractAddressInput) => {
+export const getUniqueContractAddress = ({
+  name,
+  chainId,
+}: GetUniqueContractAddressInput): Address | undefined => {
   const contractAddresses = addresses[name];
 
   return Object.prototype.hasOwnProperty.call(contractAddresses, chainId)

--- a/apps/evm/src/libs/wallet/Web3Wrapper/config.ts
+++ b/apps/evm/src/libs/wallet/Web3Wrapper/config.ts
@@ -7,6 +7,10 @@ import type { Chain, Transport } from 'viem';
 import { chains } from '../chains';
 import { WALLET_CONNECT_PROJECT_ID } from '../constants';
 
+const batchSettings = {
+  wait: 50,
+};
+
 const connectKitConfig = getDefaultConfig({
   chains: chains as [Chain, ...Chain[]],
   transports: chains.reduce((acc, chain) => {
@@ -14,7 +18,9 @@ const connectKitConfig = getDefaultConfig({
 
     return {
       ...acc,
-      [chain.id]: http(url),
+      [chain.id]: http(url, {
+        batch: batchSettings,
+      }),
     };
   }, {}) as Record<ChainId, Transport>,
   walletConnectProjectId: WALLET_CONNECT_PROJECT_ID,
@@ -23,6 +29,7 @@ const connectKitConfig = getDefaultConfig({
   appDescription:
     'Venus is a decentralized finance (DeFi) algorithmic money market protocol on EVM networks.',
   appIcon: 'https://venus.io/180x180.png',
+  batch: batchSettings,
 });
 
 const config = createConfig(connectKitConfig);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4691,7 +4691,7 @@
   resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz#10f65fe1891fd8cde4957360835e78fd1936bfdd"
   integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
 
-"@openzeppelin-3/contracts@npm:@openzeppelin/contracts@^3.4.2-solc-0.7":
+"@openzeppelin-3/contracts@npm:@openzeppelin/contracts@^3.4.2-solc-0.7", "@openzeppelin/contracts-v0.7@npm:@openzeppelin/contracts@v3.4.2":
   version "3.4.2"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
   integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
@@ -4705,11 +4705,6 @@
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.9.5.tgz#572b5da102fc9be1d73f34968e0ca56765969812"
   integrity sha512-f7L1//4sLlflAN7fVzJLoRedrf5Na3Oal5PZfIq55NFcVZ90EpV1q5xOvL4lFvg3MNICSDr2hH0JUBxwlxcoPg==
-
-"@openzeppelin/contracts-v0.7@npm:@openzeppelin/contracts@v3.4.2":
-  version "3.4.2"
-  resolved "https://registry.yarnpkg.com/@openzeppelin/contracts/-/contracts-3.4.2.tgz#d81f786fda2871d1eb8a8c5a73e455753ba53527"
-  integrity sha512-z0zMCjyhhp4y7XKAcDAi3Vgms4T2PstwBdahiO0+9NaGICQKjynK3wduSRplTgk4LXmoO1yfDGO5RbjKYxtuxA==
 
 "@openzeppelin/contracts@3.4.2-solc-0.7":
   version "3.4.2-solc-0.7"
@@ -12608,9 +12603,9 @@ jpeg-js@^0.4.2, jpeg-js@^0.4.4:
   integrity sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==
 
 js-base64@^3.7.2:
-  version "3.7.5"
-  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.5.tgz#21e24cf6b886f76d6f5f165bfcd69cc55b9e3fca"
-  integrity sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==
+  version "3.7.7"
+  resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-3.7.7.tgz#e51b84bf78fbf5702b9541e2cb7bfcb893b43e79"
+  integrity sha512-7rCnleh0z2CkXhH67J8K1Ytz0b2Y+yxTPL+/KOJoa20hfnVQ/3/T6W/KflYI4bRHRagNeXeU2bkNGI3v1oS/lw==
 
 js-cookie@^2.2.1:
   version "2.2.1"
@@ -16779,16 +16774,7 @@ string-format@^2.0.0:
   resolved "https://registry.yarnpkg.com/string-format/-/string-format-2.0.0.tgz#f2df2e7097440d3b65de31b6d40d54c96eaffb9b"
   integrity sha512-bbEs3scLeYNXLecRRuk6uJxdXUSj6le/8rNPHChIJTn2V79aXVTR1EH2OH5zLKKoz0V02fOUKZZcw01pLUShZA==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -16855,7 +16841,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -16868,13 +16854,6 @@ strip-ansi@^4.0.0:
   integrity sha512-4XaJ2zQdCzROZDivEVIDPkcQn8LMFSa8kj8Gxb/Lnwzv9A8VctNZ+lfivC/sV3ivW8ElJTERXZoPBRrZKkNKow==
   dependencies:
     ansi-regex "^3.0.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -18592,7 +18571,7 @@ workerpool@6.2.1:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-6.2.1.tgz#46fc150c17d826b86a008e5a4508656777e9c343"
   integrity sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -18605,15 +18584,6 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
## Changes

- update contracts library to support viem. I updated two query functions: `getCurrentVotes` and `getAllowance`, to showcase how viem can be used. The end goal is to refactor all the query and mutation functions to use viem, so that we can then remove ethers.js from the repository
- enable batching in wagmi config