### PR TITLE
fix: only show acknowledgement component when needed

### DIFF
--- a/.changeset/vast-parks-make.md
+++ b/.changeset/vast-parks-make.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+only show acknowledgement component when needed

--- a/apps/evm/src/pages/Market/OperationForm/BorrowForm/index.tsx
+++ b/apps/evm/src/pages/Market/OperationForm/BorrowForm/index.tsx
@@ -341,7 +341,7 @@ export const BorrowFormUi: React.FC<BorrowFormUiProps> = ({
             pool={pool}
           />
 
-          {isRiskyOperation && (
+          {isRiskyOperation && formError?.code === 'REQUIRES_RISK_ACKNOWLEDGEMENT' && (
             <RiskAcknowledgementToggle
               value={formValues.acknowledgeRisk}
               onChange={(_, checked) => handleToggleAcknowledgeRisk(checked)}

--- a/apps/evm/src/pages/Market/OperationForm/WithdrawForm/index.tsx
+++ b/apps/evm/src/pages/Market/OperationForm/WithdrawForm/index.tsx
@@ -346,7 +346,7 @@ export const WithdrawFormUi: React.FC<WithdrawFormUiProps> = ({
             pool={pool}
           />
 
-          {isRiskyOperation && (
+          {isRiskyOperation && formError?.code === 'REQUIRES_RISK_ACKNOWLEDGEMENT' && (
             <RiskAcknowledgementToggle
               value={formValues.acknowledgeRisk}
               onChange={(_, checked) => handleToggleAcknowledgeRisk(checked)}


### PR DESCRIPTION
## Jira ticket(s)

VPD-176

## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- only show acknowledgement component when needed