### PR TITLE
fix: only fetch VAI repay APR if VAI Controller address exists

### DIFF
--- a/.changeset/rare-months-drum.md
+++ b/.changeset/rare-months-drum.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+only attempt to fetch VAI repay APR if VAI Controller address exists

--- a/apps/evm/src/clients/api/queries/getVaiRepayApr/useGetVaiRepayApr.ts
+++ b/apps/evm/src/clients/api/queries/getVaiRepayApr/useGetVaiRepayApr.ts
@@ -29,6 +29,7 @@ export const useGetVaiRepayApr = (options?: Partial<Options>) => {
     queryKey: [FunctionKey.GET_VAI_REPAY_APR, { chainId }],
     queryFn: () =>
       callOrThrow({ vaiControllerAddress }, params => getVaiRepayApr({ ...params, publicClient })),
+    enabled: !!vaiControllerAddress && (options?.enabled === undefined || options?.enabled),
     ...options,
   });
 };


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- only attempt to fetch VAI repay APR if VAI Controller address exists