### PR TITLE
fix: filter inactive rewards from MarketInfo

### DIFF
--- a/.changeset/tiny-feet-see.md
+++ b/.changeset/tiny-feet-see.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Filter inactive rewards from market info

--- a/apps/evm/src/pages/Market/MarketInfo/index.tsx
+++ b/apps/evm/src/pages/Market/MarketInfo/index.tsx
@@ -57,6 +57,7 @@ const MarketInfo: React.FC<MarketInfoProps> = ({ asset }) => {
       // Filter out distributions that do not indicate the amount of tokens distributed to everyone
       // per day and those that equal 0
       if (
+        !distribution.isActive ||
         !('dailyDistributedTokens' in distribution) ||
         distribution.dailyDistributedTokens.isEqualTo(0)
       ) {


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- Filter inactive rewards from the `MarketInfo` component