### PR TITLE
fix: use SafePal Android friendly QR code colors

### DIFF
--- a/.changeset/mean-otters-wink.md
+++ b/.changeset/mean-otters-wink.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+Use SafePal Android friendly QR code colors when connecting wallets

--- a/apps/evm/src/libs/wallet/Web3Wrapper/ConnectKitWrapper/index.tsx
+++ b/apps/evm/src/libs/wallet/Web3Wrapper/ConnectKitWrapper/index.tsx
@@ -46,6 +46,8 @@ export const ConnectKitWrapper: React.FC<ConnectKitWrapperProps> = ({ children }
         '--ck-body-color': theme.colors.offWhite,
         '--ck-body-background-tertiary': theme.colors.lightGrey,
         '--ck-body-background': theme.colors.cards,
+        '--ck-qr-dot-color': 'rgba(0, 0, 0, 1)',
+        '--ck-qr-background': theme.colors.offWhite,
       }}
     >
       <AuthHandler />


### PR DESCRIPTION
## Jira ticket(s)

VEN-3091

## Changes

- SafePal on Android has an easier time reading QR codes that are black dots on a white background
