### PR TITLE
feat: allow enter and exit markets to be disabled

### DIFF
--- a/.changeset/tangy-needles-fix.md
+++ b/.changeset/tangy-needles-fix.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+allow enter and exit market actions to be disabled

--- a/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.prime.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.prime.spec.ts.snap
@@ -35,6 +35,7 @@ exports[`useGetPools > does not fetch Prime distributions if user is not Prime 1
           "disabledTokenActions": [
             "supply",
             "borrow",
+            "enterMarket",
           ],
           "exchangeRateVTokens": "49.19405324154271215086",
           "isCollateralOfUser": true,
@@ -1198,6 +1199,7 @@ exports[`useGetPools > fetches and formats Prime distributions and Prime distrib
           "disabledTokenActions": [
             "supply",
             "borrow",
+            "enterMarket",
           ],
           "exchangeRateVTokens": "49.19405324154271215086",
           "isCollateralOfUser": true,
@@ -2466,6 +2468,7 @@ exports[`useGetPools > filters out Prime simulations that are 0 1`] = `
           "disabledTokenActions": [
             "supply",
             "borrow",
+            "enterMarket",
           ],
           "exchangeRateVTokens": "49.19405324154271215086",
           "isCollateralOfUser": true,

--- a/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/clients/api/queries/useGetPools/__tests__/__snapshots__/index.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`useGetPools > returns pools in the correct format 1`] = `
           "disabledTokenActions": [
             "supply",
             "borrow",
+            "enterMarket",
           ],
           "exchangeRateVTokens": "49.19405324154271215086",
           "isCollateralOfUser": false,
@@ -970,6 +971,7 @@ exports[`useGetPools > returns pools with time based reward rates in the correct
           "disabledTokenActions": [
             "supply",
             "borrow",
+            "enterMarket",
           ],
           "exchangeRateVTokens": "49.19405324154271215086",
           "isCollateralOfUser": false,
@@ -1922,6 +1924,7 @@ exports[`useGetPools > returns pools with user data in the correct format 1`] = 
           "disabledTokenActions": [
             "supply",
             "borrow",
+            "enterMarket",
           ],
           "exchangeRateVTokens": "49.19405324154271215086",
           "isCollateralOfUser": true,

--- a/apps/evm/src/containers/MarketTable/useGenerateColumns.tsx
+++ b/apps/evm/src/containers/MarketTable/useGenerateColumns.tsx
@@ -26,6 +26,7 @@ import {
   formatTokensToReadableValue,
   getCombinedDistributionApys,
   isAssetPaused,
+  isCollateralActionDisabled,
 } from 'utilities';
 
 import { Apy } from 'components';
@@ -127,6 +128,10 @@ const useGenerateColumns = ({
             const isPaused = isAssetPaused({
               disabledTokenActions: poolAsset.disabledTokenActions,
             });
+            const isCollateralToggleDisabled = isCollateralActionDisabled({
+              disabledTokenActions: poolAsset.disabledTokenActions,
+              isCollateralOfUser: poolAsset.isCollateralOfUser,
+            });
 
             if (column === 'asset') {
               return (
@@ -166,7 +171,7 @@ const useGenerateColumns = ({
                 <Toggle
                   onChange={() => collateralOnChange(poolAsset)}
                   value={poolAsset.isCollateralOfUser}
-                  disabled={isAccountOnWrongChain}
+                  disabled={isAccountOnWrongChain || isCollateralToggleDisabled}
                 />
               ) : (
                 PLACEHOLDER_KEY

--- a/apps/evm/src/pages/Market/Page/OperationForm/SupplyForm/index.tsx
+++ b/apps/evm/src/pages/Market/Page/OperationForm/SupplyForm/index.tsx
@@ -28,6 +28,7 @@ import {
   convertMantissaToTokens,
   convertTokensToMantissa,
   getUniqueTokenBalances,
+  isCollateralActionDisabled,
 } from 'utilities';
 
 import { ConnectWallet } from 'containers/ConnectWallet';
@@ -180,6 +181,10 @@ export const SupplyFormUi: React.FC<SupplyFormUiProps> = ({
   const { chainId: accountChainId } = useAccountChainId();
   const { chainId } = useChainId();
   const isAccountOnWrongChain = accountChainId !== chainId;
+  const isCollateralToggleDisabled = isCollateralActionDisabled({
+    disabledTokenActions: asset.disabledTokenActions,
+    isCollateralOfUser: asset.isCollateralOfUser,
+  });
 
   const handleToggleCollateral = async () => {
     try {
@@ -248,7 +253,7 @@ export const SupplyFormUi: React.FC<SupplyFormUiProps> = ({
               <Toggle
                 onChange={handleToggleCollateral}
                 value={asset.isCollateralOfUser}
-                disabled={!isUserConnected || isAccountOnWrongChain}
+                disabled={!isUserConnected || isAccountOnWrongChain || isCollateralToggleDisabled}
               />
             </LabeledInlineContent>
           </>

--- a/apps/evm/src/types/index.ts
+++ b/apps/evm/src/types/index.ts
@@ -39,7 +39,14 @@ export interface VToken extends Omit<Token, 'isNative' | 'asset' | 'tokenWrapped
   asset?: string;
 }
 
-export type TokenAction = 'swapAndSupply' | 'supply' | 'withdraw' | 'borrow' | 'repay';
+export type TokenAction =
+  | 'swapAndSupply'
+  | 'supply'
+  | 'withdraw'
+  | 'borrow'
+  | 'repay'
+  | 'enterMarket'
+  | 'exitMarket';
 
 export interface TokenBalance {
   token: Token;

--- a/apps/evm/src/utilities/getDisabledTokenActions/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/utilities/getDisabledTokenActions/__tests__/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,7 @@
 exports[`getDisabledTokenActions > returns the list of paused actions from bitmask and local disabled actions, merged correctly 1`] = `
 [
   "supply",
-  "borrow",
+  "withdraw",
   "swapAndSupply",
   "repay",
 ]
@@ -12,6 +12,10 @@ exports[`getDisabledTokenActions > returns the list of paused actions from bitma
 exports[`getDisabledTokenActions > returns the list of paused actions from the bitmask correctly 1`] = `
 [
   "supply",
+  "withdraw",
   "borrow",
+  "repay",
+  "enterMarket",
+  "exitMarket",
 ]
 `;

--- a/apps/evm/src/utilities/getDisabledTokenActions/__tests__/index.spec.ts
+++ b/apps/evm/src/utilities/getDisabledTokenActions/__tests__/index.spec.ts
@@ -10,7 +10,7 @@ import { getDisabledTokenActions } from '..';
 describe('getDisabledTokenActions', () => {
   it('returns the list of paused actions from the bitmask correctly', () => {
     const result = getDisabledTokenActions({
-      bitmask: 165,
+      bitmask: 511, // 0b111111111
       chainId: ChainId.BSC_TESTNET,
       tokenAddresses: [],
     });
@@ -38,7 +38,7 @@ describe('getDisabledTokenActions', () => {
     (getLocalDisabledTokenActions as Mock).mockImplementation(() => localDisabledTokenActions);
 
     const result = getDisabledTokenActions({
-      bitmask: 165,
+      bitmask: 3, // 0b000000011 - MINT and REDEEM
       chainId: ChainId.BSC_TESTNET,
       tokenAddresses: [xvs.address],
     });

--- a/apps/evm/src/utilities/getDisabledTokenActions/index.ts
+++ b/apps/evm/src/utilities/getDisabledTokenActions/index.ts
@@ -51,6 +51,10 @@ export const getDisabledTokenActions = ({
         translatedDisabledAction = 'borrow';
       } else if (pausedAction === ContractVTokenAction.REPAY) {
         translatedDisabledAction = 'repay';
+      } else if (pausedAction === ContractVTokenAction.ENTER_MARKET) {
+        translatedDisabledAction = 'enterMarket';
+      } else if (pausedAction === ContractVTokenAction.EXIT_MARKET) {
+        translatedDisabledAction = 'exitMarket';
       }
 
       if (!translatedDisabledAction) {

--- a/apps/evm/src/utilities/index.ts
+++ b/apps/evm/src/utilities/index.ts
@@ -51,3 +51,4 @@ export * from './getProposalStateLabel';
 export * from './isProposalExecutable';
 export * from './isPoolIsolated';
 export * from './calculateHealthFactor';
+export * from './isCollateralActionDisabled';

--- a/apps/evm/src/utilities/isCollateralActionDisabled/__tests__/index.spec.ts
+++ b/apps/evm/src/utilities/isCollateralActionDisabled/__tests__/index.spec.ts
@@ -1,0 +1,35 @@
+import type { TokenAction } from 'types';
+import { isCollateralActionDisabled } from '..';
+
+const disabledActions: TokenAction[] = ['withdraw', 'repay', 'supply', 'borrow', 'swapAndSupply'];
+
+describe('isCollateralActionDisabled', () => {
+  it('can enter market when the action is enabled', () =>
+    expect(
+      isCollateralActionDisabled({
+        isCollateralOfUser: false,
+        disabledTokenActions: [...disabledActions, 'exitMarket'],
+      }),
+    ).toBe(false));
+  it('cannot enter market when the action is disabled', () =>
+    expect(
+      isCollateralActionDisabled({
+        isCollateralOfUser: false,
+        disabledTokenActions: [...disabledActions, 'enterMarket'],
+      }),
+    ).toBe(true));
+  it('can exit market when the action is disabled', () =>
+    expect(
+      isCollateralActionDisabled({
+        isCollateralOfUser: true,
+        disabledTokenActions: [...disabledActions, 'enterMarket'],
+      }),
+    ).toBe(false));
+  it('cannot exit market when the action is disabled', () =>
+    expect(
+      isCollateralActionDisabled({
+        isCollateralOfUser: true,
+        disabledTokenActions: [...disabledActions, 'exitMarket'],
+      }),
+    ).toBe(true));
+});

--- a/apps/evm/src/utilities/isCollateralActionDisabled/index.ts
+++ b/apps/evm/src/utilities/isCollateralActionDisabled/index.ts
@@ -1,0 +1,26 @@
+import type { TokenAction } from 'types';
+
+export const isCollateralActionDisabled = ({
+  disabledTokenActions,
+  isCollateralOfUser,
+}: {
+  disabledTokenActions: TokenAction[];
+  isCollateralOfUser: boolean;
+}) => {
+  let isEnterMarketActionDisabled = false;
+  let isExitMarketActionDisabled = false;
+
+  disabledTokenActions.forEach(disabledTokenAction => {
+    if (disabledTokenAction === 'enterMarket') {
+      isEnterMarketActionDisabled = true;
+    }
+
+    if (disabledTokenAction === 'exitMarket') {
+      isExitMarketActionDisabled = true;
+    }
+  });
+
+  // if the asset is a collateral, consider the exit market action
+  // if not, consider the enter market action
+  return isCollateralOfUser ? isExitMarketActionDisabled : isEnterMarketActionDisabled;
+};


### PR DESCRIPTION
## Jira ticket(s)

VEN-3236

## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- Allow enter and exit market actions to be disabled, following the `pausedActionsBitmap`
