### PR TITLE
refactor: better types for getContractAddress

### DIFF
--- a/.changeset/big-spies-prove.md
+++ b/.changeset/big-spies-prove.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+better types for getContractAddress

--- a/apps/evm/src/containers/ReadableActionSignature/getContractName.ts
+++ b/apps/evm/src/containers/ReadableActionSignature/getContractName.ts
@@ -34,11 +34,7 @@ const getContractName = ({ target, vTokens, tokens, chainId }: GetContractNameIn
   // Search within contracts
   const matchingUniqueContractInfo = Object.entries(addresses.uniques).find(
     ([_uniqueContractName, address]) => {
-      let contractAddress: string | Record<number, string> = '';
-
-      if (Object.prototype.hasOwnProperty.call(address, chainId)) {
-        contractAddress = address[chainId as keyof typeof address];
-      }
+      const contractAddress = address[chainId];
 
       if (!contractAddress) {
         return false;
@@ -48,11 +44,6 @@ const getContractName = ({ target, vTokens, tokens, chainId }: GetContractNameIn
         // Handle unique contracts
         return areAddressesEqual(contractAddress, target);
       }
-
-      // Handle SwapRouter contract
-      return Object.values(contractAddress).some(swapRouterAddress =>
-        areAddressesEqual(swapRouterAddress, target),
-      );
     },
   );
 

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/__tests__/__snapshots__/index.spec.ts.snap
@@ -3,7 +3,14 @@
 exports[`generateAddressList > calls writeFile with the right arguments 1`] = `
 [
   {
-    "content": "export const addresses = {
+    "content": "import type { ChainId } from "types";
+import type { Address } from "viem";
+type MapChainIdToAddress = Partial<{ [chainId in ChainId]: Address }>;
+type MapChainIdToPoolAddress = Partial<{ [chainId in ChainId]: Record<Address, Address> }>;
+type Unique = {PoolLens: MapChainIdToAddress};
+type UniquePerPool = {SwapRouter: MapChainIdToPoolAddress};
+type Addresses = { uniques: Unique, uniquesPerPool: UniquePerPool }
+export const addresses: Addresses = {
     uniques: {PoolLens: {
       56: '0x25E215CcE40bD849B7c286912B85212F984Ff1e0',97: '0x6492dF28A9478230205c940A245Ffb114EaEb9d1',
     },},

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/__tests__/__snapshots__/index.spec.ts.snap
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/__tests__/__snapshots__/index.spec.ts.snap
@@ -12,7 +12,7 @@ exports[`generateAddressList > calls writeFile with the right arguments 1`] = `
       56: {'0xfd36e2c2a6789db23113685031d7f16329158384': '0x8938E6dA30b59c1E27d5f70a94688A89F7c815a4','0x94c1495cd4c557f1560cbd68eab0d197e6291571': '0xBBd8E2b5d69fcE9Aaa599c50F0f0960AA58B32aA',},97: {'0x94d1820b2d1c7c7452a163983dc888cec546b77d': '0x83edf1deE1B730b7e8e13C00ba76027D63a51ac0',},
     },
     },
-  }",
+  } as const",
     "outputPath": "fake/output/director/path",
   },
 ]

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/index.ts
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/index.ts
@@ -74,7 +74,7 @@ export const generateAddressList = async ({
   // Close addresses output
   addressesOutput += `
     },
-  }`;
+  } as const`;
 
   // Generate addresses file
   writeFile({

--- a/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/index.ts
+++ b/apps/evm/src/libs/contracts/scripts/generateContractRecords/generateContracts/generateAddressList/index.ts
@@ -40,7 +40,19 @@ export const generateAddressList = async ({
   });
 
   // Open addresses output
-  let addressesOutput = `export const addresses = {
+  let addressesOutput = 'import type { ChainId } from "types";\n';
+  addressesOutput += 'import type { Address } from "viem";\n';
+  addressesOutput += 'type MapChainIdToAddress = Partial<{ [chainId in ChainId]: Address }>;\n';
+  addressesOutput +=
+    'type MapChainIdToPoolAddress = Partial<{ [chainId in ChainId]: Record<Address, Address> }>;\n';
+  addressesOutput += `type Unique = {${sortedConfig.uniques
+    .map(({ name }) => `${name}: MapChainIdToAddress`)
+    .join(', ')}};\n`;
+  addressesOutput += `type UniquePerPool = {${sortedConfig.uniquesPerPool
+    .map(({ name }) => `${name}: MapChainIdToPoolAddress`)
+    .join(', ')}};\n`;
+  addressesOutput += 'type Addresses = { uniques: Unique, uniquesPerPool: UniquePerPool }\n';
+  addressesOutput += `export const addresses: Addresses = {
     uniques: {`;
 
   sortedConfig.uniques.forEach(config => {

--- a/apps/evm/src/libs/contracts/utilities/getContractAddress/index.ts
+++ b/apps/evm/src/libs/contracts/utilities/getContractAddress/index.ts
@@ -20,19 +20,19 @@ export type GetContractAddressInput =
   | GetUniqueContractAddressInput
   | GetUniquePerPoolContractAddressInput;
 
-export const getContractAddress = (input: GetContractAddressInput): Address | undefined => {
+export const getContractAddress = (input: GetContractAddressInput) => {
   if ('poolComptrollerContractAddress' in input) {
-    const contractAddressesByPool =
-      addresses.uniquesPerPool[input.name as keyof typeof addresses.uniquesPerPool];
+    const contractAddressesByPool = addresses.uniquesPerPool[input.name];
 
-    const contractAddresses =
-      contractAddressesByPool[input.chainId as keyof typeof contractAddressesByPool];
+    const contractAddresses = contractAddressesByPool[input.chainId];
 
-    return contractAddresses[
-      input.poolComptrollerContractAddress.toLowerCase() as keyof typeof contractAddresses
-    ];
+    return contractAddresses
+      ? contractAddresses[
+          input.poolComptrollerContractAddress.toLowerCase() as keyof typeof contractAddresses
+        ]
+      : undefined;
   }
 
-  const contractAddresses = addresses.uniques[input.name as keyof typeof addresses.uniques];
-  return contractAddresses[input.chainId as keyof typeof contractAddresses];
+  const contractAddresses = addresses.uniques[input.name];
+  return contractAddresses[input.chainId];
 };

--- a/apps/evm/src/libs/contracts/utilities/getContractAddress/index.ts
+++ b/apps/evm/src/libs/contracts/utilities/getContractAddress/index.ts
@@ -13,14 +13,14 @@ export type GetUniqueContractAddressInput = {
 export type GetUniquePerPoolContractAddressInput = {
   name: UniquePerPoolContractName;
   chainId: ChainId;
-  poolComptrollerContractAddress: string;
+  poolComptrollerContractAddress: Address;
 };
 
 export type GetContractAddressInput =
   | GetUniqueContractAddressInput
   | GetUniquePerPoolContractAddressInput;
 
-export const getContractAddress = (input: GetContractAddressInput) => {
+export const getContractAddress = (input: GetContractAddressInput): Address | undefined => {
   if ('poolComptrollerContractAddress' in input) {
     const contractAddressesByPool =
       addresses.uniquesPerPool[input.name as keyof typeof addresses.uniquesPerPool];
@@ -30,7 +30,7 @@ export const getContractAddress = (input: GetContractAddressInput) => {
 
     return contractAddresses[
       input.poolComptrollerContractAddress.toLowerCase() as keyof typeof contractAddresses
-    ] as Address | undefined;
+    ];
   }
 
   const contractAddresses = addresses.uniques[input.name as keyof typeof addresses.uniques];


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- Added a bit extra type safety for `getContractAddress`