### PR TITLE
fix: only fetch VAI borrow balance if VAI vault exists

### DIFF
--- a/.changeset/big-carpets-bathe.md
+++ b/.changeset/big-carpets-bathe.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+only fetch VAI borrow balance if VAI vault exists

--- a/apps/evm/src/clients/api/queries/getUserVaiBorrowBalance/useGetUserVaiBorrowBalance.ts
+++ b/apps/evm/src/clients/api/queries/getUserVaiBorrowBalance/useGetUserVaiBorrowBalance.ts
@@ -58,5 +58,6 @@ export const useGetUserVaiBorrowBalance = (
         }),
       ),
     ...options,
+    enabled: !!vaiControllerContractAddress && (options?.enabled === undefined || options?.enabled),
   });
 };


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- only fetch VAI borrow balance if VAI vault exists