### PR TITLE
feat: update logic to repay full native currency loan

### DIFF
--- a/.changeset/empty-impalas-lick.md
+++ b/.changeset/empty-impalas-lick.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+update logic to repay full native currency loan

--- a/apps/evm/src/clients/api/mutations/repay/index.spec.ts
+++ b/apps/evm/src/clients/api/mutations/repay/index.spec.ts
@@ -13,7 +13,7 @@ import {
   getVTokenContract,
 } from 'libs/contracts';
 
-import repay, { FULL_REPAYMENT_NATIVE_BUFFER_PERCENTAGE } from '.';
+import repay from '.';
 
 const fakeAmountMantissa = new BigNumber(10000000000000000);
 
@@ -37,15 +37,11 @@ describe('repay', () => {
         repayFullLoan: true,
       });
 
-      const amountWithBufferMantissa = fakeAmountMantissa.multipliedBy(
-        1 + FULL_REPAYMENT_NATIVE_BUFFER_PERCENTAGE / 100,
-      );
-
       expect(response).toStrictEqual({
         contract: fakeMaximillionContract,
         args: [fakeSignerAddress, vBnb.address],
         overrides: {
-          value: amountWithBufferMantissa.toFixed(),
+          value: fakeAmountMantissa.toFixed(),
         },
         methodName: 'repayBehalfExplicit',
       });
@@ -143,15 +139,11 @@ describe('repay', () => {
         wrap: true,
       });
 
-      const amountWithBufferMantissa = fakeAmountMantissa.multipliedBy(
-        1 + FULL_REPAYMENT_NATIVE_BUFFER_PERCENTAGE / 100,
-      );
-
       expect(response).toStrictEqual({
         contract: fakeNativeTokenGatewayContract,
         args: [],
         overrides: {
-          value: amountWithBufferMantissa.toFixed(),
+          value: fakeAmountMantissa.toFixed(),
         },
         methodName: 'wrapAndRepay',
       });

--- a/apps/evm/src/clients/api/mutations/repay/index.ts
+++ b/apps/evm/src/clients/api/mutations/repay/index.ts
@@ -24,12 +24,6 @@ export interface RepayInput {
 
 export type RepayOutput = LooseEthersContractTxData;
 
-export const FULL_REPAYMENT_NATIVE_BUFFER_PERCENTAGE = 0.1;
-
-// calculate buffer and remove decimals
-const bufferAmount = ({ amountMantissa }: { amountMantissa: BigNumber }) =>
-  amountMantissa.multipliedBy(1 + FULL_REPAYMENT_NATIVE_BUFFER_PERCENTAGE / 100).toFixed(0);
-
 const repay = async ({
   signer,
   vToken,
@@ -43,7 +37,6 @@ const repay = async ({
   // at the moment BNB is the only native market we have
   if (vToken.underlyingToken.isNative && repayFullLoan) {
     return callOrThrow({ maximillionContract, signer }, async ({ maximillionContract }) => {
-      const bufferedAmountMantissa = bufferAmount({ amountMantissa });
       const accountAddress = await signer.getAddress();
 
       return {
@@ -51,7 +44,7 @@ const repay = async ({
         methodName: 'repayBehalfExplicit',
         args: [accountAddress, vToken.address],
         overrides: {
-          value: bufferedAmountMantissa,
+          value: amountMantissa.toFixed(),
         },
       };
     });
@@ -88,7 +81,7 @@ const repay = async ({
       methodName: 'wrapAndRepay',
       args: [],
       overrides: {
-        value: repayFullLoan ? bufferAmount({ amountMantissa }) : amountMantissa.toFixed(),
+        value: amountMantissa.toFixed(),
       },
     };
   }


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- update `repay` mutation function so it no longer adds a buffer amount to full repayments
- update `RepayForm` so it adds a small buffer amount (0.0001%) to a full native currency borrow balance, so that we account for newly-accrued interests when repaying a full native currency loan
