### PR TITLE
feat: fetch user Merkl rewards amounts

### DIFF
--- a/.changeset/young-zebras-arrive.md
+++ b/.changeset/young-zebras-arrive.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+display and claim user rewards from Merkl

--- a/apps/evm/src/__mocks__/models/asset.ts
+++ b/apps/evm/src/__mocks__/models/asset.ts
@@ -41,6 +41,7 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('0.11720675342484096'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
     ],
     borrowTokenDistributions: [
@@ -49,6 +50,7 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('4.17469243006608279'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
     ],
     supplyPointDistributions: [
@@ -104,11 +106,13 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('1.353105649796123742'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
       {
         type: 'primeSimulation',
         token: usdc,
         apyPercentage: new BigNumber('0.953105649796123742'),
+        isActive: true,
         referenceValues: {
           userBorrowBalanceTokens: new BigNumber('1000'),
           userSupplyBalanceTokens: new BigNumber('1000'),
@@ -119,6 +123,7 @@ export const assetData: Asset[] = [
         type: 'prime',
         token: usdc,
         apyPercentage: new BigNumber('0.753105649796123742'),
+        isActive: true,
       },
     ],
     borrowTokenDistributions: [
@@ -127,11 +132,13 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('1.670327607690572731'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
       {
         type: 'primeSimulation',
         token: usdc,
         apyPercentage: new BigNumber('1.233105649796123742'),
+        isActive: true,
         referenceValues: {
           userBorrowBalanceTokens: new BigNumber('1000'),
           userSupplyBalanceTokens: new BigNumber('1000'),
@@ -142,6 +149,7 @@ export const assetData: Asset[] = [
         type: 'prime',
         token: usdc,
         apyPercentage: new BigNumber('0.913105649796123742'),
+        isActive: true,
       },
     ],
     supplyPointDistributions: [],
@@ -181,11 +189,13 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('0.421719501189155143'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
       {
         type: 'primeSimulation',
         token: usdt,
         apyPercentage: new BigNumber('1.753105649796123742'),
+        isActive: true,
         referenceValues: {
           userBorrowBalanceTokens: new BigNumber('1000'),
           userSupplyBalanceTokens: new BigNumber('1000'),
@@ -199,11 +209,13 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('0.522209972682294832'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
       {
         type: 'primeSimulation',
         token: usdt,
         apyPercentage: new BigNumber('1.015310564979612374'),
+        isActive: true,
         referenceValues: {
           userBorrowBalanceTokens: new BigNumber('1000'),
           userSupplyBalanceTokens: new BigNumber('1000'),
@@ -256,11 +268,13 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('0.678420831753642169'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
       {
         type: 'primeSimulation',
         token: busd,
         apyPercentage: new BigNumber('1.753105649796123742'),
+        isActive: true,
         referenceValues: {
           userBorrowBalanceTokens: new BigNumber('1000'),
           userSupplyBalanceTokens: new BigNumber('1000'),
@@ -271,6 +285,7 @@ export const assetData: Asset[] = [
         type: 'prime',
         token: xvs,
         apyPercentage: new BigNumber(0),
+        isActive: true,
       },
     ],
     borrowTokenDistributions: [
@@ -279,11 +294,13 @@ export const assetData: Asset[] = [
         token: xvs,
         apyPercentage: new BigNumber('0.852697602175970714'),
         dailyDistributedTokens: new BigNumber('9999999.5'),
+        isActive: true,
       },
       {
         type: 'primeSimulation',
         token: busd,
         apyPercentage: new BigNumber('1.753105649796123742'),
+        isActive: true,
         referenceValues: {
           userBorrowBalanceTokens: new BigNumber('1000'),
           userSupplyBalanceTokens: new BigNumber('1000'),
@@ -294,6 +311,7 @@ export const assetData: Asset[] = [
         type: 'prime',
         token: busd,
         apyPercentage: new BigNumber('0.913105649796123742'),
+        isActive: true,
       },
     ],
     supplyPointDistributions: [

--- a/apps/evm/src/clients/api/queries/getPendingRewards/__testUtils__/fakeData.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/__testUtils__/fakeData.ts
@@ -1,3 +1,4 @@
+import BigNumber from 'bignumber.js';
 import { BigNumber as BN } from 'ethers';
 
 export const fakeGetPriceOutput = BN.from('0x30f7dc8a6370b000');
@@ -75,3 +76,92 @@ export const fakeGetPrimePendingRewardsOutput = [
     vToken: '0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7',
   },
 ];
+
+export const fakeMerklCampaigns = {
+  '0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7': [
+    {
+      type: 'merkl' as const,
+      token: {
+        address: '0xB9e0E753630434d7863528cc73CB7AC638a7c8ff' as const,
+        decimals: 18,
+        symbol: 'XVS',
+        asset: '/src/libs/tokens/img/underlyingTokens/xvs.svg',
+      },
+      apyPercentage: new BigNumber('4.948661868555404'),
+      dailyDistributedTokens: new BigNumber('24879.397857142857142752'),
+      rewardDetails: {
+        apr: 3.933979039668833,
+        name: 'Supply ZK on Venus',
+        tags: ['zksync'],
+        appName: 'Ignite',
+        claimUrl: 'https://app.zksyncignite.xyz/',
+        description: 'Ignite campaign',
+        merklCampaignId: '11261554123924093519',
+        merklCampaignIdentifier:
+          '0x05b2a61240d8e71f2507bb72f9f3a8209ac8ba50ed44ab77ef981602613ebde6',
+        marketAddress: '0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7',
+      },
+      isActive: false,
+    },
+  ],
+  '0xb7526572FFE56AB9D7489838Bf2E18e3323b441A': [
+    {
+      type: 'merkl' as const,
+      token: {
+        address: '0x5a7d6b2f92c77fad6ccabd7ee0624e64907eaf3e' as const,
+        decimals: 18,
+        symbol: 'ZK',
+        asset: '/src/libs/tokens/img/underlyingTokens/zk.svg',
+      },
+      apyPercentage: new BigNumber('4.918338308869741'),
+      dailyDistributedTokens: new BigNumber('21301.973571428571428352'),
+      rewardDetails: {
+        apr: 4.7961486347104,
+        name: 'Supply USDC on Venus',
+        tags: ['zksync'],
+        appName: 'Ignite',
+        claimUrl: 'https://app.zksyncignite.xyz/',
+        description: 'Ignite campaign',
+        merklCampaignId: '4137895647330923054',
+        merklCampaignIdentifier:
+          '0xa7e87a020413bc49e0db7b65f8806c86af035888f447d9fa030d2be17c8d50c6',
+        marketAddress: '0xb7526572FFE56AB9D7489838Bf2E18e3323b441A',
+      },
+      isActive: true,
+    },
+  ],
+};
+
+export const fakeMerklRewardsResponse = {
+  rewards: [
+    {
+      root: '0xf53954b8200a10d4fcc7ec978037be383a58146463c2bb80555bd9c8f4ffab78',
+      recipient: '0xFd7dA20ea0bE63ACb0852f97E950376E7E4a817D',
+      amount: '1076268856872481933',
+      claimed: '0',
+      pending: '15980464719442818',
+      token: {
+        address: '0x5A7d6b2F92C77FAD6CCaBd7EE0624E64907Eaf3E',
+        chainId: 324,
+        symbol: 'ZK',
+        decimals: 18,
+      },
+      breakdowns: [
+        {
+          reason: 'ERC20_0x1Fa916C27c7C2c4602124A14C77Dbb40a5FF1BE8',
+          amount: '148724354119319218',
+          claimed: '0',
+          pending: '87476171975286',
+          campaignId: '0xa87004bef5a42a24de9dd6bee569cc6bfcf7048bde3495a5078712fd3097e218',
+        },
+        {
+          reason: 'ERC20_0x697a70779C1A03Ba2BD28b7627a902BFf831b616',
+          amount: '76658101233016960',
+          claimed: '0',
+          pending: '0',
+          campaignId: '0x05b2a61240d8e71f2507bb72f9f3a8209ac8ba50ed44ab77ef981602613ebde6',
+        },
+      ],
+    },
+  ],
+};

--- a/apps/evm/src/clients/api/queries/getPendingRewards/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/__tests__/__snapshots__/index.spec.ts.snap
@@ -81,6 +81,112 @@ exports[`getPendingRewards > returns pool rewards of the user in the correct for
 }
 `;
 
+exports[`getPendingRewards > returns pool rewards of the user, including Merkl rewards, in the correct format on success 1`] = `
+{
+  "pendingRewardGroups": [
+    {
+      "comptrollerAddress": "0x94d1820b2D1c7c7452A163983Dc888CEC546b77D",
+      "rewardAmountCents": "6892647.61413516495268939951386",
+      "rewardAmountMantissa": "1.9534041188941933361355e+22",
+      "rewardToken": {
+        "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
+        "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
+        "decimals": 18,
+        "symbol": "XVS",
+      },
+      "type": "legacyPool",
+      "vTokenAddressesWithPendingReward": [
+        "0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7",
+        "0xb7526572FFE56AB9D7489838Bf2E18e3323b441A",
+      ],
+    },
+    {
+      "comptrollerAddress": "0x1291820b2D1c7c7452A163983Dc888CEC546b78k",
+      "pendingRewards": [
+        {
+          "rewardAmountCents": "3.881384452e-11",
+          "rewardAmountMantissa": "110000",
+          "rewardToken": {
+            "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+            "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+            "decimals": 18,
+            "symbol": "lisUSD",
+          },
+          "rewardsDistributorAddress": "0x2aBEf3602B688493fe698EF11D27DCa43a0CE4BE",
+          "vTokenAddressesWithPendingReward": [
+            "0x170d3b2da05cc2124334240fB34ad1359e34C562",
+            "0x3338988d0beb4419Acb8fE624218754053362D06",
+          ],
+        },
+      ],
+      "type": "isolatedPool",
+    },
+    {
+      "isDisabled": false,
+      "rewardAmountCents": "352.853132",
+      "rewardAmountMantissa": "1000000000000000000",
+      "rewardToken": {
+        "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
+        "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
+        "decimals": 18,
+        "symbol": "XVS",
+      },
+      "stakedToken": {
+        "address": "0x5fFbE5302BadED40941A403228E6AD03f93752d9",
+        "asset": "/src/libs/tokens/img/underlyingTokens/vai.svg",
+        "decimals": 18,
+        "symbol": "VAI",
+      },
+      "type": "vault",
+    },
+    {
+      "isDisabled": false,
+      "poolIndex": 0,
+      "rewardAmountCents": "227.6612616584371779",
+      "rewardAmountMantissa": "645201192825000000",
+      "rewardToken": {
+        "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
+        "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
+        "decimals": 18,
+        "symbol": "XVS",
+      },
+      "stakedToken": {
+        "address": "0x5fFbE5302BadED40941A403228E6AD03f93752d9",
+        "asset": "/src/libs/tokens/img/underlyingTokens/vai.svg",
+        "decimals": 18,
+        "symbol": "VAI",
+      },
+      "type": "xvsVestingVault",
+    },
+    {
+      "appName": "Ignite",
+      "campaignName": "Ignite campaign",
+      "claimUrl": "https://app.zksyncignite.xyz/",
+      "pendingRewards": [
+        {
+          "appName": "Ignite",
+          "campaignName": "Ignite campaign",
+          "claimUrl": "https://app.zksyncignite.xyz/",
+          "rewardAmountCents": "27.04905111324309614511872",
+          "rewardAmountMantissa": "76658101233016960",
+          "rewardToken": {
+            "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
+            "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
+            "decimals": 18,
+            "symbol": "XVS",
+          },
+          "rewardsDistributorAddress": "",
+          "vTokenAddressesWithPendingReward": [
+            "0xD5C4C2e2facBEB59D0216D0595d63FcDc6F9A1a7",
+          ],
+        },
+      ],
+      "type": "external",
+    },
+  ],
+}
+`;
+
 exports[`getPendingRewards > returns pool rewards of the user, including Prime rewards, in the correct format on success 1`] = `
 {
   "pendingRewardGroups": [

--- a/apps/evm/src/clients/api/queries/getPendingRewards/__tests__/index.spec.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/__tests__/index.spec.ts
@@ -61,6 +61,8 @@ describe('getPendingRewards', () => {
       venusLensContract: fakeVenusLensContract,
       vaiVaultContract: fakeVaiVaultContract,
       xvsVaultContract: fakeXvsVaultContract,
+      chainId: ChainId.BSC_TESTNET,
+      merklCampaigns: {},
     });
 
     expect(res).toMatchSnapshot();
@@ -79,6 +81,8 @@ describe('getPendingRewards', () => {
       vaiVaultContract: fakeVaiVaultContract,
       xvsVaultContract: fakeXvsVaultContract,
       primeContract: fakePrimeContract,
+      chainId: ChainId.BSC_TESTNET,
+      merklCampaigns: {},
     });
 
     expect(res).toMatchSnapshot();

--- a/apps/evm/src/clients/api/queries/getPendingRewards/__tests__/index.spec.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/__tests__/index.spec.ts
@@ -4,6 +4,8 @@ import tokens from '__mocks__/models/tokens';
 import type { PoolLens, Prime, VaiVault, VenusLens, XvsVault } from 'libs/contracts';
 
 import { ChainId } from 'types';
+import { restService } from 'utilities';
+import type { Mock } from 'vitest';
 import getPendingRewards from '..';
 import {
   fakeGetIsolatedPoolPendingRewardsOutput,
@@ -14,7 +16,12 @@ import {
   fakeGetXvsVaultPendingRewardOutput,
   fakeGetXvsVaultPendingWithdrawalsBeforeUpgradeOutput,
   fakeGetXvsVaultPoolInfosOutput,
+  fakeMerklCampaigns,
+  fakeMerklRewardsResponse,
 } from '../__testUtils__/fakeData';
+import { BASE_MERKL_API_URL } from '../getMerklRewards';
+
+vi.mock('utilities/restService');
 
 const fakeLegacyPoolComptrollerAddress = '0x94d1820b2D1c7c7452A163983Dc888CEC546b77D';
 const fakeIsolatedPoolComptrollerAddress = '0x1291820b2D1c7c7452A163983Dc888CEC546b78k';
@@ -49,9 +56,8 @@ const fakePrimeContract = {
 } as unknown as Prime;
 
 describe('getPendingRewards', () => {
-  test('returns pool rewards of the user in the correct format on success', async () => {
+  it('returns pool rewards of the user in the correct format on success', async () => {
     const res = await getPendingRewards({
-      chainId: ChainId.BSC_TESTNET,
       legacyPoolComptrollerContractAddress: fakeLegacyPoolComptrollerAddress,
       isolatedPoolComptrollerAddresses: [fakeIsolatedPoolComptrollerAddress],
       tokens,
@@ -68,9 +74,8 @@ describe('getPendingRewards', () => {
     expect(res).toMatchSnapshot();
   });
 
-  test('returns pool rewards of the user, including Prime rewards, in the correct format on success', async () => {
+  it('returns pool rewards of the user, including Prime rewards, in the correct format on success', async () => {
     const res = await getPendingRewards({
-      chainId: ChainId.BSC_TESTNET,
       legacyPoolComptrollerContractAddress: fakeLegacyPoolComptrollerAddress,
       isolatedPoolComptrollerAddresses: [fakeIsolatedPoolComptrollerAddress],
       tokens,
@@ -83,6 +88,37 @@ describe('getPendingRewards', () => {
       primeContract: fakePrimeContract,
       chainId: ChainId.BSC_TESTNET,
       merklCampaigns: {},
+    });
+
+    expect(res).toMatchSnapshot();
+  });
+
+  it('returns pool rewards of the user, including Merkl rewards, in the correct format on success', async () => {
+    (restService as Mock).mockImplementation(async () => ({
+      data: [fakeMerklRewardsResponse],
+    }));
+    const res = await getPendingRewards({
+      legacyPoolComptrollerContractAddress: fakeLegacyPoolComptrollerAddress,
+      isolatedPoolComptrollerAddresses: [fakeIsolatedPoolComptrollerAddress],
+      tokens,
+      xvsVestingVaultPoolCount: 1,
+      accountAddress: fakeAddress,
+      poolLensContract: fakePoolLensContract,
+      venusLensContract: fakeVenusLensContract,
+      vaiVaultContract: fakeVaiVaultContract,
+      xvsVaultContract: fakeXvsVaultContract,
+      chainId: ChainId.BSC_TESTNET,
+      merklCampaigns: fakeMerklCampaigns,
+    });
+
+    expect(restService).toHaveBeenCalledTimes(1);
+    expect(restService).toHaveBeenCalledWith({
+      baseUrl: BASE_MERKL_API_URL,
+      endpoint: `users/${fakeAddress}/rewards`,
+      method: 'GET',
+      params: {
+        chainId: ChainId.BSC_TESTNET,
+      },
     });
 
     expect(res).toMatchSnapshot();

--- a/apps/evm/src/clients/api/queries/getPendingRewards/formatOutput/formatToExternalPendingRewardGroup.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/formatOutput/formatToExternalPendingRewardGroup.ts
@@ -1,0 +1,61 @@
+import type BigNumber from 'bignumber.js';
+
+import type { Token } from 'types';
+
+import type {
+  ExternalPendingReward,
+  ExternalPendingRewardGroup,
+  PendingExternalRewardSummary,
+} from '../types';
+import formatRewardSummaryData from './formatRewardSummaryData';
+
+function formatToExternalPendingRewardGroup({
+  externalRewardsSummaries,
+  tokenPriceMapping,
+  tokens,
+}: {
+  tokenPriceMapping: Record<string, BigNumber>;
+  tokens: Token[];
+  externalRewardsSummaries: PendingExternalRewardSummary[];
+}) {
+  const pendingRewardPerCampaign = externalRewardsSummaries.reduce<{
+    [campaignName: string]: ExternalPendingRewardGroup;
+  }>((acc, rewardSummary) => {
+    const formattedReward = formatRewardSummaryData({
+      rewardSummary,
+      tokenPriceMapping,
+      tokens,
+    });
+
+    if (!formattedReward) {
+      return acc;
+    }
+
+    const formattedExternalReward: ExternalPendingReward = {
+      ...formattedReward,
+      campaignName: rewardSummary.campaignName,
+      appName: rewardSummary.appName,
+      claimUrl: rewardSummary.claimUrl,
+    };
+
+    const { appName, campaignName, claimUrl } = rewardSummary;
+    let campaign = acc[campaignName] || {
+      type: 'external',
+      appName,
+      campaignName,
+      claimUrl,
+      pendingRewards: [],
+    };
+    campaign = {
+      ...campaign,
+      pendingRewards: [...campaign.pendingRewards, formattedExternalReward],
+    };
+    return {
+      ...acc,
+      [campaignName]: campaign,
+    };
+  }, {});
+  return Object.values(pendingRewardPerCampaign);
+}
+
+export default formatToExternalPendingRewardGroup;

--- a/apps/evm/src/clients/api/queries/getPendingRewards/formatOutput/formatToIsolatedPoolPendingRewardGroup.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/formatOutput/formatToIsolatedPoolPendingRewardGroup.ts
@@ -1,9 +1,11 @@
 import type BigNumber from 'bignumber.js';
-
-import type { PoolLens } from 'libs/contracts';
 import type { Token } from 'types';
 
-import type { IsolatedPoolPendingReward, IsolatedPoolPendingRewardGroup } from '../types';
+import type {
+  IsolatedPoolPendingReward,
+  IsolatedPoolPendingRewardGroup,
+  PendingInternalRewardSummary,
+} from '../types';
 import formatRewardSummaryData from './formatRewardSummaryData';
 
 function formatToPoolPendingRewardGroup({
@@ -13,7 +15,7 @@ function formatToPoolPendingRewardGroup({
   tokens,
 }: {
   comptrollerContractAddress: string;
-  rewardSummaries: Awaited<ReturnType<PoolLens['getPendingRewards']>>;
+  rewardSummaries: PendingInternalRewardSummary[];
   tokenPriceMapping: Record<string, BigNumber>;
   tokens: Token[];
 }) {

--- a/apps/evm/src/clients/api/queries/getPendingRewards/formatOutput/formatToLegacyPoolPendingRewardGroup.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/formatOutput/formatToLegacyPoolPendingRewardGroup.ts
@@ -1,4 +1,4 @@
-import type BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 
 import type { VenusLens } from 'libs/contracts';
 import type { Token } from 'types';
@@ -18,7 +18,16 @@ function formatToLegacyPoolPendingRewardGroup({
   venusLensPendingRewards: Awaited<ReturnType<VenusLens['pendingRewards']>>;
 }) {
   const rewardSummaryData = formatRewardSummaryData({
-    rewardSummary: venusLensPendingRewards,
+    rewardSummary: {
+      type: 'legacyPool',
+      distributorAddress: venusLensPendingRewards.distributorAddress,
+      rewardTokenAddress: venusLensPendingRewards.rewardTokenAddress,
+      totalRewards: new BigNumber(venusLensPendingRewards.totalRewards.toString()),
+      pendingRewards: venusLensPendingRewards.pendingRewards.map(({ amount, vTokenAddress }) => ({
+        amountMantissa: new BigNumber(amount.toString()),
+        vTokenAddress,
+      })),
+    },
     tokenPriceMapping,
     tokens,
   });

--- a/apps/evm/src/clients/api/queries/getPendingRewards/getMerklRewards/formatMerklRewardsResponse.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/getMerklRewards/formatMerklRewardsResponse.ts
@@ -1,0 +1,104 @@
+import BigNumber from 'bignumber.js';
+import type { MerklDistribution, Token } from 'types';
+import { areAddressesEqual } from 'utilities';
+import type { GetMerklUserRewardsResponse, MerklRewardBreakdown } from '.';
+import type { PendingExternalRewardSummary } from '../types';
+
+export const formatMerklRewardsPayload = (
+  apiPayload: GetMerklUserRewardsResponse,
+  merklCampaigns: Record<string, MerklDistribution[]>,
+): PendingExternalRewardSummary[] => {
+  const allDistributions = Object.values(merklCampaigns).flat();
+
+  // list all Merkl campaign ids and their corresponding reward token
+  const campaignIdRewardTokenMapping = allDistributions.reduce<Record<string, Token>>(
+    (acc, d) => ({
+      ...acc,
+      [d.rewardDetails.merklCampaignIdentifier.toLowerCase()]: d.token,
+    }),
+    {},
+  );
+
+  // from the API response, filter the reward breakdowns from campaigns relevant to Venus
+  // it will only contain one entry at most, since we filtered by chainId
+  const apiRewards = apiPayload?.[0]?.rewards || [];
+
+  // apiRewards is an array of all the user reward tokens in the given chain
+  // these entries are generated from campaigns, and each campaign breakdown tells how much a user can claim/has claimed
+  const campaignIdToBreakdownMapping: Record<string, MerklRewardBreakdown> = {};
+  apiRewards.forEach(reward => {
+    reward.breakdowns.forEach(breakdown => {
+      const campaignId = breakdown.campaignId.toLowerCase();
+      if (campaignIdRewardTokenMapping[campaignId]) {
+        campaignIdToBreakdownMapping[campaignId] = breakdown;
+      }
+    });
+  });
+
+  // for each unique reward token, calculate the total rewards and the pending amounts for each market
+  const merklRewardTokenAddresses = new Set(allDistributions.map(d => d.token.address));
+
+  const pendingMerklRewards = [...merklRewardTokenAddresses].reduce<PendingExternalRewardSummary[]>(
+    (acc, rewardTokenAddress) => {
+      const rewardTokenCampaigns = allDistributions.filter(d =>
+        areAddressesEqual(rewardTokenAddress, d.token.address),
+      );
+      const rewardSummaryForToken = rewardTokenCampaigns.reduce<PendingExternalRewardSummary>(
+        (accRewardSummary, { rewardDetails }) => {
+          const {
+            appName,
+            merklCampaignIdentifier: campaignId,
+            description,
+            claimUrl,
+          } = rewardDetails;
+          const correspondingRewardToken = campaignIdRewardTokenMapping[campaignId.toLowerCase()];
+
+          const campaignBreakdown = campaignIdToBreakdownMapping[campaignId.toLowerCase()];
+
+          const amountLiberated = campaignBreakdown
+            ? new BigNumber(campaignBreakdown.amount)
+            : new BigNumber(0);
+          // the claimable amount is the difference between "amount" and "claimed" in the breakdown
+          // if the API returned no breakdown, there is no reward
+          const amountMantissa =
+            campaignBreakdown && amountLiberated.gt(0)
+              ? amountLiberated.minus(campaignBreakdown.claimed)
+              : new BigNumber(0);
+
+          const pendingReward = {
+            vTokenAddress: rewardDetails.marketAddress,
+            amountMantissa,
+          };
+
+          const pendingRewards = accRewardSummary.pendingRewards.concat(pendingReward);
+
+          return {
+            ...accRewardSummary,
+            campaignId,
+            appName,
+            campaignName: description,
+            claimUrl,
+            rewardTokenAddress: correspondingRewardToken.address,
+            pendingRewards,
+          };
+        },
+        {
+          type: 'external',
+          appName: '',
+          campaignId: '',
+          campaignName: '',
+          claimUrl: '',
+          distributorAddress: '',
+          rewardTokenAddress: '',
+          totalRewards: new BigNumber(0),
+          pendingRewards: [],
+        },
+      );
+
+      return [...acc, rewardSummaryForToken];
+    },
+    [],
+  );
+
+  return pendingMerklRewards;
+};

--- a/apps/evm/src/clients/api/queries/getPendingRewards/getMerklRewards/index.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/getMerklRewards/index.ts
@@ -1,10 +1,10 @@
-import { logError } from 'libs/errors';
+import { VError } from 'libs/errors';
 import type { ChainId, MerklDistribution } from 'types';
 import { restService } from 'utilities';
 import type { PendingExternalRewardSummary } from '../types';
 import { formatMerklRewardsPayload } from './formatMerklRewardsResponse';
 
-const BASE_MERKL_API_URL = 'https://api.merkl.xyz/v4/';
+export const BASE_MERKL_API_URL = 'https://api.merkl.xyz/v4/';
 
 export interface MerklRewardBreakdown {
   reason: string;
@@ -57,8 +57,13 @@ const getMerklUserRewards = async ({
   const payload = response.data;
 
   if (payload && 'error' in payload) {
-    logError(payload.error);
-    return [];
+    throw new VError({
+      type: 'unexpected',
+      code: 'somethingWentWrong',
+      data: {
+        message: payload.error,
+      },
+    });
   }
 
   return payload ? formatMerklRewardsPayload(payload, merklCampaigns) : [];

--- a/apps/evm/src/clients/api/queries/getPendingRewards/getMerklRewards/index.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/getMerklRewards/index.ts
@@ -1,0 +1,67 @@
+import { logError } from 'libs/errors';
+import type { ChainId, MerklDistribution } from 'types';
+import { restService } from 'utilities';
+import type { PendingExternalRewardSummary } from '../types';
+import { formatMerklRewardsPayload } from './formatMerklRewardsResponse';
+
+const BASE_MERKL_API_URL = 'https://api.merkl.xyz/v4/';
+
+export interface MerklRewardBreakdown {
+  reason: string;
+  amount: string; // the amount the user can claim plus what was already claimed
+  claimed: string; // the amount the user has claimed (less or equal than amount)
+  pending: string; // the amount of rewards the user has accumulated but can't be claimed yet
+  campaignId: string;
+  tokenAddress: string;
+}
+
+export type GetMerklUserRewardsResponse = Array<{
+  rewards: {
+    root: string;
+    amount: string;
+    recipient: string;
+    token: {
+      address: string;
+      chainId: number;
+      symbol: string;
+      decimals: number;
+    };
+    breakdowns: MerklRewardBreakdown[];
+  }[];
+}>;
+
+export interface GetMerklUserRewardsInput {
+  chainId: ChainId;
+  accountAddress: string;
+  merklCampaigns: Record<string, MerklDistribution[]>;
+}
+
+export type GetMerklUserRewardsOutput = PendingExternalRewardSummary[];
+
+const getMerklUserRewards = async ({
+  chainId,
+  accountAddress,
+  merklCampaigns,
+}: GetMerklUserRewardsInput): Promise<GetMerklUserRewardsOutput> => {
+  const endpoint = `users/${accountAddress}/rewards`;
+
+  const response = await restService<GetMerklUserRewardsResponse>({
+    baseUrl: BASE_MERKL_API_URL,
+    endpoint,
+    method: 'GET',
+    params: {
+      chainId,
+    },
+  });
+
+  const payload = response.data;
+
+  if (payload && 'error' in payload) {
+    logError(payload.error);
+    return [];
+  }
+
+  return payload ? formatMerklRewardsPayload(payload, merklCampaigns) : [];
+};
+
+export default getMerklUserRewards;

--- a/apps/evm/src/clients/api/queries/getPendingRewards/index.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/index.ts
@@ -16,7 +16,6 @@ import type {
 } from './types';
 
 const getPendingRewards = async ({
-  chainId,
   tokens,
   legacyPoolComptrollerContractAddress,
   isolatedPoolComptrollerAddresses,

--- a/apps/evm/src/clients/api/queries/getPendingRewards/types.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/types.ts
@@ -1,11 +1,10 @@
 import type BigNumber from 'bignumber.js';
 
 import type { PoolLens, Prime, VaiVault, VenusLens, XvsVault } from 'libs/contracts';
-import type { ChainId, Token } from 'types';
+import type { ChainId, MerklDistribution, Token } from 'types';
 import type { Address } from 'viem';
 
 export interface GetPendingRewardsInput {
-  chainId: ChainId;
   tokens: Token[];
   isolatedPoolComptrollerAddresses: string[];
   xvsVestingVaultPoolCount: number;
@@ -16,7 +15,35 @@ export interface GetPendingRewardsInput {
   venusLensContract?: VenusLens;
   primeContract?: Prime;
   legacyPoolComptrollerContractAddress?: string;
+  chainId: ChainId;
+  merklCampaigns: Record<string, MerklDistribution[]>; // maps Asset -> Merkl campaigns
 }
+
+interface PendingRewardEntry {
+  vTokenAddress: string;
+  amountMantissa: BigNumber;
+}
+
+export type PendingInternalRewardSummary = {
+  type: 'legacyPool' | 'isolatedPool';
+  poolComptrollerAddress: string;
+  distributorAddress: string;
+  rewardTokenAddress: string;
+  totalRewards: BigNumber;
+  pendingRewards: PendingRewardEntry[];
+};
+
+export type PendingExternalRewardSummary = {
+  type: 'external';
+  appName: string;
+  campaignId: string;
+  campaignName: string;
+  claimUrl: string;
+  distributorAddress: string;
+  rewardTokenAddress: string;
+  totalRewards: BigNumber;
+  pendingRewards: PendingRewardEntry[];
+};
 
 export interface GetPendingRewardsOutput {
   pendingRewardGroups: PendingRewardGroup[];
@@ -27,6 +54,16 @@ export interface IsolatedPoolPendingReward {
   rewardAmountMantissa: BigNumber;
   rewardAmountCents: BigNumber | undefined;
   vTokenAddressesWithPendingReward: string[];
+  rewardsDistributorAddress: string;
+}
+
+export interface ExternalPendingReward {
+  campaignName: string;
+  appName: string;
+  claimUrl: string;
+  rewardToken: Token;
+  rewardAmountMantissa: BigNumber;
+  rewardAmountCents: BigNumber | undefined;
   rewardsDistributorAddress: string;
 }
 
@@ -43,6 +80,14 @@ export interface LegacyPoolPendingRewardGroup {
   rewardAmountMantissa: BigNumber;
   rewardAmountCents: BigNumber | undefined;
   vTokenAddressesWithPendingReward: string[];
+}
+
+export interface ExternalPendingRewardGroup {
+  type: 'external';
+  claimUrl: string;
+  campaignName: string;
+  appName: string;
+  pendingRewards: ExternalPendingReward[];
 }
 
 export interface VaultPendingRewardGroup {
@@ -82,4 +127,5 @@ export type PendingRewardGroup =
   | IsolatedPoolPendingRewardGroup
   | VaultPendingRewardGroup
   | XvsVestingVaultPendingRewardGroup
-  | PrimePendingRewardGroup;
+  | PrimePendingRewardGroup
+  | ExternalPendingRewardGroup;

--- a/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
@@ -106,7 +106,6 @@ const useGetPendingRewards = (input: TrimmedGetPendingRewardsInput, options?: Pa
           {},
         );
 
-        // and then classify them under the pool (if there are any)
         const merklRewards =
           Object.keys(merklRewardsPerAsset).length > 0
             ? {

--- a/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
@@ -13,7 +13,7 @@ import {
 } from 'libs/contracts';
 import { useGetTokens } from 'libs/tokens';
 import { useChainId } from 'libs/wallet';
-import type { ChainId } from 'types';
+import type { ChainId, MerklDistribution } from 'types';
 import { callOrThrow, generatePseudoRandomRefetchInterval } from 'utilities';
 
 import getPendingRewards from '.';
@@ -34,6 +34,7 @@ type TrimmedGetPendingRewardsInput = Omit<
   | 'xvsTokenAddress'
   | 'tokens'
   | 'chainId'
+  | 'merklCampaigns'
 >;
 
 export type UseGetPendingRewardsQueryKey = [
@@ -73,14 +74,60 @@ const useGetPendingRewards = (input: TrimmedGetPendingRewardsInput, options?: Pa
     accountAddress: input.accountAddress || undefined,
   });
 
-  const isolatedPoolComptrollerAddresses = useMemo(
-    () =>
-      (getPoolsData?.pools || []).reduce<string[]>(
-        (acc, pool) => (pool.isIsolated ? [...acc, pool.comptrollerAddress] : acc),
-        [],
-      ),
-    [getPoolsData?.pools],
-  );
+  const { isolatedPoolComptrollerAddresses, merklCampaigns } = useMemo(() => {
+    const data = (getPoolsData?.pools || []).reduce<{
+      isolatedPoolComptrollerAddresses: string[];
+      merklCampaigns: GetPendingRewardsInput['merklCampaigns'];
+    }>(
+      (acc, pool) => {
+        const comptrollerAddresses = pool.isIsolated
+          ? [...acc.isolatedPoolComptrollerAddresses, pool.comptrollerAddress]
+          : acc.isolatedPoolComptrollerAddresses;
+
+        // list all Merkl rewards for each market present in the pool
+        const { assets } = pool;
+        const merklRewardsPerAsset = assets.reduce<Record<string, MerklDistribution[]>>(
+          (accMerklDistributionsForAsset, a) => {
+            const assetMerklRewards = [
+              ...a.supplyTokenDistributions.filter(d => d.type === 'merkl'),
+              ...a.borrowTokenDistributions.filter(d => d.type === 'merkl'),
+            ];
+
+            const entries =
+              assetMerklRewards.length > 0
+                ? {
+                    ...accMerklDistributionsForAsset,
+                    [a.vToken.address]: assetMerklRewards,
+                  }
+                : accMerklDistributionsForAsset;
+
+            return entries;
+          },
+          {},
+        );
+
+        // and then classify them under the pool (if there are any)
+        const merklRewards =
+          Object.keys(merklRewardsPerAsset).length > 0
+            ? {
+                ...acc.merklCampaigns,
+                ...merklRewardsPerAsset,
+              }
+            : acc.merklCampaigns;
+
+        return {
+          isolatedPoolComptrollerAddresses: comptrollerAddresses,
+          merklCampaigns: merklRewards,
+        };
+      },
+      {
+        isolatedPoolComptrollerAddresses: [],
+        merklCampaigns: {},
+      },
+    );
+
+    return data;
+  }, [getPoolsData?.pools]);
 
   // Get XVS vesting vault pool count
   const { data: getXvsVaultPoolCountData, isLoading: isGetXvsVaultPoolCountLoading } =
@@ -103,7 +150,6 @@ const useGetPendingRewards = (input: TrimmedGetPendingRewardsInput, options?: Pa
         },
         params =>
           getPendingRewards({
-            chainId,
             legacyPoolComptrollerContractAddress,
             venusLensContract,
             isolatedPoolComptrollerAddresses: sortedIsolatedPoolComptrollerAddresses,
@@ -111,6 +157,8 @@ const useGetPendingRewards = (input: TrimmedGetPendingRewardsInput, options?: Pa
             vaiVaultContract,
             tokens,
             primeContract: isPrimeEnabled ? primeContract : undefined,
+            chainId,
+            merklCampaigns,
             ...input,
             ...params,
           }),

--- a/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
@@ -106,6 +106,7 @@ const useGetPendingRewards = (input: TrimmedGetPendingRewardsInput, options?: Pa
           {},
         );
 
+        // and then map them by market
         const merklRewards =
           Object.keys(merklRewardsPerAsset).length > 0
             ? {

--- a/apps/evm/src/clients/api/queries/useGetAsset/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/clients/api/queries/useGetAsset/__snapshots__/index.spec.tsx.snap
@@ -20,6 +20,7 @@ exports[`api/queries/useGetAsset > returns the correct asset 1`] = `
       {
         "apyPercentage": "4.17469243006608279",
         "dailyDistributedTokens": "9999999.5",
+        "isActive": true,
         "token": {
           "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
           "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -56,6 +57,7 @@ exports[`api/queries/useGetAsset > returns the correct asset 1`] = `
       {
         "apyPercentage": "0.11720675342484096",
         "dailyDistributedTokens": "9999999.5",
+        "isActive": true,
         "token": {
           "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
           "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",

--- a/apps/evm/src/clients/api/queries/useGetPool/__snapshots__/index.spec.tsx.snap
+++ b/apps/evm/src/clients/api/queries/useGetPool/__snapshots__/index.spec.tsx.snap
@@ -22,6 +22,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "4.17469243006608279",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -58,6 +59,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "0.11720675342484096",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -97,6 +99,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "1.670327607690572731",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -107,6 +110,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "1.233105649796123742",
+            "isActive": true,
             "referenceValues": {
               "userBorrowBalanceTokens": "1000",
               "userSupplyBalanceTokens": "1000",
@@ -122,6 +126,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "0.913105649796123742",
+            "isActive": true,
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
               "asset": "/src/libs/tokens/img/underlyingTokens/usdc.svg",
@@ -153,6 +158,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "1.353105649796123742",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -163,6 +169,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "0.953105649796123742",
+            "isActive": true,
             "referenceValues": {
               "userBorrowBalanceTokens": "1000",
               "userSupplyBalanceTokens": "1000",
@@ -178,6 +185,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "0.753105649796123742",
+            "isActive": true,
             "token": {
               "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
               "asset": "/src/libs/tokens/img/underlyingTokens/usdc.svg",
@@ -225,6 +233,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "0.522209972682294832",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -235,6 +244,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "1.015310564979612374",
+            "isActive": true,
             "referenceValues": {
               "userBorrowBalanceTokens": "1000",
               "userSupplyBalanceTokens": "1000",
@@ -270,6 +280,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "0.421719501189155143",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -280,6 +291,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "1.753105649796123742",
+            "isActive": true,
             "referenceValues": {
               "userBorrowBalanceTokens": "1000",
               "userSupplyBalanceTokens": "1000",
@@ -324,6 +336,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "0.852697602175970714",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -334,6 +347,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "1.753105649796123742",
+            "isActive": true,
             "referenceValues": {
               "userBorrowBalanceTokens": "1000",
               "userSupplyBalanceTokens": "1000",
@@ -349,6 +363,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "0.913105649796123742",
+            "isActive": true,
             "token": {
               "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
               "asset": "/src/libs/tokens/img/underlyingTokens/busd.svg",
@@ -387,6 +402,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           {
             "apyPercentage": "0.678420831753642169",
             "dailyDistributedTokens": "9999999.5",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -397,6 +413,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "1.753105649796123742",
+            "isActive": true,
             "referenceValues": {
               "userBorrowBalanceTokens": "1000",
               "userSupplyBalanceTokens": "1000",
@@ -412,6 +429,7 @@ exports[`api/queries/useGetPool > returns the correct asset 1`] = `
           },
           {
             "apyPercentage": "0",
+            "isActive": true,
             "token": {
               "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
               "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",

--- a/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.prime.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.prime.spec.ts.snap
@@ -13,19 +13,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowPointDistributions": [],
           "borrowTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "563078969.54779945903835725538",
                 "userSupplyBalanceTokens": "1071811362327614186.97785297335171745333",
@@ -68,19 +57,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           ],
           "supplyTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "563078969.54779945903835725538",
                 "userSupplyBalanceTokens": "1071811362327614186.97785297335171745333",
@@ -126,7 +104,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "1.5797413696681861",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -163,7 +142,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "1.5819817239252298",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -205,7 +185,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "0.6478221277312901",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -242,7 +223,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "0.7921351276470645",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -280,20 +262,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowBalanceTokens": "416884.364702270734855123",
           "borrowCapTokens": "270000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 68,
           "cashTokens": "2259657.074761148481496107",
           "collateralFactor": 0.6,
@@ -317,20 +286,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "639.33143",
           "userBorrowBalanceCents": "63.933143",
           "userBorrowBalanceTokens": "0.1",
@@ -362,7 +318,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "16.981964056809385",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -373,6 +330,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "10009.21",
                 "userSupplyBalanceTokens": "5003.94",
@@ -414,7 +372,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -425,6 +384,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "10009.21",
                 "userSupplyBalanceTokens": "5003.94",
@@ -470,7 +430,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "0.000007467880158706",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -481,6 +442,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "2405.43",
                 "userSupplyBalanceTokens": "13068.75",
@@ -522,7 +484,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -533,6 +496,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "2405.43",
                 "userSupplyBalanceTokens": "13068.75",
@@ -584,21 +548,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowBalanceTokens": "102.672734",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "2649291.731707",
           "collateralFactor": 0.8,
@@ -629,21 +579,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "9999628300000",
           "userBorrowBalanceTokens": "100000000000",
@@ -737,19 +673,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowPointDistributions": [],
           "borrowTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0.000002",
                 "userSupplyBalanceTokens": "2206200.00000079982100000036",
@@ -796,19 +721,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           ],
           "supplyTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0.000002",
                 "userSupplyBalanceTokens": "2206200.00000079982100000036",
@@ -850,20 +764,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowBalanceTokens": "0.267025220823379366",
           "borrowCapTokens": "56000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 5,
           "cashTokens": "0.000705300034659891",
           "collateralFactor": 0.45,
@@ -879,20 +780,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "supplyBalanceTokens": "0.26773052085803925699",
           "supplyCapTokens": "80000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "52505.2944",
           "userBorrowBalanceCents": "5250.52944",
           "userBorrowBalanceTokens": "0.1",
@@ -984,7 +872,21 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowBalanceTokens": "10300.914588649133175062",
           "borrowCapTokens": "200000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [],
+          "borrowTokenDistributions": [
+            {
+              "apyPercentage": "253.70824691591528",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "borrowerCount": 4,
           "cashTokens": "32569.640339677929523638",
           "collateralFactor": 0.65,
@@ -1000,7 +902,21 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "supplyBalanceTokens": "42870.55476159846231009819",
           "supplyCapTokens": "500000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [],
+          "supplyTokenDistributions": [
+            {
+              "apyPercentage": "35.51944135207958",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "tokenPriceCents": "100",
           "userBorrowBalanceCents": "10",
           "userBorrowBalanceTokens": "0.1",
@@ -1030,19 +946,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowPointDistributions": [],
           "borrowTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "1004.648231",
                 "userSupplyBalanceTokens": "142739.88334414285239883265",
@@ -1089,19 +994,8 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           ],
           "supplyTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "1004.648231",
                 "userSupplyBalanceTokens": "142739.88334414285239883265",
@@ -1156,6 +1050,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "borrowTokenDistributions": [
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0",
                 "userSupplyBalanceTokens": "10000",
@@ -1188,6 +1083,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "supplyTokenDistributions": [
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0",
                 "userSupplyBalanceTokens": "10000",
@@ -1248,19 +1144,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowPointDistributions": [],
           "borrowTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.32051113933926345",
+              "isActive": true,
               "token": {
                 "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
                 "asset": "/src/libs/tokens/img/underlyingTokens/busd.svg",
@@ -1271,6 +1156,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "563078969.54779945903835725538",
                 "userSupplyBalanceTokens": "1071811362327614186.97785297335171745333",
@@ -1313,19 +1199,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           ],
           "supplyTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.2904197513866391",
+              "isActive": true,
               "token": {
                 "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
                 "asset": "/src/libs/tokens/img/underlyingTokens/busd.svg",
@@ -1336,6 +1211,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "563078969.54779945903835725538",
                 "userSupplyBalanceTokens": "1071811362327614186.97785297335171745333",
@@ -1381,7 +1257,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "1.5797413696681861",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1418,7 +1295,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "1.5819817239252298",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1460,7 +1338,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "0.6478221277312901",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1497,7 +1376,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "0.7921351276470645",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1535,20 +1415,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowBalanceTokens": "416884.364702270734855123",
           "borrowCapTokens": "270000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 68,
           "cashTokens": "2259657.074761148481496107",
           "collateralFactor": 0.6,
@@ -1572,20 +1439,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "639.33143",
           "userBorrowBalanceCents": "63.933143",
           "userBorrowBalanceTokens": "0.1",
@@ -1617,7 +1471,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "16.981964056809385",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1628,6 +1483,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.32051113933926345",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -1638,6 +1494,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "10009.21",
                 "userSupplyBalanceTokens": "5003.94",
@@ -1679,7 +1536,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1690,6 +1548,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.2904197513866391",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -1700,6 +1559,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "10009.21",
                 "userSupplyBalanceTokens": "5003.94",
@@ -1745,7 +1605,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "0.000007467880158706",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1756,6 +1617,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.32051113933926345",
+              "isActive": true,
               "token": {
                 "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdc.svg",
@@ -1766,6 +1628,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "2405.43",
                 "userSupplyBalanceTokens": "13068.75",
@@ -1807,7 +1670,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1818,6 +1682,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.2904197513866391",
+              "isActive": true,
               "token": {
                 "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdc.svg",
@@ -1828,6 +1693,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "2405.43",
                 "userSupplyBalanceTokens": "13068.75",
@@ -1879,21 +1745,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowBalanceTokens": "102.672734",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "2649291.731707",
           "collateralFactor": 0.8,
@@ -1924,21 +1776,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "9999628300000",
           "userBorrowBalanceTokens": "100000000000",
@@ -2032,19 +1870,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowPointDistributions": [],
           "borrowTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.32051113933926345",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -2055,6 +1882,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0.000002",
                 "userSupplyBalanceTokens": "2206200.00000079982100000036",
@@ -2101,19 +1929,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           ],
           "supplyTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.2904197513866391",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -2124,6 +1941,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0.000002",
                 "userSupplyBalanceTokens": "2206200.00000079982100000036",
@@ -2165,20 +1983,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowBalanceTokens": "0.267025220823379366",
           "borrowCapTokens": "56000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 5,
           "cashTokens": "0.000705300034659891",
           "collateralFactor": 0.45,
@@ -2194,20 +1999,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "supplyBalanceTokens": "0.26773052085803925699",
           "supplyCapTokens": "80000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "52505.2944",
           "userBorrowBalanceCents": "5250.52944",
           "userBorrowBalanceTokens": "0.1",
@@ -2299,7 +2091,21 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowBalanceTokens": "10300.914588649133175062",
           "borrowCapTokens": "200000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [],
+          "borrowTokenDistributions": [
+            {
+              "apyPercentage": "253.70824691591528",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "borrowerCount": 4,
           "cashTokens": "32569.640339677929523638",
           "collateralFactor": 0.65,
@@ -2315,7 +2121,21 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "supplyBalanceTokens": "42870.55476159846231009819",
           "supplyCapTokens": "500000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [],
+          "supplyTokenDistributions": [
+            {
+              "apyPercentage": "35.51944135207958",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "tokenPriceCents": "100",
           "userBorrowBalanceCents": "10",
           "userBorrowBalanceTokens": "0.1",
@@ -2345,19 +2165,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowPointDistributions": [],
           "borrowTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.32051113933926345",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -2368,6 +2177,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "1004.648231",
                 "userSupplyBalanceTokens": "142739.88334414285239883265",
@@ -2414,19 +2224,8 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           ],
           "supplyTokenDistributions": [
             {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
               "apyPercentage": "0.2904197513866391",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -2437,6 +2236,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "1004.648231",
                 "userSupplyBalanceTokens": "142739.88334414285239883265",
@@ -2491,6 +2291,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "borrowTokenDistributions": [
             {
               "apyPercentage": "0.32051113933926345",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -2501,6 +2302,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.20019958435848473",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0",
                 "userSupplyBalanceTokens": "10000",
@@ -2533,6 +2335,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "supplyTokenDistributions": [
             {
               "apyPercentage": "0.2904197513866391",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -2543,6 +2346,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
             },
             {
               "apyPercentage": "0.23026397657694986",
+              "isActive": true,
               "referenceValues": {
                 "userBorrowBalanceTokens": "0",
                 "userSupplyBalanceTokens": "10000",
@@ -2604,18 +2408,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowTokenDistributions": [
             {
               "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-            {
-              "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
                 "asset": "/src/libs/tokens/img/underlyingTokens/busd.svg",
@@ -2654,18 +2447,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "supplyTokenDistributions": [
             {
               "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-            {
-              "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",
                 "asset": "/src/libs/tokens/img/underlyingTokens/busd.svg",
@@ -2706,7 +2488,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "1.5797413696681861",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2743,7 +2526,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "1.5819817239252298",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2785,7 +2569,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "0.6478221277312901",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2822,7 +2607,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "0.7921351276470645",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2860,20 +2646,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowBalanceTokens": "416884.364702270734855123",
           "borrowCapTokens": "270000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 68,
           "cashTokens": "2259657.074761148481496107",
           "collateralFactor": 0.6,
@@ -2897,20 +2670,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "639.33143",
           "userBorrowBalanceCents": "63.933143",
           "userBorrowBalanceTokens": "0.1",
@@ -2942,7 +2702,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "16.981964056809385",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2953,6 +2714,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             },
             {
               "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -2989,7 +2751,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -3000,6 +2763,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             },
             {
               "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -3040,7 +2804,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "0.000007467880158706",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -3051,6 +2816,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             },
             {
               "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdc.svg",
@@ -3087,7 +2853,8 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -3098,6 +2865,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
             },
             {
               "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0x16227D60f7a0e586C66B005219dfc887D13C9531",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdc.svg",
@@ -3144,21 +2912,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowBalanceTokens": "102.672734",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "2649291.731707",
           "collateralFactor": 0.8,
@@ -3189,21 +2943,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "9999628300000",
           "userBorrowBalanceTokens": "100000000000",
@@ -3298,18 +3038,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowTokenDistributions": [
             {
               "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
-              "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -3352,18 +3081,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "supplyTokenDistributions": [
             {
               "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
-              "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -3400,20 +3118,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowBalanceTokens": "0.267025220823379366",
           "borrowCapTokens": "56000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 5,
           "cashTokens": "0.000705300034659891",
           "collateralFactor": 0.45,
@@ -3429,20 +3134,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "supplyBalanceTokens": "0.26773052085803925699",
           "supplyCapTokens": "80000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "52505.2944",
           "userBorrowBalanceCents": "5250.52944",
           "userBorrowBalanceTokens": "0.1",
@@ -3534,7 +3226,21 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowBalanceTokens": "10300.914588649133175062",
           "borrowCapTokens": "200000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [],
+          "borrowTokenDistributions": [
+            {
+              "apyPercentage": "253.70824691591528",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "borrowerCount": 4,
           "cashTokens": "32569.640339677929523638",
           "collateralFactor": 0.65,
@@ -3550,7 +3256,21 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "supplyBalanceTokens": "42870.55476159846231009819",
           "supplyCapTokens": "500000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [],
+          "supplyTokenDistributions": [
+            {
+              "apyPercentage": "35.51944135207958",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "tokenPriceCents": "100",
           "userBorrowBalanceCents": "10",
           "userBorrowBalanceTokens": "0.1",
@@ -3581,18 +3301,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowTokenDistributions": [
             {
               "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
-              "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -3635,18 +3344,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "supplyTokenDistributions": [
             {
               "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-            {
-              "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -3696,6 +3394,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "borrowTokenDistributions": [
             {
               "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
@@ -3723,6 +3422,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "supplyTokenDistributions": [
             {
               "apyPercentage": "0",
+              "isActive": true,
               "token": {
                 "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
                 "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",

--- a/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.spec.ts.snap
@@ -11,20 +11,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "borrowBalanceTokens": "246628588661.936163058800477859",
           "borrowCapTokens": "1e-18",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 438,
           "cashTokens": "1.00000000080503544824460983238917793784e+21",
           "collateralFactor": 0,
@@ -51,20 +38,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "100.00062",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -96,7 +70,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "1.5797413696681861",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -133,7 +108,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "1.5819817239252298",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -175,7 +151,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "0.6478221277312901",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -212,7 +189,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "0.7921351276470645",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -250,20 +228,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "borrowBalanceTokens": "416884.364702270734855123",
           "borrowCapTokens": "270000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 68,
           "cashTokens": "2259657.074761148481496107",
           "collateralFactor": 0.6,
@@ -287,20 +252,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "639.33143",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -332,7 +284,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "16.981964056809385",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -369,7 +322,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -410,7 +364,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "0.000007467880158706",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -447,7 +402,8 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -494,21 +450,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "borrowBalanceTokens": "102.672734",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "2649291.731707",
           "collateralFactor": 0.8,
@@ -539,21 +481,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -645,20 +573,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "borrowBalanceTokens": "0.000004",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 2,
           "cashTokens": "11031000",
           "collateralFactor": 0.8,
@@ -689,20 +604,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -730,20 +632,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "borrowBalanceTokens": "0.267025220823379366",
           "borrowCapTokens": "56000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 5,
           "cashTokens": "0.000705300034659891",
           "collateralFactor": 0.45,
@@ -759,20 +648,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "supplyBalanceTokens": "0.26773052085803925699",
           "supplyCapTokens": "80000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "52505.2944",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -864,7 +740,21 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "borrowBalanceTokens": "10300.914588649133175062",
           "borrowCapTokens": "200000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [],
+          "borrowTokenDistributions": [
+            {
+              "apyPercentage": "253.70824691591528",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "borrowerCount": 4,
           "cashTokens": "32569.640339677929523638",
           "collateralFactor": 0.65,
@@ -880,7 +770,21 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "supplyBalanceTokens": "42870.55476159846231009819",
           "supplyCapTokens": "500000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [],
+          "supplyTokenDistributions": [
+            {
+              "apyPercentage": "35.51944135207958",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "tokenPriceCents": "100",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -908,20 +812,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "borrowBalanceTokens": "1004.648231",
           "borrowCapTokens": "400000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "998174.53518",
           "collateralFactor": 0.8,
@@ -952,20 +843,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -1064,20 +942,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "borrowBalanceTokens": "246628588661.936163058800477859",
           "borrowCapTokens": "1e-18",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 0,
           "cashTokens": "1.00000000080503544824460983238917793784e+21",
           "collateralFactor": 0,
@@ -1104,20 +969,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "100.00062",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -1149,7 +1001,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "4.814274201887225",
               "dailyDistributedTokens": "750.0000384",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1186,7 +1039,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "4.8212088357220795",
               "dailyDistributedTokens": "750.0000384",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1228,7 +1082,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "1.9560488349289473",
               "dailyDistributedTokens": "4499.9999712",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1265,7 +1120,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "2.3952270378375884",
               "dailyDistributedTokens": "4499.9999712",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1303,20 +1159,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "borrowBalanceTokens": "416884.364702270734855123",
           "borrowCapTokens": "270000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 0,
           "cashTokens": "2259657.074761148481496107",
           "collateralFactor": 0.6,
@@ -1340,20 +1183,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "639.33143",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -1385,7 +1215,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "60.0548989604708",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1422,7 +1253,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1463,7 +1295,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "0.00002240364211925",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1500,7 +1333,8 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -1547,21 +1381,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "borrowBalanceTokens": "102.672734",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "2649291.731707",
           "collateralFactor": 0.8,
@@ -1592,21 +1412,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -1698,20 +1504,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "borrowBalanceTokens": "0.000004",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 2,
           "cashTokens": "11031000",
           "collateralFactor": 0.8,
@@ -1742,20 +1535,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -1783,20 +1563,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "borrowBalanceTokens": "0.267025220823379366",
           "borrowCapTokens": "56000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 5,
           "cashTokens": "0.000705300034659891",
           "collateralFactor": 0.45,
@@ -1812,20 +1579,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "supplyBalanceTokens": "0.26773052085803925699",
           "supplyCapTokens": "80000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "52505.2944",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -1917,7 +1671,21 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "borrowBalanceTokens": "10300.914588649133175062",
           "borrowCapTokens": "200000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [],
+          "borrowTokenDistributions": [
+            {
+              "apyPercentage": "4267.887652021992",
+              "dailyDistributedTokens": "107.142857142857136",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "borrowerCount": 4,
           "cashTokens": "32569.640339677929523638",
           "collateralFactor": 0.65,
@@ -1933,7 +1701,21 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "supplyBalanceTokens": "42870.55476159846231009819",
           "supplyCapTokens": "500000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [],
+          "supplyTokenDistributions": [
+            {
+              "apyPercentage": "148.69983759681423",
+              "dailyDistributedTokens": "107.142857142857136",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "tokenPriceCents": "100",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -1961,20 +1743,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "borrowBalanceTokens": "1004.648231",
           "borrowCapTokens": "400000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "998174.53518",
           "collateralFactor": 0.8,
@@ -2005,20 +1774,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -2117,20 +1873,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "borrowBalanceTokens": "246628588661.936163058800477859",
           "borrowCapTokens": "1e-18",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 438,
           "cashTokens": "1.00000000080503544824460983238917793784e+21",
           "collateralFactor": 0,
@@ -2157,20 +1900,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "100.00062",
           "userBorrowBalanceCents": "10.000062",
           "userBorrowBalanceTokens": "0.1",
@@ -2202,7 +1932,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "1.5797413696681861",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2239,7 +1970,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "1.5819817239252298",
               "dailyDistributedTokens": "250.0000128",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2281,7 +2013,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "0.6478221277312901",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2318,7 +2051,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "0.7921351276470645",
               "dailyDistributedTokens": "1499.9999904",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2356,20 +2090,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "borrowBalanceTokens": "416884.364702270734855123",
           "borrowCapTokens": "270000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 68,
           "cashTokens": "2259657.074761148481496107",
           "collateralFactor": 0.6,
@@ -2393,20 +2114,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
               "title": "Fake points",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
-                "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
-                "decimals": 18,
-                "symbol": "XVS",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "639.33143",
           "userBorrowBalanceCents": "63.933143",
           "userBorrowBalanceTokens": "0.1",
@@ -2438,7 +2146,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "16.981964056809385",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2475,7 +2184,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2516,7 +2226,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "0.000007467880158706",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2553,7 +2264,8 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
             {
               "apyPercentage": "0",
               "dailyDistributedTokens": "499.9999968",
-              "description": undefined,
+              "isActive": true,
+              "rewardDetails": undefined,
               "token": {
                 "address": "0xB9e0E753630434d7863528cc73CB7AC638a7c8ff",
                 "asset": "/src/libs/tokens/img/underlyingTokens/xvs.svg",
@@ -2600,21 +2312,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "borrowBalanceTokens": "102.672734",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "2649291.731707",
           "collateralFactor": 0.8,
@@ -2645,21 +2343,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "claimUrl": undefined,
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xA11c8D9DC9b66E209Ef60F0C8D969D3CD988782c",
-                "asset": "/src/libs/tokens/img/underlyingTokens/usdt.svg",
-                "decimals": 6,
-                "symbol": "USDT",
-              },
-              "type": "merkl",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "9999628300000",
           "userBorrowBalanceTokens": "100000000000",
@@ -2751,20 +2435,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "borrowBalanceTokens": "0.000004",
           "borrowCapTokens": "14880000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 2,
           "cashTokens": "11031000",
           "collateralFactor": 0.8,
@@ -2795,20 +2466,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "0",
           "userBorrowBalanceTokens": "0",
@@ -2836,20 +2494,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "borrowBalanceTokens": "0.267025220823379366",
           "borrowCapTokens": "56000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 5,
           "cashTokens": "0.000705300034659891",
           "collateralFactor": 0.45,
@@ -2865,20 +2510,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "supplyBalanceTokens": "0.26773052085803925699",
           "supplyCapTokens": "80000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "52505.2944",
           "userBorrowBalanceCents": "5250.52944",
           "userBorrowBalanceTokens": "0.1",
@@ -2970,7 +2602,21 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "borrowBalanceTokens": "10300.914588649133175062",
           "borrowCapTokens": "200000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [],
+          "borrowTokenDistributions": [
+            {
+              "apyPercentage": "253.70824691591528",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "borrowerCount": 4,
           "cashTokens": "32569.640339677929523638",
           "collateralFactor": 0.65,
@@ -2986,7 +2632,21 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "supplyBalanceTokens": "42870.55476159846231009819",
           "supplyCapTokens": "500000",
           "supplyPointDistributions": [],
-          "supplyTokenDistributions": [],
+          "supplyTokenDistributions": [
+            {
+              "apyPercentage": "35.51944135207958",
+              "dailyDistributedTokens": "35.714285714285712",
+              "isActive": false,
+              "rewardDetails": undefined,
+              "token": {
+                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
+                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
+                "decimals": 18,
+                "symbol": "lisUSD",
+              },
+              "type": "venus",
+            },
+          ],
           "tokenPriceCents": "100",
           "userBorrowBalanceCents": "10",
           "userBorrowBalanceTokens": "0.1",
@@ -3014,20 +2674,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "borrowBalanceTokens": "1004.648231",
           "borrowCapTokens": "400000",
           "borrowPointDistributions": [],
-          "borrowTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "borrowTokenDistributions": [],
           "borrowerCount": 1,
           "cashTokens": "998174.53518",
           "collateralFactor": 0.8,
@@ -3058,20 +2705,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
               "title": "Fake points 2",
             },
           ],
-          "supplyTokenDistributions": [
-            {
-              "apyPercentage": "0",
-              "dailyDistributedTokens": "0",
-              "description": undefined,
-              "token": {
-                "address": "0xe73774DfCD551BF75650772dC2cC56a2B6323453",
-                "asset": "/src/libs/tokens/img/underlyingTokens/lisUSD.png",
-                "decimals": 18,
-                "symbol": "lisUSD",
-              },
-              "type": "venus",
-            },
-          ],
+          "supplyTokenDistributions": [],
           "tokenPriceCents": "99.996283",
           "userBorrowBalanceCents": "9999628300000",
           "userBorrowBalanceTokens": "100000000000",

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/appendPrimeSimulationDistributions/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/appendPrimeSimulationDistributions/index.ts
@@ -101,6 +101,7 @@ export const appendPrimeSimulationDistributions = async ({
             type: 'primeSimulation',
             token: asset.vToken.underlyingToken,
             apyPercentage: borrowSimulatedPrimeApy,
+            isActive: true,
             referenceValues,
           });
         }
@@ -114,6 +115,7 @@ export const appendPrimeSimulationDistributions = async ({
             type: 'primeSimulation',
             token: asset.vToken.underlyingToken,
             apyPercentage: supplySimulatedPrimeApy,
+            isActive: true,
             referenceValues,
           });
         }

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/isDistributingRewards/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/isDistributingRewards/index.ts
@@ -11,9 +11,8 @@ export const isDistributingRewards = ({
   lastRewardingBlock?: number;
   currentBlockNumber: bigint;
 }): boolean => {
-  const nowTimestamp = getUnixTime(new Date());
-
   if (isTimeBasedOrMerklReward && typeof lastRewardingTimestamp === 'number') {
+    const nowTimestamp = getUnixTime(new Date());
     return lastRewardingTimestamp === 0 || lastRewardingTimestamp >= nowTimestamp;
   }
 

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/index.ts
@@ -150,7 +150,7 @@ export const formatOutput = ({
         supplyBalanceTokens,
         borrowBalanceTokens,
         currentBlockNumber,
-        apiRewardsDistributors: market.rewardsDistributors.filter(rd => rd.isActive),
+        apiRewardsDistributors: market.rewardsDistributors,
         apiPointDistributions: market.pointDistributions,
       });
 

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/getApiPools/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/getApiPools/index.ts
@@ -6,7 +6,7 @@ import { type ApiPointDistribution, pointDistributions } from './pointDistributi
 
 export type { ApiPointDistribution } from './pointDistributions';
 
-export interface ApiRewardDistributor {
+interface ApiReward {
   marketAddress: Address;
   rewardTokenAddress: Address;
   lastRewardingSupplyBlockOrTimestamp: string;
@@ -15,13 +15,27 @@ export interface ApiRewardDistributor {
   borrowSpeed: string;
   priceMantissa: string;
   rewardsDistributorContractAddress: Address;
-  rewardType: 'venus' | 'merkl';
   isActive: boolean;
-  rewardDetails?: {
-    description?: string;
-    claimUrl?: string;
+}
+
+interface ApiVenusReward extends ApiReward {
+  rewardType: 'venus';
+  rewardDetails: null;
+}
+
+interface ApiMerklReward extends ApiReward {
+  rewardType: 'merkl';
+  rewardDetails: {
+    appName: string;
+    claimUrl: string;
+    merklCampaignId: string;
+    description: string;
+    merklCampaignIdentifier: string;
+    tags: string[];
   };
 }
+
+export type ApiRewardDistributor = ApiVenusReward | ApiMerklReward;
 
 export interface ApiMarket {
   address: Address;

--- a/apps/evm/src/components/Apy/BoostTooltip/index.tsx
+++ b/apps/evm/src/components/Apy/BoostTooltip/index.tsx
@@ -49,7 +49,7 @@ export const BoostTooltip: React.FC<BoostTooltipProps> = ({
 
     if (d.type === 'merkl') {
       const distribution: DistributionProps = {
-        name: d.description || t('apy.boost.tooltip.defaultMerklRewardName'),
+        name: d.rewardDetails.description || t('apy.boost.tooltip.defaultMerklRewardName'),
         value: formatPercentageToReadableValue(d.apyPercentage),
         logoSrc: d.token.asset,
         description: (
@@ -57,7 +57,11 @@ export const BoostTooltip: React.FC<BoostTooltipProps> = ({
             i18nKey="apy.boost.tooltip.externalRewardDescription"
             components={{
               AppLink: (
-                <Link target="_blank" href={d.claimUrl} onClick={e => e.stopPropagation()} />
+                <Link
+                  target="_blank"
+                  href={d.rewardDetails.claimUrl}
+                  onClick={e => e.stopPropagation()}
+                />
               ),
             }}
           />

--- a/apps/evm/src/components/Apy/index.tsx
+++ b/apps/evm/src/components/Apy/index.tsx
@@ -35,7 +35,9 @@ export const Apy: React.FC<ApyProps> = ({ asset, type }) => {
   let primeDistribution: PrimeDistribution | undefined;
   let primeSimulationDistribution: PrimeSimulationDistribution | undefined;
   const tokenDistributions =
-    type === 'supply' ? asset.supplyTokenDistributions : asset.borrowTokenDistributions;
+    type === 'supply'
+      ? asset.supplyTokenDistributions.filter(d => d.isActive)
+      : asset.borrowTokenDistributions.filter(d => d.isActive);
 
   tokenDistributions.forEach(distribution => {
     if (distribution.type === 'prime') {

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
@@ -49,7 +49,7 @@ export const ClaimRewardsContent = ({
     >
       {hasInternalRewards && (
         <RewardGroupFrame
-          className={cn(hasExternalRewards && 'border-b pb-4 mb-4 md:mb-0')}
+          className={cn(hasExternalRewards && 'border-b pb-6 mb-4 md:mb-0')}
           title={t('claimReward.modal.rewards')}
           claimComponent={
             <Checkbox
@@ -59,7 +59,7 @@ export const ClaimRewardsContent = ({
             />
           }
         >
-          <div data-testid={TEST_IDS.claimRewardBreakdown}>
+          <div data-testid={TEST_IDS.claimRewardBreakdown} className="space-y-4">
             {internalRewardsGroups.map(group => (
               <InternalRewardGroup
                 group={group}
@@ -90,7 +90,7 @@ export const ClaimRewardsContent = ({
       )}
       {hasExternalRewards && (
         <RewardGroupFrame title={t('claimReward.modal.externalRewards')}>
-          <div data-testid={TEST_IDS.claimExternalRewardBreakdown}>
+          <div data-testid={TEST_IDS.claimExternalRewardBreakdown} className="space-y-4">
             {externalRewardsGroups.map(group => (
               <ExternalRewardGroup
                 group={group}

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
@@ -41,6 +41,7 @@ export const ClaimRewardsContent = ({
   const isSubmitDisabled = !internalRewardsGroups.some(group => group.isChecked);
   const hasInternalRewards = internalRewardsGroups.length > 0;
   const hasExternalRewards = externalRewardsGroups.length > 0;
+
   return (
     <div
       className="flex flex-col md:gap-4 md:rounded-3xl md:mx-4"

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
@@ -1,9 +1,9 @@
-import { Checkbox, PrimaryButton } from 'components';
+import { PrimaryButton, cn } from '@venusprotocol/ui';
+import { Checkbox } from 'components';
 import { ConnectWallet } from 'containers/ConnectWallet';
 import { SwitchChain } from 'containers/SwitchChain';
 import { handleError } from 'libs/errors';
 import { useTranslation } from 'react-i18next';
-import { cn } from 'utilities';
 import TEST_IDS from '../../testIds';
 import { ExternalRewardGroup } from '../ExternalRewardGroup';
 import { InternalRewardGroup } from '../InternalRewardGroup';

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/ClaimRewardsContent/index.tsx
@@ -1,0 +1,104 @@
+import { Checkbox, PrimaryButton } from 'components';
+import { ConnectWallet } from 'containers/ConnectWallet';
+import { SwitchChain } from 'containers/SwitchChain';
+import { handleError } from 'libs/errors';
+import { useTranslation } from 'react-i18next';
+import { cn } from 'utilities';
+import TEST_IDS from '../../testIds';
+import { ExternalRewardGroup } from '../ExternalRewardGroup';
+import { InternalRewardGroup } from '../InternalRewardGroup';
+import { RewardGroupFrame } from '../RewardGroupFrame';
+import type { ExternalRewardsGroup, InternalRewardsGroup } from '../types';
+
+interface ClaimRewardsContentProps {
+  isClaimingRewards: boolean;
+  internalRewardsGroups: InternalRewardsGroup[];
+  externalRewardsGroups: ExternalRewardsGroup[];
+  onCloseModal: () => void;
+  onClaimReward: () => Promise<unknown>;
+  onToggleAllGroups: () => void;
+  onToggleGroup: (toggledGroup: InternalRewardsGroup) => void;
+}
+export const ClaimRewardsContent = ({
+  isClaimingRewards,
+  internalRewardsGroups,
+  externalRewardsGroups,
+  onCloseModal,
+  onClaimReward,
+  onToggleAllGroups,
+  onToggleGroup,
+}: ClaimRewardsContentProps) => {
+  const { t } = useTranslation();
+  const handleClaimReward = async () => {
+    try {
+      await onClaimReward();
+      onCloseModal();
+    } catch (error) {
+      handleError({ error });
+    }
+  };
+
+  const isSubmitDisabled = !internalRewardsGroups.some(group => group.isChecked);
+  const hasInternalRewards = internalRewardsGroups.length > 0;
+  const hasExternalRewards = externalRewardsGroups.length > 0;
+  return (
+    <div
+      className="flex flex-col md:gap-4 md:rounded-3xl md:mx-4"
+      onClick={e => e.stopPropagation()}
+    >
+      {hasInternalRewards && (
+        <RewardGroupFrame
+          className={cn(hasExternalRewards && 'border-b pb-4 mb-4 md:mb-0')}
+          title={t('claimReward.modal.rewards')}
+          claimComponent={
+            <Checkbox
+              onChange={onToggleAllGroups}
+              value={internalRewardsGroups.every(group => group.isChecked || group.isDisabled)}
+              data-testid={TEST_IDS.claimRewardSelectAllCheckbox}
+            />
+          }
+        >
+          <div data-testid={TEST_IDS.claimRewardBreakdown}>
+            {internalRewardsGroups.map(group => (
+              <InternalRewardGroup
+                group={group}
+                onCheckChange={() => onToggleGroup(group)}
+                key={`claim-reward-modal-reward-group-${group.id}`}
+              />
+            ))}
+          </div>
+
+          <div className="w-full mt-4">
+            <ConnectWallet>
+              <SwitchChain>
+                <PrimaryButton
+                  className="w-full"
+                  onClick={handleClaimReward}
+                  disabled={isSubmitDisabled}
+                  data-testid={TEST_IDS.claimRewardSubmitButton}
+                  loading={isClaimingRewards}
+                >
+                  {isSubmitDisabled
+                    ? t('claimReward.modal.claimButton.disabledLabel')
+                    : t('claimReward.modal.claimButton.enabledLabel')}
+                </PrimaryButton>
+              </SwitchChain>
+            </ConnectWallet>
+          </div>
+        </RewardGroupFrame>
+      )}
+      {hasExternalRewards && (
+        <RewardGroupFrame title={t('claimReward.modal.externalRewards')}>
+          <div data-testid={TEST_IDS.claimExternalRewardBreakdown}>
+            {externalRewardsGroups.map(group => (
+              <ExternalRewardGroup
+                group={group}
+                key={`claim-reward-modal-external-reward-group-${group.id}`}
+              />
+            ))}
+          </div>
+        </RewardGroupFrame>
+      )}
+    </div>
+  );
+};

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/ExternalRewardGroup/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/ExternalRewardGroup/index.tsx
@@ -1,0 +1,31 @@
+import { Icon } from 'components';
+
+import { Link } from 'containers/Link';
+import { useTranslation } from 'libs/translations';
+import { RewardGroupContent } from '../RewardGroupContent';
+import type { ExternalRewardsGroup } from '../types';
+
+export interface RewardGroupProps {
+  group: ExternalRewardsGroup;
+}
+
+export const ExternalRewardGroup: React.FC<RewardGroupProps> = ({ group }) => {
+  const { t } = useTranslation();
+
+  return (
+    <RewardGroupContent
+      rightTitleComponent={
+        <Link
+          className="flex flex-row items-center"
+          target="_blank"
+          href={group.claimUrl}
+          onClick={e => e.stopPropagation()}
+        >
+          {t('claimReward.modal.claimOn', { appName: group.appName })}
+          <Icon className="text-blue" name="arrowRight" />
+        </Link>
+      }
+      group={group}
+    />
+  );
+};

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/InternalRewardGroup/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/InternalRewardGroup/index.tsx
@@ -1,0 +1,23 @@
+import { Checkbox, type CheckboxProps } from 'components';
+
+import { RewardGroupContent } from '../RewardGroupContent';
+import type { InternalRewardsGroup } from '../types';
+
+export interface RewardGroupProps {
+  group: InternalRewardsGroup;
+  onCheckChange?: (newIsChecked: boolean) => void;
+}
+
+export const InternalRewardGroup: React.FC<RewardGroupProps> = ({ group, onCheckChange }) => {
+  const handleOnCheckChange: CheckboxProps['onChange'] = event =>
+    onCheckChange?.(event.currentTarget.checked);
+
+  return (
+    <RewardGroupContent
+      rightTitleComponent={
+        !group.isDisabled && <Checkbox onChange={handleOnCheckChange} value={group.isChecked} />
+      }
+      group={group}
+    />
+  );
+};

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupContent/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupContent/index.tsx
@@ -1,20 +1,17 @@
+import { LayeredValues, TokenIconWithSymbol } from 'components';
 import { useMemo } from 'react';
-
-import { Checkbox, type CheckboxProps, LayeredValues, TokenIconWithSymbol } from 'components';
 import { convertMantissaToTokens, formatCentsToReadableValue } from 'utilities';
+import type { ExternalRewardsGroup, InternalRewardsGroup, PendingReward } from '../types';
 
-import type { Group, PendingReward } from '../types';
-
-export interface RewardGroupProps {
-  group: Group;
-  onCheckChange: (newIsChecked: boolean) => void;
+export interface RewardGroupContentProps {
+  rightTitleComponent: React.ReactNode;
+  group: InternalRewardsGroup | ExternalRewardsGroup;
 }
 
-export const RewardGroup: React.FC<RewardGroupProps> = ({ group, onCheckChange }) => {
-  const handleOnCheckChange: CheckboxProps['onChange'] = event =>
-    onCheckChange(event.currentTarget.checked);
-
-  // Group pending rewards by reward token
+export const RewardGroupContent: React.FC<RewardGroupContentProps> = ({
+  rightTitleComponent,
+  group,
+}: RewardGroupContentProps) => {
   const pendingRewards = useMemo(() => {
     const pendingRewardMapping = new Map<string, PendingReward>([]);
 
@@ -33,22 +30,21 @@ export const RewardGroup: React.FC<RewardGroupProps> = ({ group, onCheckChange }
 
     return Array.from(pendingRewardMapping.values());
   }, [group.pendingRewards]);
-
   return (
-    <div className="border-lightGrey mb-4 border-b pb-4 last:border-none last:pb-0">
-      <div className="mb-4">
+    <div className="border-lightGrey mb-4 last:mb-0">
+      <div className="my-4">
         <div className="flex items-center justify-between">
           <p className="text-lg">{group.name}</p>
 
-          {!group.isDisabled && <Checkbox onChange={handleOnCheckChange} value={group.isChecked} />}
+          {rightTitleComponent}
         </div>
 
-        {group.warningMessage && <p className="text-orange mt-2">{group.warningMessage}</p>}
+        {group.warningMessage}
       </div>
 
       {pendingRewards.map(pendingReward => (
         <div
-          className="mb-4 flex items-center justify-between last:mb-0"
+          className="border-lightGrey mb-4 flex items-center border-b last:border-b-0 justify-between last:mb-0"
           key={`reward-group-${group.name}-${pendingReward.rewardToken.address}`}
         >
           <div className="flex">

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupContent/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupContent/index.tsx
@@ -31,8 +31,8 @@ export const RewardGroupContent: React.FC<RewardGroupContentProps> = ({
     return Array.from(pendingRewardMapping.values());
   }, [group.pendingRewards]);
   return (
-    <div className="border-lightGrey mb-4 last:mb-0">
-      <div className="my-4">
+    <div>
+      <div className="mb-4">
         <div className="flex items-center justify-between">
           <p className="text-lg">{group.name}</p>
 
@@ -42,28 +42,30 @@ export const RewardGroupContent: React.FC<RewardGroupContentProps> = ({
         {group.warningMessage}
       </div>
 
-      {pendingRewards.map(pendingReward => (
-        <div
-          className="border-lightGrey mb-4 flex items-center border-b last:border-b-0 justify-between last:mb-0"
-          key={`reward-group-${group.name}-${pendingReward.rewardToken.address}`}
-        >
-          <div className="flex">
-            <TokenIconWithSymbol token={pendingReward.rewardToken} />
-          </div>
+      <div className="space-y-3">
+        {pendingRewards.map(pendingReward => (
+          <div
+            className="flex items-start justify-between"
+            key={`reward-group-${group.name}-${pendingReward.rewardToken.address}`}
+          >
+            <div className="flex">
+              <TokenIconWithSymbol token={pendingReward.rewardToken} />
+            </div>
 
-          <LayeredValues
-            className="text-end"
-            topValue={formatCentsToReadableValue({
-              value: pendingReward.rewardAmountCents,
-            })}
-            bottomValue={convertMantissaToTokens({
-              value: pendingReward.rewardAmountMantissa,
-              token: pendingReward.rewardToken,
-              returnInReadableFormat: true,
-            })}
-          />
-        </div>
-      ))}
+            <LayeredValues
+              className="text-end"
+              topValue={formatCentsToReadableValue({
+                value: pendingReward.rewardAmountCents,
+              })}
+              bottomValue={convertMantissaToTokens({
+                value: pendingReward.rewardAmountMantissa,
+                token: pendingReward.rewardToken,
+                returnInReadableFormat: true,
+              })}
+            />
+          </div>
+        ))}
+      </div>
     </div>
   );
 };

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupFrame/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupFrame/index.tsx
@@ -1,0 +1,27 @@
+import { cn } from 'utilities';
+
+export interface RewardGroupFrameProps {
+  className?: string;
+  title: string;
+  children: React.ReactNode;
+  claimComponent?: React.ReactNode;
+}
+
+export const RewardGroupFrame: React.FC<RewardGroupFrameProps> = ({
+  className,
+  children,
+  claimComponent,
+  title,
+}: RewardGroupFrameProps) => {
+  return (
+    <div
+      className={cn('border-lightGrey md:rounded-2xl md:border px-4 md:py-6 bg-cards', className)}
+    >
+      <div className="border-lightGrey flex items-center justify-between border-b pb-4 mb-4">
+        <p className="text-lg">{title}</p>
+        {claimComponent}
+      </div>
+      {children}
+    </div>
+  );
+};

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupFrame/index.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/RewardGroupFrame/index.tsx
@@ -1,4 +1,4 @@
-import { cn } from 'utilities';
+import { cn } from '@venusprotocol/ui';
 
 export interface RewardGroupFrameProps {
   className?: string;

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/__testUtils__/fakeData.ts
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/__testUtils__/fakeData.ts
@@ -1,7 +1,7 @@
 import { BigNumber } from 'bignumber.js';
 
 import { poolData } from '__mocks__/models/pools';
-import { vai, xvs } from '__mocks__/models/tokens';
+import { bnb, usdt, vai, xvs } from '__mocks__/models/tokens';
 
 import type { PendingRewardGroup } from 'clients/api/queries/getPendingRewards/types';
 
@@ -75,6 +75,40 @@ export const fakePendingRewardGroups: PendingRewardGroup[] = [
         rewardToken: xvs,
         rewardAmountMantissa: new BigNumber('3000000000000000000000000000'),
         rewardAmountCents: new BigNumber('112'),
+      },
+    ],
+  },
+  {
+    type: 'external',
+    appName: 'Mock App',
+    campaignName: 'Mock campaign',
+    claimUrl: 'http://mock.app',
+    pendingRewards: [
+      {
+        appName: 'Mock App',
+        campaignName: 'Mock campaign',
+        claimUrl: 'http://mock.app',
+        rewardAmountCents: new BigNumber('700'),
+        rewardAmountMantissa: new BigNumber('1000000000000000000000000000'),
+        rewardsDistributorAddress: '',
+        rewardToken: bnb,
+      },
+    ],
+  },
+  {
+    type: 'external',
+    appName: 'Mock App 2',
+    campaignName: 'Mock campaign 2',
+    claimUrl: 'http://mock2.app',
+    pendingRewards: [
+      {
+        appName: 'Mock App 2',
+        campaignName: 'Mock campaign 2',
+        claimUrl: 'http://mock2.app',
+        rewardAmountCents: new BigNumber('123'),
+        rewardAmountMantissa: new BigNumber('12300000000'),
+        rewardsDistributorAddress: '',
+        rewardToken: usdt,
       },
     ],
   },

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
@@ -87,7 +87,7 @@ describe('ClaimRewardButton', () => {
     fireEvent.click(getByTestId(TEST_IDS.claimRewardOpenModalButton));
 
     await waitFor(() =>
-      expect(getByText(en.layout.claimRewardModal.vaultGroup.disabledContractWarningMessage)),
+      expect(getByText(en.claimReward.modal.vaultGroup.disabledContractWarningMessage)),
     );
   });
 
@@ -115,7 +115,7 @@ describe('ClaimRewardButton', () => {
     fireEvent.click(getByTestId(TEST_IDS.claimRewardOpenModalButton));
 
     await waitFor(() =>
-      expect(getByText(en.layout.claimRewardModal.vaultGroup.disabledContractWarningMessage)),
+      expect(getByText(en.claimReward.modal.vaultGroup.disabledContractWarningMessage)),
     );
   });
 
@@ -143,7 +143,7 @@ describe('ClaimRewardButton', () => {
     fireEvent.click(getByTestId(TEST_IDS.claimRewardOpenModalButton));
 
     await waitFor(() =>
-      expect(getByText(en.layout.claimRewardModal.primeGroup.disabledContractWarningMessage)),
+      expect(getByText(en.claimReward.modal.primeGroup.disabledContractWarningMessage)),
     );
   });
 

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
@@ -241,14 +241,7 @@ describe('ClaimRewardButton', () => {
     await waitFor(() => expect(claimRewards).toHaveBeenCalledTimes(1));
     expect((claimRewards as Mock).mock.calls[0][0]).toMatchSnapshot();
 
-    await waitFor(() =>
-      expect(queryByTestId(TEST_IDS.claimRewardMobileOverlay)).not.toHaveClass('opacity-100'),
-    );
-    await waitFor(() =>
-      expect(queryByTestId(TEST_IDS.claimRewardMobileOverlay)).not.toHaveClass(
-        'pointer-events-auto',
-      ),
-    );
+    await waitFor(() => expect(queryByTestId(TEST_IDS.claimRewardSubmitButton)).toBeNull());
   });
 
   it('it claims only selected and enabled rewards on submit button click on success', async () => {
@@ -288,5 +281,34 @@ describe('ClaimRewardButton', () => {
 
     await waitFor(() => expect(claimRewards).toHaveBeenCalledTimes(1));
     expect((claimRewards as Mock).mock.calls[0][0]).toMatchSnapshot();
+  });
+
+  it('renders external rewards if user has pending external rewards to claim', async () => {
+    const { getByTestId, queryByText } = renderComponent(<ClaimRewardButton />, {
+      accountAddress: fakeAddress,
+    });
+    await waitFor(() => expect(getByTestId(TEST_IDS.claimRewardOpenModalButton)));
+    // Open modal
+    fireEvent.click(getByTestId(TEST_IDS.claimRewardOpenModalButton));
+
+    await waitFor(() => expect(getByTestId(TEST_IDS.claimExternalRewardBreakdown)));
+
+    const fakeExternalRewards = fakePendingRewardGroups.filter(g => g.type === 'external');
+    await waitFor(() => expect(queryByText(fakeExternalRewards[0].campaignName)));
+    await waitFor(() => expect(queryByText(fakeExternalRewards[1].campaignName)));
+  });
+
+  it('does not render external rewards if there is none of this type', async () => {
+    (getPendingRewards as Mock).mockImplementation(() => ({
+      pendingRewardGroups: fakePendingRewardGroups.filter(g => g.type !== 'external'),
+    }));
+    const { getByTestId, queryByTestId } = renderComponent(<ClaimRewardButton />, {
+      accountAddress: fakeAddress,
+    });
+    await waitFor(() => expect(getByTestId(TEST_IDS.claimRewardOpenModalButton)));
+    // Open modal
+    fireEvent.click(getByTestId(TEST_IDS.claimRewardOpenModalButton));
+
+    await waitFor(() => expect(queryByTestId(TEST_IDS.claimExternalRewardBreakdown)).toBeNull());
   });
 });

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/__tests__/index.spec.tsx
@@ -241,7 +241,14 @@ describe('ClaimRewardButton', () => {
     await waitFor(() => expect(claimRewards).toHaveBeenCalledTimes(1));
     expect((claimRewards as Mock).mock.calls[0][0]).toMatchSnapshot();
 
-    await waitFor(() => expect(queryByTestId(TEST_IDS.claimRewardSubmitButton)).toBeNull());
+    await waitFor(() =>
+      expect(queryByTestId(TEST_IDS.claimRewardMobileOverlay)).not.toHaveClass('opacity-100'),
+    );
+    await waitFor(() =>
+      expect(queryByTestId(TEST_IDS.claimRewardMobileOverlay)).not.toHaveClass(
+        'pointer-events-auto',
+      ),
+    );
   });
 
   it('it claims only selected and enabled rewards on submit button click on success', async () => {

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/types.ts
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/types.ts
@@ -9,12 +9,23 @@ export interface PendingReward {
   rewardAmountCents: BigNumber | undefined;
 }
 
-export interface Group {
+interface RewardsGroup {
   id: string;
   name: string;
-  isChecked: boolean;
   pendingRewards: PendingReward[];
+  warningMessage?: string | React.ReactNode;
+}
+
+export interface InternalRewardsGroup extends RewardsGroup {
+  isChecked: boolean;
   claims: Claim[];
   isDisabled?: boolean;
-  warningMessage?: string;
 }
+
+export interface ExternalRewardsGroup extends RewardsGroup {
+  claimUrl: string;
+  campaignName: string;
+  appName: string;
+}
+
+export type Group = InternalRewardsGroup | ExternalRewardsGroup;

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/useGetGroups.ts
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/useGetGroups.ts
@@ -5,7 +5,7 @@ import { NULL_ADDRESS } from 'constants/address';
 import { useGetToken } from 'libs/tokens';
 import { useTranslation } from 'libs/translations';
 import { useAccountAddress } from 'libs/wallet';
-import type { Group } from './types';
+import type { ExternalRewardsGroup, Group, InternalRewardsGroup } from './types';
 
 const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) => {
   const { t } = useTranslation();
@@ -29,149 +29,165 @@ const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) =>
   );
 
   // Format pending rewards into groups
-  return useMemo(
+  const internalRewards =
+    getPendingRewardsData?.pendingRewardGroups.filter(g => g.type !== 'external') || [];
+  const externalRewards =
+    getPendingRewardsData?.pendingRewardGroups.filter(g => g.type === 'external') || [];
+  const internalRewardsGroups = useMemo(
     () =>
-      (getPendingRewardsData?.pendingRewardGroups || []).reduce<Group[]>(
-        (acc, pendingRewardGroup) => {
-          // Vaults
-          if (
-            pendingRewardGroup.type === 'vault' ||
-            pendingRewardGroup.type === 'xvsVestingVault'
-          ) {
-            const id =
-              pendingRewardGroup.type === 'vault'
-                ? `vault-${pendingRewardGroup.stakedToken.address}-${pendingRewardGroup.rewardToken.address}`
-                : `xvs-vesting-vault-${pendingRewardGroup.rewardToken.asset}-${pendingRewardGroup.poolIndex}`;
+      internalRewards.reduce<InternalRewardsGroup[]>((acc, pendingRewardGroup) => {
+        // Vaults
+        if (pendingRewardGroup.type === 'vault' || pendingRewardGroup.type === 'xvsVestingVault') {
+          const id =
+            pendingRewardGroup.type === 'vault'
+              ? `vault-${pendingRewardGroup.stakedToken.address}-${pendingRewardGroup.rewardToken.address}`
+              : `xvs-vesting-vault-${pendingRewardGroup.rewardToken.asset}-${pendingRewardGroup.poolIndex}`;
 
-            const name =
-              pendingRewardGroup.type === 'vault'
-                ? t('layout.claimRewardModal.vaultGroup.name', {
-                    stakedTokenSymbol: pendingRewardGroup.stakedToken.symbol,
-                  })
-                : t('layout.claimRewardModal.vestingVaultGroup.name', {
-                    stakedTokenSymbol: xvs?.symbol,
-                  });
+          const name =
+            pendingRewardGroup.type === 'vault'
+              ? t('layout.claimRewardModal.vaultGroup.name', {
+                  stakedTokenSymbol: pendingRewardGroup.stakedToken.symbol,
+                })
+              : t('layout.claimRewardModal.vestingVaultGroup.name', {
+                  stakedTokenSymbol: xvs?.symbol,
+                });
 
-            const claim: Claim =
-              pendingRewardGroup.type === 'vault'
-                ? {
-                    contract: 'vaiVault',
-                  }
-                : {
-                    contract: 'xvsVestingVault',
-                    rewardToken: pendingRewardGroup.rewardToken,
-                    poolIndex: pendingRewardGroup.poolIndex,
-                  };
-
-            const group: Group = {
-              id,
-              name,
-              isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
-              isDisabled: pendingRewardGroup.isDisabled,
-              warningMessage: pendingRewardGroup.isDisabled
-                ? t('layout.claimRewardModal.vaultGroup.disabledContractWarningMessage')
-                : undefined,
-              pendingRewards: [
-                {
+          const claim: Claim =
+            pendingRewardGroup.type === 'vault'
+              ? {
+                  contract: 'vaiVault',
+                }
+              : {
+                  contract: 'xvsVestingVault',
                   rewardToken: pendingRewardGroup.rewardToken,
-                  rewardAmountMantissa: pendingRewardGroup.rewardAmountMantissa,
-                  rewardAmountCents: pendingRewardGroup.rewardAmountCents,
-                },
-              ],
-              claims: [claim],
-            };
+                  poolIndex: pendingRewardGroup.poolIndex,
+                };
 
-            return [...acc, group];
-          }
+          const group: Group = {
+            id,
+            name,
+            isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
+            isDisabled: pendingRewardGroup.isDisabled,
+            warningMessage: pendingRewardGroup.isDisabled
+              ? t('layout.claimRewardModal.vaultGroup.disabledContractWarningMessage')
+              : undefined,
+            pendingRewards: [
+              {
+                rewardToken: pendingRewardGroup.rewardToken,
+                rewardAmountMantissa: pendingRewardGroup.rewardAmountMantissa,
+                rewardAmountCents: pendingRewardGroup.rewardAmountCents,
+              },
+            ],
+            claims: [claim],
+          };
 
-          // Prime
-          if (pendingRewardGroup.type === 'prime') {
-            const id = 'prime';
+          return [...acc, group];
+        }
 
-            const group: Group = {
-              id,
-              isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
-              name: t('layout.claimRewardModal.primeGroup.name'),
-              isDisabled: pendingRewardGroup.isDisabled,
-              pendingRewards: pendingRewardGroup.pendingRewards,
-              warningMessage: pendingRewardGroup.isDisabled
-                ? t('layout.claimRewardModal.primeGroup.disabledContractWarningMessage')
-                : undefined,
-              claims: [
-                {
-                  contract: 'prime',
-                  vTokenAddressesWithPendingReward:
-                    pendingRewardGroup.vTokenAddressesWithPendingReward,
-                },
-              ],
-            };
+        // Prime
+        if (pendingRewardGroup.type === 'prime') {
+          const id = 'prime';
 
-            return [...acc, group];
-          }
+          const group: InternalRewardsGroup = {
+            id,
+            isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
+            name: t('layout.claimRewardModal.primeGroup.name'),
+            isDisabled: pendingRewardGroup.isDisabled,
+            pendingRewards: pendingRewardGroup.pendingRewards,
+            warningMessage: pendingRewardGroup.isDisabled
+              ? t('layout.claimRewardModal.primeGroup.disabledContractWarningMessage')
+              : undefined,
+            claims: [
+              {
+                contract: 'prime',
+                vTokenAddressesWithPendingReward:
+                  pendingRewardGroup.vTokenAddressesWithPendingReward,
+              },
+            ],
+          };
 
-          const pool = (getPoolsData?.pools || []).find(
-            item =>
-              item.comptrollerAddress.toLowerCase() ===
-              pendingRewardGroup.comptrollerAddress.toLowerCase(),
-          );
+          return [...acc, group];
+        }
 
-          if (!pool) {
-            return acc;
-          }
+        const pool = (getPoolsData?.pools || []).find(
+          item =>
+            item.comptrollerAddress.toLowerCase() ===
+            pendingRewardGroup.comptrollerAddress.toLowerCase(),
+        );
 
-          // Core pool
-          if (pendingRewardGroup.type === 'legacyPool') {
-            const id = 'main-pool';
+        if (!pool) {
+          return acc;
+        }
 
-            const group: Group = {
-              id,
-              name: pool.name,
-              isChecked: !uncheckedGroupIds.includes(id),
-              pendingRewards: [
-                {
-                  rewardToken: pendingRewardGroup.rewardToken,
-                  rewardAmountMantissa: pendingRewardGroup.rewardAmountMantissa,
-                  rewardAmountCents: pendingRewardGroup.rewardAmountCents,
-                },
-              ],
-              claims: [
-                {
-                  contract: 'legacyPoolComptroller',
-                  vTokenAddressesWithPendingReward:
-                    pendingRewardGroup.vTokenAddressesWithPendingReward,
-                },
-              ],
-            };
-
-            return [...acc, group];
-          }
-
-          // Isolated pools
-          const id = `isolated-pool-${pendingRewardGroup.comptrollerAddress}`;
+        // Core pool
+        if (pendingRewardGroup.type === 'legacyPool') {
+          const id = 'main-pool';
 
           const group: Group = {
             id,
             name: pool.name,
             isChecked: !uncheckedGroupIds.includes(id),
-            pendingRewards: pendingRewardGroup.pendingRewards.map(pendingReward => ({
-              rewardToken: pendingReward.rewardToken,
-              rewardAmountMantissa: pendingReward.rewardAmountMantissa,
-              rewardAmountCents: pendingReward.rewardAmountCents,
-            })),
-            claims: pendingRewardGroup.pendingRewards.map(pendingReward => ({
-              contract: 'rewardsDistributor',
-              contractAddress: pendingReward.rewardsDistributorAddress,
-              comptrollerContractAddress: pendingRewardGroup.comptrollerAddress,
-              vTokenAddressesWithPendingReward: pendingReward.vTokenAddressesWithPendingReward,
-            })),
+            pendingRewards: [
+              {
+                rewardToken: pendingRewardGroup.rewardToken,
+                rewardAmountMantissa: pendingRewardGroup.rewardAmountMantissa,
+                rewardAmountCents: pendingRewardGroup.rewardAmountCents,
+              },
+            ],
+            claims: [
+              {
+                contract: 'legacyPoolComptroller',
+                vTokenAddressesWithPendingReward:
+                  pendingRewardGroup.vTokenAddressesWithPendingReward,
+              },
+            ],
           };
 
           return [...acc, group];
-        },
-        [],
-      ),
-    [getPendingRewardsData?.pendingRewardGroups, uncheckedGroupIds, getPoolsData?.pools, xvs, t],
+        }
+
+        // Isolated pools
+        const id = `isolated-pool-${pendingRewardGroup.comptrollerAddress}`;
+
+        const group: InternalRewardsGroup = {
+          id,
+          name: pool.name,
+          isChecked: !uncheckedGroupIds.includes(id),
+          pendingRewards: pendingRewardGroup.pendingRewards.map(pendingReward => ({
+            rewardToken: pendingReward.rewardToken,
+            rewardAmountMantissa: pendingReward.rewardAmountMantissa,
+            rewardAmountCents: pendingReward.rewardAmountCents,
+          })),
+          claims: pendingRewardGroup.pendingRewards.map(pendingReward => ({
+            contract: 'rewardsDistributor',
+            contractAddress: pendingReward.rewardsDistributorAddress,
+            comptrollerContractAddress: pendingRewardGroup.comptrollerAddress,
+            vTokenAddressesWithPendingReward: pendingReward.vTokenAddressesWithPendingReward,
+          })),
+        };
+
+        return [...acc, group];
+      }, []),
+    [internalRewards, uncheckedGroupIds, getPoolsData?.pools, xvs, t],
   );
+
+  const externalRewardsGroups = useMemo(
+    () =>
+      externalRewards.reduce<ExternalRewardsGroup[]>((acc, pendingRewardGroup) => {
+        const id = `external-${pendingRewardGroup.campaignName}`;
+
+        const group: ExternalRewardsGroup = {
+          id,
+          name: pendingRewardGroup.campaignName,
+          ...pendingRewardGroup,
+        };
+
+        return [...acc, group];
+      }, []),
+    [externalRewards],
+  );
+
+  return { internalRewardsGroups, externalRewardsGroups };
 };
 
 export default useGetGroups;

--- a/apps/evm/src/containers/Layout/ClaimRewardButton/useGetGroups.ts
+++ b/apps/evm/src/containers/Layout/ClaimRewardButton/useGetGroups.ts
@@ -45,10 +45,10 @@ const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) =>
 
           const name =
             pendingRewardGroup.type === 'vault'
-              ? t('layout.claimRewardModal.vaultGroup.name', {
+              ? t('claimReward.modal.vaultGroup.name', {
                   stakedTokenSymbol: pendingRewardGroup.stakedToken.symbol,
                 })
-              : t('layout.claimRewardModal.vestingVaultGroup.name', {
+              : t('claimReward.modal.vestingVaultGroup.name', {
                   stakedTokenSymbol: xvs?.symbol,
                 });
 
@@ -69,7 +69,7 @@ const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) =>
             isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
             isDisabled: pendingRewardGroup.isDisabled,
             warningMessage: pendingRewardGroup.isDisabled
-              ? t('layout.claimRewardModal.vaultGroup.disabledContractWarningMessage')
+              ? t('claimReward.modal.vaultGroup.disabledContractWarningMessage')
               : undefined,
             pendingRewards: [
               {
@@ -91,11 +91,11 @@ const useGetGroups = ({ uncheckedGroupIds }: { uncheckedGroupIds: string[] }) =>
           const group: InternalRewardsGroup = {
             id,
             isChecked: !uncheckedGroupIds.includes(id) && !pendingRewardGroup.isDisabled,
-            name: t('layout.claimRewardModal.primeGroup.name'),
+            name: t('claimReward.modal.primeGroup.name'),
             isDisabled: pendingRewardGroup.isDisabled,
             pendingRewards: pendingRewardGroup.pendingRewards,
             warningMessage: pendingRewardGroup.isDisabled
-              ? t('layout.claimRewardModal.primeGroup.disabledContractWarningMessage')
+              ? t('claimReward.modal.primeGroup.disabledContractWarningMessage')
               : undefined,
             claims: [
               {

--- a/apps/evm/src/containers/Layout/testIds.ts
+++ b/apps/evm/src/containers/Layout/testIds.ts
@@ -4,5 +4,5 @@ export default {
   claimRewardBreakdown: 'layout-claim-reward-breakdown',
   claimExternalRewardBreakdown: 'layout-claim-external-reward-breakdown',
   claimRewardSubmitButton: 'layout-claim-reward-submit-button',
-  claimRewardMobileOverlay: 'layout-claim-reward-mobile-overlay',
+  claimRewardExternalRewards: 'layout-claim-reward-external-rewards',
 };

--- a/apps/evm/src/containers/Layout/testIds.ts
+++ b/apps/evm/src/containers/Layout/testIds.ts
@@ -2,5 +2,7 @@ export default {
   claimRewardSelectAllCheckbox: 'layout-claim-reward-select-all-checkbox',
   claimRewardOpenModalButton: 'layout-claim-reward-open-modal-button',
   claimRewardBreakdown: 'layout-claim-reward-breakdown',
+  claimExternalRewardBreakdown: 'layout-claim-external-reward-breakdown',
   claimRewardSubmitButton: 'layout-claim-reward-submit-button',
+  claimRewardMobileOverlay: 'layout-claim-reward-mobile-overlay',
 };

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -245,8 +245,10 @@
         "disabledLabel": "Select groups to collect reward from",
         "enabledLabel": "Claim"
       },
-      "selectAll": "Select all",
-      "title": "Claim reward ({{chainName}})"
+      "externalRewards": "External rewards",
+      "rewards": "Rewards",
+      "title": "Claim reward ({{chainName}})",
+      "claimOn": "Claim on {{appName}}"
     },
     "openModalButton": {
       "label": "Claim {{rewardAmount}}"

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -245,10 +245,21 @@
         "disabledLabel": "Select groups to collect reward from",
         "enabledLabel": "Claim"
       },
+      "claimOn": "Claim on {{appName}}",
       "externalRewards": "External rewards",
+      "primeGroup": {
+        "disabledContractWarningMessage": "The Prime contract is currently paused. Interests from Prime are still accruing but can't be claimed until the contract is unpaused.",
+        "name": "Prime"
+      },
       "rewards": "Rewards",
       "title": "Claim reward ({{chainName}})",
-      "claimOn": "Claim on {{appName}}"
+      "vaultGroup": {
+        "disabledContractWarningMessage": "This vault is currently paused. Interest rates are still accruing but can't be claimed until the vault is unpaused.",
+        "name": "{{stakedTokenSymbol}} vault"
+      },
+      "vestingVaultGroup": {
+        "name": "{{stakedTokenSymbol}} vesting vault"
+      }
     },
     "openModalButton": {
       "label": "Claim {{rewardAmount}}"
@@ -374,19 +385,6 @@
   "layout": {
     "chainSelect": {
       "label": "Select chain"
-    },
-    "claimRewardModal": {
-      "primeGroup": {
-        "disabledContractWarningMessage": "The Prime contract is currently paused. Interests from Prime are still accruing but can't be claimed until the contract is unpaused.",
-        "name": "Prime"
-      },
-      "vaultGroup": {
-        "disabledContractWarningMessage": "This vault is currently paused. Interest rates are still accruing but can't be claimed until the vault is unpaused.",
-        "name": "{{stakedTokenSymbol}} vault"
-      },
-      "vestingVaultGroup": {
-        "name": "{{stakedTokenSymbol}} vesting vault"
-      }
     },
     "header": {
       "isolated": "Isolated",

--- a/apps/evm/src/pages/Market/Page/OperationForm/AssetInfo/index.tsx
+++ b/apps/evm/src/pages/Market/Page/OperationForm/AssetInfo/index.tsx
@@ -116,7 +116,7 @@ export const AssetInfo: React.FC<AssetInfoProps> = ({
         }
         if (distribution.type === 'merkl') {
           label = t('assetInfo.externalDistributionApy', {
-            description: distribution.description,
+            description: distribution.rewardDetails.description,
             tokenSymbol: distribution.token.symbol,
           });
         }

--- a/apps/evm/src/types/index.ts
+++ b/apps/evm/src/types/index.ts
@@ -52,18 +52,21 @@ export interface RewardDistributorDistribution {
   token: Token;
   apyPercentage: BigNumber;
   dailyDistributedTokens: BigNumber;
+  isActive: boolean;
 }
 
 export interface PrimeDistribution {
   type: 'prime';
   token: Token;
   apyPercentage: BigNumber;
+  isActive: boolean;
 }
 
 export interface PrimeSimulationDistribution {
   type: 'primeSimulation';
   token: Token;
   apyPercentage: BigNumber;
+  isActive: boolean;
   referenceValues: {
     userSupplyBalanceTokens: BigNumber;
     userBorrowBalanceTokens: BigNumber;
@@ -76,8 +79,15 @@ export interface MerklDistribution {
   token: Token;
   apyPercentage: BigNumber;
   dailyDistributedTokens: BigNumber;
-  claimUrl: string;
-  description?: string;
+  isActive: boolean;
+  rewardDetails: {
+    appName: string;
+    claimUrl: string;
+    marketAddress: string;
+    merklCampaignIdentifier: string;
+    description: string;
+    tags: string[];
+  };
 }
 
 export type TokenDistribution =

--- a/apps/evm/src/utilities/getCombinedDistributionApys/index.ts
+++ b/apps/evm/src/utilities/getCombinedDistributionApys/index.ts
@@ -50,8 +50,12 @@ export interface GetCombinedDistributionApysInput {
 }
 
 const getCombinedDistributionApys = ({ asset }: GetCombinedDistributionApysInput) => {
-  const supply = aggregatePercentages({ distributions: asset.supplyTokenDistributions });
-  const borrow = aggregatePercentages({ distributions: asset.borrowTokenDistributions });
+  const supply = aggregatePercentages({
+    distributions: asset.supplyTokenDistributions.filter(d => d.isActive),
+  });
+  const borrow = aggregatePercentages({
+    distributions: asset.borrowTokenDistributions.filter(d => d.isActive),
+  });
 
   const totalSupplyApyBoostPercentage = supply.apyRewardsPercentage.plus(supply.apyPrimePercentage);
   const totalBorrowApyBoostPercentage = borrow.apyRewardsPercentage.plus(borrow.apyPrimePercentage);

--- a/apps/evm/src/utilities/restService.ts
+++ b/apps/evm/src/utilities/restService.ts
@@ -5,6 +5,7 @@ import config from 'config';
 import { logError } from 'libs/errors';
 
 interface RestServiceInput {
+  baseUrl?: string;
   endpoint: string;
   method: 'GET' | 'POST' | 'PATCH' | 'DELETE';
   next?: boolean;
@@ -37,6 +38,7 @@ const createQueryParams = (params: Record<string, unknown>) => {
 };
 
 export async function restService<D>({
+  baseUrl,
   endpoint,
   method,
   params,
@@ -44,7 +46,8 @@ export async function restService<D>({
   next = false,
 }: RestServiceInput): Promise<ApiResponse<D>> {
   const headers = {};
-  let path = `${config.apiUrl}${endpoint}`;
+  const basePath = baseUrl ?? config.apiUrl;
+  let path = `${basePath}${endpoint}`;
 
   _set(headers, 'Accept', 'application/json');
 


### PR DESCRIPTION
## Jira ticket(s)

VEN-2993

## Changes

- Allow the user to see the available amount of rewards accrued from Merkl campaigns
- Reworked claim reward modal to display external rewards
- Reworked mobile version of the claim reward modal to be an overlay
