### PR TITLE
fix: p tags font-size on landing page

### DIFF
--- a/.changeset/swift-files-speak.md
+++ b/.changeset/swift-files-speak.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/landing": patch
+---
+
+fix p tags font-size on landing page

--- a/apps/landing/src/assets/styles/index.css
+++ b/apps/landing/src/assets/styles/index.css
@@ -27,7 +27,7 @@ p {
   font-size: 1rem;
 
   @media (min-width: 1280px) {
-    font-size: 1.2rem;
+    font-size: 1.125rem;
   }
 }
 

--- a/apps/landing/src/pages/Home/Safety/Safety.module.css
+++ b/apps/landing/src/pages/Home/Safety/Safety.module.css
@@ -23,7 +23,6 @@
 
 .assetSecurity {
     text-align: center;
-    font-size: 1.2rem;
     max-width: 650px;
 
     margin: 16px 0 40px 0;


### PR DESCRIPTION
### [landing app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/landing/)
- fix `p` tags font size