### PR TITLE
fix: only show import position modal if user has importable positions

### DIFF
--- a/.changeset/gentle-taxes-bake.md
+++ b/.changeset/gentle-taxes-bake.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+only show import position modal if user has importable positions

--- a/apps/evm/src/containers/ImportPositionsModal/index.tsx
+++ b/apps/evm/src/containers/ImportPositionsModal/index.tsx
@@ -1,5 +1,7 @@
+import { useGetProfitableImports } from 'hooks/useGetProfitableImports';
 import { useUserChainSettings } from 'hooks/useUserChainSettings';
 import { useAccountAddress } from 'libs/wallet';
+import { useMeeClient } from 'libs/wallet';
 import { Suspense } from 'react';
 import { safeLazyLoad } from 'utilities';
 
@@ -8,8 +10,15 @@ const Modal = safeLazyLoad(() => import('./Modal'));
 const ImportPositionsModal: React.FC = () => {
   const { accountAddress } = useAccountAddress();
   const [userChainSettings] = useUserChainSettings();
+  const { importablePositionsCount } = useGetProfitableImports();
+  const { data: getMeeClientData } = useMeeClient();
 
-  if (!accountAddress || userChainSettings.doNotShowImportPositionsModal) {
+  if (
+    !accountAddress ||
+    userChainSettings.doNotShowImportPositionsModal ||
+    importablePositionsCount === 0 ||
+    !getMeeClientData
+  ) {
     return undefined;
   }
 


### PR DESCRIPTION
### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
-  only show import position modal if user has importable positions
