### PR TITLE
feat: improve Tabs to handle search param nav

### DIFF
--- a/.changeset/silent-emus-camp.md
+++ b/.changeset/silent-emus-camp.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+improve Tabs to handle search param nav

--- a/apps/evm/src/components/MarkdownEditor/index.tsx
+++ b/apps/evm/src/components/MarkdownEditor/index.tsx
@@ -29,9 +29,10 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
 }) => {
   const { t } = useTranslation();
 
-  const tabsContent = useMemo(
+  const tabs = useMemo(
     () => [
       {
+        id: 'markdown',
         title: t('markdownEditor.markdownTabLabel'),
         content: (
           <textarea
@@ -49,6 +50,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         ),
       },
       {
+        id: 'preview',
         title: t('markdownEditor.previewTabLabel'),
         content: (
           <div className="-mt-4 w-full">
@@ -70,7 +72,7 @@ export const MarkdownEditor: React.FC<MarkdownEditorProps> = ({
         <p className={cn('mb-1 text-sm font-semibold', hasError && 'text-red')}>{label}</p>
       )}
 
-      <Tabs tabsContent={tabsContent} />
+      <Tabs tabs={tabs} />
     </div>
   );
 };

--- a/apps/evm/src/components/Tabs/index.stories.tsx
+++ b/apps/evm/src/components/Tabs/index.stories.tsx
@@ -7,13 +7,9 @@ export default {
   component: Tabs,
 } as Meta<typeof Tabs>;
 
-const tabsContent = [
-  { title: 'Borrow', content: <>first tab content</> },
-  { title: 'Repay', content: <>second tab content</> },
+const tabs = [
+  { id: 'borrow', title: 'Borrow', content: <>first tab content</> },
+  { id: 'repay', title: 'Repay', content: <>second tab content</> },
 ];
 
-export const Default = () => <Tabs tabsContent={tabsContent} />;
-
-export const WithInitialSecondTabActive = () => (
-  <Tabs initialActiveTabIndex={1} tabsContent={tabsContent} />
-);
+export const Default = () => <Tabs tabs={tabs} />;

--- a/apps/evm/src/components/Tabs/index.tsx
+++ b/apps/evm/src/components/Tabs/index.tsx
@@ -1,34 +1,36 @@
 /** @jsxImportSource @emotion/react */
-import { type ReactElement, useState } from 'react';
-
+import { type Tab, type TabNavType, useTabs } from 'hooks/useTabs';
 import { ButtonGroup } from '../ButtonGroup';
 import { useStyles } from './styles';
 
-export type TabContent = {
-  title: string;
-  content: ReactElement;
-};
-
 export interface TabsProps {
-  tabsContent: TabContent[];
-  initialActiveTabIndex?: number;
+  tabs: Tab[];
   onTabChange?: (newIndex: number) => void;
+  navType?: TabNavType;
+  initialActiveTabId?: string;
   className?: string;
 }
 
 export const Tabs = ({
-  tabsContent,
-  initialActiveTabIndex = 0,
+  tabs,
   onTabChange,
+  initialActiveTabId,
   className,
+  navType = 'state',
 }: TabsProps) => {
   const styles = useStyles();
-  const [activeTabIndex, setActiveTabIndex] = useState(initialActiveTabIndex);
+  const { activeTab, setActiveTab } = useTabs({
+    tabs,
+    navType,
+    initialActiveTabId,
+  });
 
   const handleChange = (index: number) => {
-    setActiveTabIndex(index);
+    const id = tabs[index].id;
+    setActiveTab({ id });
+
     // Only call onTabChange callback if tab clicked isn't currently active
-    if (index !== activeTabIndex && onTabChange) {
+    if (id !== activeTab.id && onTabChange) {
       onTabChange(index);
     }
   };
@@ -36,14 +38,14 @@ export const Tabs = ({
   return (
     <div className={className}>
       <ButtonGroup
-        buttonLabels={tabsContent.map(({ title }) => title)}
+        buttonLabels={tabs.map(({ title }) => title)}
         css={styles.buttonsContainer}
-        activeButtonIndex={activeTabIndex}
+        activeButtonIndex={tabs.findIndex(tab => activeTab.id === tab.id)}
         onButtonClick={handleChange}
         fullWidth
       />
 
-      {tabsContent[activeTabIndex].content}
+      {activeTab.content}
     </div>
   );
 };

--- a/apps/evm/src/containers/Vault/WithdrawFromVestingVaultModal/index.tsx
+++ b/apps/evm/src/containers/Vault/WithdrawFromVestingVaultModal/index.tsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 
 import { Modal, type ModalProps, Tabs, TextButton } from 'components';
+import type { Tab } from 'hooks/useTabs';
 import { useTranslation } from 'libs/translations';
 import type { Token } from 'types';
 
@@ -23,7 +24,9 @@ const WithdrawFromVestingVaultModal: React.FC<WithdrawFromVestingVaultModalProps
   poolIndex,
   userHasPendingWithdrawalsFromBeforeUpgrade,
 }) => {
-  const [initialActiveTabIndex, setInitialActiveTabIndex] = useState(0);
+  const { t } = useTranslation();
+  const styles = useStyles();
+
   const [shouldDisplayWithdrawalRequestList, setShouldDisplayWithdrawalRequestList] =
     useState(false);
 
@@ -32,11 +35,36 @@ const WithdrawFromVestingVaultModal: React.FC<WithdrawFromVestingVaultModalProps
     setShouldDisplayWithdrawalRequestList(true);
     // Set initial active tab index to 1 so that if user clicks on modal back button
     // they get redirect to the "Request withdrawal" tab
-    setInitialActiveTabIndex(1);
+    setInitialActiveTabId(tabs[1].id);
   };
 
-  const { t } = useTranslation();
-  const styles = useStyles();
+  const tabs: Tab[] = [
+    {
+      id: 'withdraw',
+      title: t('withdrawFromVestingVaultModalModal.withdrawTabTitle'),
+      content: (
+        <div css={styles.tabContainer}>
+          <Withdraw stakedToken={stakedToken} poolIndex={poolIndex} handleClose={handleClose} />
+        </div>
+      ),
+    },
+    {
+      id: 'request-withdrawal',
+      title: t('withdrawFromVestingVaultModalModal.requestWithdrawalTabTitle'),
+      content: (
+        <div css={styles.tabContainer}>
+          <RequestWithdrawal
+            stakedToken={stakedToken}
+            poolIndex={poolIndex}
+            handleClose={handleClose}
+            handleDisplayWithdrawalRequestList={handleDisplayWithdrawalRequestList}
+          />
+        </div>
+      ),
+    },
+  ];
+
+  const [initialActiveTabId, setInitialActiveTabId] = useState(tabs[0].id);
 
   return (
     <Modal
@@ -78,36 +106,7 @@ const WithdrawFromVestingVaultModal: React.FC<WithdrawFromVestingVaultModalProps
               </div>
             </>
           ) : (
-            <Tabs
-              initialActiveTabIndex={initialActiveTabIndex}
-              tabsContent={[
-                {
-                  title: t('withdrawFromVestingVaultModalModal.withdrawTabTitle'),
-                  content: (
-                    <div css={styles.tabContainer}>
-                      <Withdraw
-                        stakedToken={stakedToken}
-                        poolIndex={poolIndex}
-                        handleClose={handleClose}
-                      />
-                    </div>
-                  ),
-                },
-                {
-                  title: t('withdrawFromVestingVaultModalModal.requestWithdrawalTabTitle'),
-                  content: (
-                    <div css={styles.tabContainer}>
-                      <RequestWithdrawal
-                        stakedToken={stakedToken}
-                        poolIndex={poolIndex}
-                        handleClose={handleClose}
-                        handleDisplayWithdrawalRequestList={handleDisplayWithdrawalRequestList}
-                      />
-                    </div>
-                  ),
-                },
-              ]}
-            />
+            <Tabs initialActiveTabId={initialActiveTabId} tabs={tabs} />
           )}
         </>
       )}

--- a/apps/evm/src/hooks/useTabs/index.tsx
+++ b/apps/evm/src/hooks/useTabs/index.tsx
@@ -1,5 +1,13 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router';
+
+export type TabNavType = 'searchParam' | 'state';
+
+export interface UseTabsInput<T extends Tab> {
+  tabs: T[];
+  navType?: TabNavType;
+  initialActiveTabId?: string;
+}
 
 export interface Tab extends Record<string, any> {
   id: string;
@@ -9,24 +17,34 @@ export interface Tab extends Record<string, any> {
 
 export const TAB_PARAM_KEY = 'tab';
 
-export const useTabs = <T extends Tab>({ tabs }: { tabs: T[] }) => {
+export const useTabs = <T extends Tab>({
+  tabs,
+  navType = 'state',
+  initialActiveTabId,
+}: UseTabsInput<T>) => {
   const [searchParams, setSearchParams] = useSearchParams();
+  const [stateActiveTabId, setStateActiveTabId] = useState(initialActiveTabId ?? tabs[0].id);
 
-  const activeTabId = searchParams.get(TAB_PARAM_KEY) ?? undefined;
+  const activeTabId = navType === 'state' ? stateActiveTabId : searchParams.get(TAB_PARAM_KEY);
   const activeTab = tabs.find(tab => tab.id === activeTabId) || tabs[0];
 
-  const setActiveTab = ({ id }: { id: string }) =>
-    setSearchParams(currentSearchParams => ({
-      ...Object.fromEntries(currentSearchParams),
-      [TAB_PARAM_KEY]: id,
-    }));
+  const setActiveTab = ({ id }: { id: string }) => {
+    if (navType === 'state') {
+      setStateActiveTabId(id);
+    } else {
+      setSearchParams(currentSearchParams => ({
+        ...Object.fromEntries(currentSearchParams),
+        [TAB_PARAM_KEY]: id,
+      }));
+    }
+  };
 
   useEffect(() => {
     // Set tab param to URL if none has been set or if it's invalid
     if (!activeTabId || !tabs.find(tab => tab.id === activeTabId)) {
-      setActiveTab({ id: tabs[0].id });
+      setActiveTab({ id: initialActiveTabId ?? tabs[0].id });
     }
-  }, [activeTabId, setActiveTab, tabs]);
+  }, [activeTabId, setActiveTab, tabs, initialActiveTabId]);
 
   return {
     activeTab,

--- a/apps/evm/src/pages/Account/NewPage/Tabs/index.tsx
+++ b/apps/evm/src/pages/Account/NewPage/Tabs/index.tsx
@@ -8,6 +8,7 @@ export interface TabsProps {
 export const Tabs: React.FC<TabsProps> = ({ tabs }) => {
   const { activeTab, setActiveTab } = useTabs({
     tabs,
+    navType: 'searchParam',
   });
 
   return (

--- a/apps/evm/src/pages/Market/OperationForm/index.tsx
+++ b/apps/evm/src/pages/Market/OperationForm/index.tsx
@@ -1,8 +1,9 @@
-import { type ModalProps, type TabContent, Tabs } from 'components';
+import { type ModalProps, Tabs } from 'components';
 import AssetAccessor from 'containers/AssetAccessor';
 import { useTranslation } from 'libs/translations';
 import type { VToken } from 'types';
 
+import type { Tab } from 'hooks/useTabs';
 import type { Address } from 'viem';
 import BorrowForm from './BorrowForm';
 import NativeTokenBalanceWrapper from './NativeTokenBalanceWrapper';
@@ -13,7 +14,7 @@ import WithdrawForm from './WithdrawForm';
 export interface OperationFormProps {
   vToken: VToken;
   poolComptrollerAddress: Address;
-  initialActiveTabIndex?: number;
+  initialActiveTabId?: string;
   onSubmitSuccess?: ModalProps['handleClose'];
 }
 
@@ -21,12 +22,13 @@ export const OperationForm: React.FC<OperationFormProps> = ({
   onSubmitSuccess,
   vToken,
   poolComptrollerAddress,
-  initialActiveTabIndex = 0,
+  initialActiveTabId,
 }) => {
   const { t } = useTranslation();
 
-  const tabsContent: TabContent[] = [
+  const tabs: Tab[] = [
     {
+      id: 'supply',
       title: t('operationForm.supplyTabTitle'),
       content: (
         <AssetAccessor
@@ -50,6 +52,7 @@ export const OperationForm: React.FC<OperationFormProps> = ({
       ),
     },
     {
+      id: 'withdraw',
       title: t('operationForm.withdrawTabTitle'),
       content: (
         <AssetAccessor
@@ -64,6 +67,7 @@ export const OperationForm: React.FC<OperationFormProps> = ({
       ),
     },
     {
+      id: 'borrow',
       title: t('operationForm.borrowTabTitle'),
       content: (
         <AssetAccessor
@@ -78,6 +82,7 @@ export const OperationForm: React.FC<OperationFormProps> = ({
       ),
     },
     {
+      id: 'repay',
       title: t('operationForm.repayTabTitle'),
       content: (
         <AssetAccessor
@@ -102,5 +107,5 @@ export const OperationForm: React.FC<OperationFormProps> = ({
     },
   ];
 
-  return <Tabs tabsContent={tabsContent} initialActiveTabIndex={initialActiveTabIndex} />;
+  return <Tabs tabs={tabs} initialActiveTabId={initialActiveTabId} navType="searchParam" />;
 };

--- a/apps/evm/src/pages/Pool/Tabs/EMode/EModeGroup/Header/BlockingPositionModal/BlockingPosition/index.tsx
+++ b/apps/evm/src/pages/Pool/Tabs/EMode/EModeGroup/Header/BlockingPositionModal/BlockingPosition/index.tsx
@@ -2,6 +2,7 @@ import { ButtonWrapper, LayeredValues, TokenIcon, TokenIconWithSymbol } from 'co
 import { routes } from 'constants/routing';
 import { Link } from 'containers/Link';
 import { useFormatTo } from 'hooks/useFormatTo';
+import { TAB_PARAM_KEY } from 'hooks/useTabs';
 import { useTranslation } from 'libs/translations';
 import type { Asset } from 'types';
 import { formatCentsToReadableValue, formatTokensToReadableValue } from 'utilities';
@@ -24,6 +25,7 @@ export const BlockingPosition: React.FC<BlockingPositionProps> = ({
       pathname: routes.market.path
         .replace(':poolComptrollerAddress', poolComptrollerAddress)
         .replace(':vTokenAddress', asset.vToken.address),
+      search: `${TAB_PARAM_KEY}=repay`,
     },
   });
 

--- a/apps/evm/src/pages/Pool/Tabs/index.tsx
+++ b/apps/evm/src/pages/Pool/Tabs/index.tsx
@@ -35,6 +35,7 @@ export const Tabs: React.FC<TabsProps> = ({ pool }) => {
 
   const { activeTab, setActiveTab } = useTabs({
     tabs,
+    navType: 'searchParam',
   });
 
   const activeTabIndex = tabs.findIndex(tab => tab.id === activeTab.id);

--- a/apps/evm/src/pages/Vai/index.tsx
+++ b/apps/evm/src/pages/Vai/index.tsx
@@ -9,8 +9,8 @@ const Vai: React.FC = () => {
   const { t, Trans } = useTranslation();
 
   const tabsContent = [
-    { title: t('vai.borrow.tabTitle'), content: <Borrow /> },
-    { title: t('vai.repay.tabTitle'), content: <Repay /> },
+    { id: 'borrow', title: t('vai.borrow.tabTitle'), content: <Borrow /> },
+    { id: 'repay', title: t('vai.repay.tabTitle'), content: <Repay /> },
   ];
 
   return (
@@ -29,7 +29,7 @@ const Vai: React.FC = () => {
         />
 
         <Card>
-          <Tabs tabsContent={tabsContent} />
+          <Tabs tabs={tabsContent} />
         </Card>
       </div>
     </Page>


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- add `initialActiveTabId` and `navType` props to `useTabs` hook
- update `Tabs` component to use `useTabs` hook
- E-mode: make sure user is redirected to Repay tab of the Market page when clicking on the CTA of a blocking borrow position