### PR TITLE
fix: preventDefault when clicking a Tooltip

### DIFF
--- a/.changeset/fuzzy-suits-collect.md
+++ b/.changeset/fuzzy-suits-collect.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+preventDefault when clicking a Tooltip

--- a/apps/evm/src/components/Tooltip/index.tsx
+++ b/apps/evm/src/components/Tooltip/index.tsx
@@ -14,7 +14,13 @@ export const Tooltip = ({ children, placement = 'top', ...rest }: TooltipProps) 
   return (
     <>
       <Global styles={styles} />
-      <MuiTooltip arrow placement={placement} enterTouchDelay={0} {...rest}>
+      <MuiTooltip
+        onClick={e => e.preventDefault()}
+        arrow
+        placement={placement}
+        enterTouchDelay={0}
+        {...rest}
+      >
         <span>{children}</span>
       </MuiTooltip>
     </>


### PR DESCRIPTION
## Changes

- This allows the `InfoIcon` to show it's `Tooltip` without triggering the surrounding navigation on mobile
