### PR TITLE
refactor: stop logging warning headers on Sentry

### DIFF
--- a/.changeset/three-cloths-create.md
+++ b/.changeset/three-cloths-create.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+stop logging warning headers on sentry

--- a/apps/evm/src/utilities/restService.ts
+++ b/apps/evm/src/utilities/restService.ts
@@ -88,13 +88,8 @@ export async function restService<D>({
 
       try {
         data = await response.json();
-        const warning = response.headers.get('Warning');
-
-        if (warning) {
-          logError(warning);
-        }
-      } catch {
-        // Do nothing
+      } catch (err) {
+        logError(err);
       }
 
       return { status, data };


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- We don't need to log warning headers on Sentry, they are expected when the backend is in the process of deprecating a certain endpoint version