### PR TITLE
chore: remove redundant word in README.md

### DIFF
--- a/apps/evm/src/libs/contracts/README.md
+++ b/apps/evm/src/libs/contracts/README.md
@@ -25,7 +25,7 @@ if (governorBravoDelegateContract) {
 }
 ```
 
-After installing dependencies, this package automatically automatically generates a list of contract
+After installing dependencies, this package automatically generates a list of contract
 functions and hooks using its [config](./config/index.ts).
 
 ## Contract types


### PR DESCRIPTION
## Jira ticket(s)

VEN-XXX

## Changes

remove redundant word in README.md

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
-

### [landing app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/landing/)
-

### [chains package](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/chains/)
-

### [UI package](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/ui/)
-
