### PR TITLE
fix: prevent unnecessary renders with integrated swap feature

### DIFF
--- a/.changeset/yellow-cases-wink.md
+++ b/.changeset/yellow-cases-wink.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+only fetch PancakeSwap pairs when integrated swap feature is enabled

--- a/apps/evm/src/hooks/useGetSwapInfo/index.ts
+++ b/apps/evm/src/hooks/useGetSwapInfo/index.ts
@@ -9,11 +9,11 @@ import BigNumber from 'bignumber.js';
 import { useMemo } from 'react';
 
 import { useGetPancakeSwapPairs } from 'clients/api';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { useGetToken } from 'libs/tokens';
 import { useChainId } from 'libs/wallet';
 import type { SwapError } from 'types';
 import { areTokensEqual, convertTokensToMantissa } from 'utilities';
-
 import formatToSwap from './formatToSwap';
 import type { UseGetSwapInfoInput, UseGetSwapInfoOutput } from './types';
 import useGetTokenCombinations from './useGetTokenCombinations';
@@ -34,10 +34,19 @@ const useGetSwapInfo = (input: UseGetSwapInfoInput): UseGetSwapInfoOutput => {
     toToken: input.toToken,
   });
 
-  // Fetch pair data
-  const { data: getPancakeSwapPairsData, isLoading } = useGetPancakeSwapPairs({
-    tokenCombinations,
+  const isIntegratedSwapFeatureEnabled = useIsFeatureEnabled({
+    name: 'integratedSwap',
   });
+
+  // Fetch pair data
+  const { data: getPancakeSwapPairsData, isLoading } = useGetPancakeSwapPairs(
+    {
+      tokenCombinations,
+    },
+    {
+      enabled: isIntegratedSwapFeatureEnabled,
+    },
+  );
 
   // Find the best trade based on pairs
   const swapInfo: Omit<UseGetSwapInfoOutput, 'isLoading'> = useMemo(() => {


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- only fetch PancakeSwap pairs when integrated swap feature is enabled