### PR TITLE
feat: update Merkl reward expiration logic

### DIFF
--- a/.changeset/fluffy-onions-work.md
+++ b/.changeset/fluffy-onions-work.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+update expiral logic for Merkl rewards

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/index.ts
@@ -65,10 +65,15 @@ export const formatDistributions = ({
         decimals: rewardToken.decimals,
       });
 
+      const isTimeBasedOrMerklReward = isChainTimeBased || rewardType === 'merkl';
       const isDistributingSupplyRewards = isDistributingRewards({
-        isTimeBased: isChainTimeBased,
-        lastRewardingTimestamp: isChainTimeBased ? +lastRewardingSupplyBlockOrTimestamp : undefined,
-        lastRewardingBlock: isChainTimeBased ? undefined : +lastRewardingSupplyBlockOrTimestamp,
+        isTimeBasedOrMerklReward,
+        lastRewardingTimestamp: isTimeBasedOrMerklReward
+          ? +lastRewardingSupplyBlockOrTimestamp
+          : undefined,
+        lastRewardingBlock: isTimeBasedOrMerklReward
+          ? undefined
+          : +lastRewardingSupplyBlockOrTimestamp,
         currentBlockNumber,
       });
 
@@ -93,9 +98,13 @@ export const formatDistributions = ({
       }
 
       const isDistributingBorrowRewards = isDistributingRewards({
-        isTimeBased: isChainTimeBased,
-        lastRewardingTimestamp: isChainTimeBased ? +lastRewardingBorrowBlockOrTimestamp : undefined,
-        lastRewardingBlock: isChainTimeBased ? undefined : +lastRewardingBorrowBlockOrTimestamp,
+        isTimeBasedOrMerklReward,
+        lastRewardingTimestamp: isTimeBasedOrMerklReward
+          ? +lastRewardingBorrowBlockOrTimestamp
+          : undefined,
+        lastRewardingBlock: isTimeBasedOrMerklReward
+          ? undefined
+          : +lastRewardingBorrowBlockOrTimestamp,
         currentBlockNumber,
       });
 

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/isDistributingRewards/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/isDistributingRewards/index.ts
@@ -1,23 +1,23 @@
 import { getUnixTime } from 'date-fns/getUnixTime';
 
 export const isDistributingRewards = ({
-  isTimeBased,
+  isTimeBasedOrMerklReward,
   lastRewardingTimestamp,
   lastRewardingBlock,
   currentBlockNumber,
 }: {
-  isTimeBased: boolean;
+  isTimeBasedOrMerklReward: boolean;
   lastRewardingTimestamp?: number;
   lastRewardingBlock?: number;
   currentBlockNumber: bigint;
 }): boolean => {
   const nowTimestamp = getUnixTime(new Date());
 
-  if (isTimeBased && typeof lastRewardingTimestamp === 'number') {
+  if (isTimeBasedOrMerklReward && typeof lastRewardingTimestamp === 'number') {
     return lastRewardingTimestamp === 0 || lastRewardingTimestamp >= nowTimestamp;
   }
 
-  if (!isTimeBased && typeof lastRewardingBlock === 'number') {
+  if (!isTimeBasedOrMerklReward && typeof lastRewardingBlock === 'number') {
     return lastRewardingBlock === 0 || lastRewardingBlock >= currentBlockNumber;
   }
 


### PR DESCRIPTION
## Changes

- Merkl rewards have a endTimestamp. Launching them on BNB means we have to consider the reward type apart from only considering if the chain is time based or not
