### PR TITLE
fix: always load Prime status on new Account page

### DIFF
--- a/.changeset/brave-worms-tan.md
+++ b/.changeset/brave-worms-tan.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+also load Prime status

--- a/apps/evm/src/hooks/useGetUserPrimeInfo/index.tsx
+++ b/apps/evm/src/hooks/useGetUserPrimeInfo/index.tsx
@@ -37,7 +37,7 @@ export const useGetUserPrimeInfo = ({ accountAddress }: { accountAddress?: Addre
       accountAddress,
     },
     {
-      enabled: isPrimeFeatureEnabled && !isGetPrimeTokenLoading && !isUserPrime,
+      enabled: isPrimeFeatureEnabled,
       refetchInterval,
     },
   );


### PR DESCRIPTION
### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- always load Prime status on new Account page
