### PR TITLE
feat: only fetch burned BNB when feature is enabled

### DIFF
--- a/.changeset/itchy-banks-roll.md
+++ b/.changeset/itchy-banks-roll.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+only fetch burned BNB when feature is enabled

--- a/apps/evm/src/clients/api/queries/getBurnedWBnb/useGetBurnedWBnb.ts
+++ b/apps/evm/src/clients/api/queries/getBurnedWBnb/useGetBurnedWBnb.ts
@@ -1,6 +1,7 @@
 import { type QueryObserverOptions, useQuery } from '@tanstack/react-query';
 
 import FunctionKey from 'constants/functionKey';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { usePublicClient } from 'libs/wallet';
 import { type GetBurnedWBnbOutput, getBurnedWBnb } from '.';
 
@@ -16,10 +17,13 @@ type Options = QueryObserverOptions<
 
 export const useGetBurnedWBnb = (options?: Partial<Options>) => {
   const { publicClient } = usePublicClient();
+  const isBurnedWBnbButtonFeatureEnabled = useIsFeatureEnabled({ name: 'burnedWBnbButton' });
 
   return useQuery({
     queryKey: [FunctionKey.GET_BURNED_BNB],
     queryFn: () => getBurnedWBnb({ publicClient }),
     ...options,
+    enabled:
+      (options?.enabled === undefined || options?.enabled) && isBurnedWBnbButtonFeatureEnabled,
   });
 };


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- only fetch burned BNB when feature is enabled