### PR TITLE
feat: update RPC providers order for opBNB mainnet

### DIFF
--- a/.changeset/cold-actors-lie.md
+++ b/.changeset/cold-actors-lie.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+update RPC providers order for opBNB mainnet

--- a/apps/evm/src/config/rpcUrls.ts
+++ b/apps/evm/src/config/rpcUrls.ts
@@ -12,8 +12,8 @@ export const rpcUrls: {
     `https://bsc-testnet.nodereal.io/v1/${envVariables.VITE_NODE_REAL_API_KEY}`,
   ],
   [ChainId.OPBNB_MAINNET]: [
-    `https://opbnb-mainnet.g.alchemy.com/v2/${envVariables.VITE_ALCHEMY_API_KEY}`,
     `https://opbnb-mainnet.nodereal.io/v1/${envVariables.VITE_NODE_REAL_API_KEY}`,
+    `https://opbnb-mainnet.g.alchemy.com/v2/${envVariables.VITE_ALCHEMY_API_KEY}`,
   ],
   [ChainId.OPBNB_TESTNET]: [
     `https://opbnb-testnet.g.alchemy.com/v2/${envVariables.VITE_ALCHEMY_API_KEY}`,


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- update RPC providers order for opBNB mainnet
