### PR TITLE
fix: timestamp of Lorentz upgrade

### DIFF
--- a/.changeset/wild-streets-speak.md
+++ b/.changeset/wild-streets-speak.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/chains": minor
+---
+
+fix timestamp of Lorentz upgrade

--- a/packages/chains/src/chainMetadata.ts
+++ b/packages/chains/src/chainMetadata.ts
@@ -27,7 +27,7 @@ const ethToken: Token = {
   isNative: true,
 };
 
-export const bnbChainMainnetLorentzUpgradeTimestamp = new Date('April 21, 2025 03:00:00 UTC');
+export const bnbChainMainnetLorentzUpgradeTimestamp = new Date('April 29, 2025 05:05:00 UTC');
 export const opbnbMainnetUpgradeTimestamp = new Date('April 21, 2025 03:00:00 UTC');
 
 const now = new Date();


### PR DESCRIPTION
## Changes

### [chains package](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/chains/)
- fix timestamp of Lorentz upgrade
