### PR TITLE
fix: filter errors thrown by canceled requests in Safari

### DIFF
--- a/.changeset/lucky-mugs-try.md
+++ b/.changeset/lucky-mugs-try.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+Filter errors thrown from canceled fetch requests

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/index.ts
@@ -20,6 +20,12 @@ const safeGetIsolatedPoolParticipantCount = async (
     const result = await getIsolatedPoolParticipantCounts(input);
     return result;
   } catch (error) {
+    // Safari throws a "TypeError: Load failed" error if the fetch is canceled
+    // e.g., if the user navigates away from the page before the request is finished
+    // we can safely filter them out from being logged
+    if (error instanceof Error && error.name === 'TypeError' && error.message === 'Load failed') {
+      return undefined;
+    }
     // Log error without throwing to prevent the entire query from failing, since this relies on a
     // third-party service that could be down and doesn't constitute a critical failure
     logError(error);


### PR DESCRIPTION
## Jira ticket(s)

VEN-3071

## Changes

This PR aims to filter this kind of error thrown by Safari: https://request-cancellation-test.vercel.app/
