### PR TITLE
feat: increase minimum Paymaster balance to enable gasless transactions

### DIFF
--- a/.changeset/eleven-lions-do.md
+++ b/.changeset/eleven-lions-do.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+increase minimum Paymaster balance to enable gasless transactions

--- a/apps/evm/src/constants/gasLess.ts
+++ b/apps/evm/src/constants/gasLess.ts
@@ -2,7 +2,7 @@ import BigNumber from 'bignumber.js';
 import { ChainId } from 'types';
 import type { Address } from 'viem';
 
-export const MIN_PAYMASTER_BALANCE_MANTISSA = new BigNumber(10).pow(14);
+export const MIN_PAYMASTER_BALANCE_MANTISSA = new BigNumber(10).pow(15);
 
 export const zyFiWalletAddresses: Partial<Record<ChainId, Address>> = {
   [ChainId.ZKSYNC_MAINNET]: '0x5768CDebd229F690F4bC045AF8e140FC97Ce275D',


### PR DESCRIPTION
## Changes

- increase minimum Paymaster balance to enable gasless transactions
