### PR TITLE
Downgrade ConnectKit

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -8921,13 +8921,12 @@ concat-stream@^1.6.0, concat-stream@^1.6.2:
     typedarray "^0.0.6"
 
 connectkit@^1.8.2:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/connectkit/-/connectkit-1.9.0.tgz#5696ae5d2ad94a8c9c640e4fcfd6f48ed8303f22"
-  integrity sha512-bkqg8zK35pWWG2q8xeo41J1mnBP8D2ffOd/ItB12aad9QZZU20SlEeiQM9iYfRyl0JAH1tqIDlZbXajqZBFfDw==
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/connectkit/-/connectkit-1.8.2.tgz#9b350b47720347f0ebb599260fe3a8c964e51321"
+  integrity sha512-Za6jR5RtCimzSFqAH1OgUYES96ThTei6d/TvKWNU3GeZPPnwVojtfhFn9wUOam81RknxylvVpG727BPmjguzbA==
   dependencies:
     buffer "^6.0.3"
     detect-browser "^5.3.0"
-    family "^0.1.1"
     framer-motion "^6.3.11"
     qrcode "^1.5.0"
     react-transition-state "^1.1.4"
@@ -10367,11 +10366,6 @@ extract-files@^11.0.0:
   version "11.0.0"
   resolved "https://registry.yarnpkg.com/extract-files/-/extract-files-11.0.0.tgz#b72d428712f787eef1f5193aff8ab5351ca8469a"
   integrity sha512-FuoE1qtbJ4bBVvv94CC7s0oTnKUGvQs+Rjf1L2SJFfS+HTVVjhPFtehPdQ0JiGPqVNfSSZvL5yzHHQq2Z4WNhQ==
-
-family@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/family/-/family-0.1.1.tgz#5d0721d6e36346d94d1ce4f5dbfd5da6655d005d"
-  integrity sha512-X9gxkV4fm7U6ftSWcrHmNLfIhwwsvyn2uKEtLVgAGXbm+b+IAxXS1YdBC0HqQfooCZSUnw0vtVQg+eXN+kJAlw==
 
 fast-base64-decode@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Changes

- downgrade ConnectKit to v1.82, because v1.9.0 promotes their "Family" extension on the forefront of the UI with no option to remove it
