### PR TITLE
fix: prevent sending transactions with empty access list

### DIFF
--- a/.changeset/legal-dogs-attend.md
+++ b/.changeset/legal-dogs-attend.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+prevent sending transactions with empty access list

--- a/apps/evm/src/clients/api/mutations/useBorrow/index.ts
+++ b/apps/evm/src/clients/api/mutations/useBorrow/index.ts
@@ -79,7 +79,7 @@ export const useBorrow = (options?: Partial<Options>) => {
         address: vToken.address,
         functionName: 'borrow',
         args: [amountMantissa],
-        accessList,
+        accessList: accessList?.length ? accessList : undefined,
       } as WriteContractParameters<readonly unknown[], string, readonly unknown[], Chain, Account>;
     },
     onConfirmed: async ({ input }) => {

--- a/apps/evm/src/clients/api/mutations/withdraw/index.ts
+++ b/apps/evm/src/clients/api/mutations/withdraw/index.ts
@@ -72,7 +72,7 @@ const withdraw = async ({
     accessList = tmpAccessList;
   }
 
-  const overrides = accessList ? { accessList } : undefined;
+  const overrides = accessList?.length ? { accessList } : undefined;
 
   return withdrawFullSupply
     ? { contract: tokenContract, methodName: 'redeem', args: [amountMantissa.toFixed()], overrides }


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- do not pass empty `accessList` from borrow and withdraw transactions, as this is causing issues with the MetaMask extension that then throws an error when attempting to send the transaction