### PR TITLE
fix: prioritize price from oracle when calculating distributions

### DIFF
--- a/.changeset/polite-yaks-sit.md
+++ b/.changeset/polite-yaks-sit.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+prioritize price from oracle when calculating distributions

--- a/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/index.ts
+++ b/apps/evm/src/clients/api/queries/useGetPools/getPools/formatOutput/formatDistributions/index.ts
@@ -75,7 +75,7 @@ export const formatDistributions = ({
           return 0;
         }
 
-        if (tp01.priceSource === 'merkl' || tp02.priceSource === 'coingecko') {
+        if (tp01.priceSource === 'oracle' || tp02.priceSource === 'coingecko') {
           return -1;
         }
 
@@ -85,6 +85,7 @@ export const formatDistributions = ({
       if (tokenPriceMapping.length === 0) {
         return;
       }
+
       const correspondingRewardTokenPrice = tokenPriceMapping[0];
 
       const { priceMantissa } = correspondingRewardTokenPrice;


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- prioritize price from oracle when calculating distributions