### PR TITLE
fix: round chart interval division

### DIFF
--- a/.changeset/tall-chicken-kiss.md
+++ b/.changeset/tall-chicken-kiss.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Round intervals division in the market charts

--- a/apps/evm/src/components/charts/ApyChart/index.tsx
+++ b/apps/evm/src/components/charts/ApyChart/index.tsx
@@ -72,7 +72,7 @@ export const ApyChart: React.FC<ApyChartProps> = ({ className, data, type, selec
             stroke={sharedStyles.accessoryColor}
             tickMargin={sharedStyles.tickMargin}
             tickCount={data.length}
-            interval={data.length / chartInterval}
+            interval={Math.round(data.length / chartInterval)}
             style={sharedStyles.axis}
           />
           <YAxis


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- Round the interval division in the market charts. This division can potentially return a non integer number, which causes the chart rendering to crash