### PR TITLE
fix: fix APY percentage sent in analytics when importing position

### DIFF
--- a/.changeset/plenty-pigs-glow.md
+++ b/.changeset/plenty-pigs-glow.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix APY percentage sent in analytics when importing position

--- a/apps/evm/src/containers/ImportablePositions/ProtocolPositions/Position/index.tsx
+++ b/apps/evm/src/containers/ImportablePositions/ProtocolPositions/Position/index.tsx
@@ -48,7 +48,7 @@ export const Position: React.FC<PropositionProps> = ({
     fromTokenAmountDollars: supplyBalanceCents.dividedBy(100).toNumber(),
     fromTokenApyPercentage: supplyPosition.supplyApyPercentage,
     toVTokenAddress: asset.vToken.address,
-    toTokenApyPercentage: currentSupplyApyPercentage,
+    toTokenApyPercentage: supplyApyPercentage.toNumber(),
   };
 
   const { mutateAsync: importSupplyPosition, isPending: isImportSupplyPositionLoading } =


### PR DESCRIPTION
### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- fix APY percentage sent in analytics when importing position
