### PR TITLE
feat: make token balances optional in SelectTokenTextField component

### DIFF
--- a/.changeset/thin-sides-slide.md
+++ b/.changeset/thin-sides-slide.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+make token balances optional in SelectTokenTextField component

--- a/apps/evm/src/components/SelectTokenTextField/TokenList/index.tsx
+++ b/apps/evm/src/components/SelectTokenTextField/TokenList/index.tsx
@@ -12,10 +12,11 @@ import { SenaryButton } from '@venusprotocol/ui';
 import { TextField } from '../../TextField';
 import { useStyles as useParentStyles } from '../styles';
 import { getTokenListItemTestId } from '../testIdGetters';
+import type { OptionalTokenBalance } from '../types';
 import { useStyles } from './styles';
 
 export interface TokenListProps {
-  tokenBalances: TokenBalance[];
+  tokenBalances: OptionalTokenBalance[];
   onTokenClick: (token: Token) => void;
   'data-testid'?: string;
 }
@@ -47,8 +48,8 @@ export const TokenList: React.FC<TokenListProps> = ({
   const sortedTokenBalances = useMemo(
     () =>
       [...tokenBalances].sort((a, b) => {
-        const aIsNonNegative = a.balanceMantissa.isGreaterThan(0);
-        const bIsNonNegative = b.balanceMantissa.isGreaterThan(0);
+        const aIsNonNegative = !!a.balanceMantissa?.isGreaterThan(0);
+        const bIsNonNegative = !!b.balanceMantissa?.isGreaterThan(0);
 
         // Both are non-negative or both are negative
         if (aIsNonNegative === bIsNonNegative) {
@@ -127,15 +128,17 @@ export const TokenList: React.FC<TokenListProps> = ({
           >
             <TokenIconWithSymbol css={parentStyles.token} token={tokenBalance.token} />
 
-            <Typography variant="small2">
-              {convertMantissaToTokens({
-                value: tokenBalance.balanceMantissa,
-                token: tokenBalance.token,
-                returnInReadableFormat: true,
+            {tokenBalance.balanceMantissa && (
+              <Typography variant="small2">
+                {convertMantissaToTokens({
+                  value: tokenBalance.balanceMantissa,
+                  token: tokenBalance.token,
+                  returnInReadableFormat: true,
 
-                addSymbol: false,
-              })}
-            </Typography>
+                  addSymbol: false,
+                })}
+              </Typography>
+            )}
           </div>
         ))}
       </div>

--- a/apps/evm/src/components/SelectTokenTextField/index.tsx
+++ b/apps/evm/src/components/SelectTokenTextField/index.tsx
@@ -3,7 +3,7 @@ import { Typography } from '@mui/material';
 import { useState } from 'react';
 
 import { TokenIconWithSymbol } from 'components/TokenIconWithSymbol';
-import type { Token, TokenBalance } from 'types';
+import type { Token } from 'types';
 
 import { TertiaryButton } from '@venusprotocol/ui';
 import { Icon } from '../Icon';
@@ -15,10 +15,11 @@ import {
   getTokenSelectButtonTestId,
   getTokenTextFieldTestId,
 } from './testIdGetters';
+import type { OptionalTokenBalance } from './types';
 
 export interface SelectTokenTextFieldProps extends Omit<TokenTextFieldProps, 'max' | 'token'> {
   selectedToken: Token;
-  tokenBalances: TokenBalance[];
+  tokenBalances: OptionalTokenBalance[];
   onChangeSelectedToken: (token: Token) => void;
   'data-testid'?: string;
 }

--- a/apps/evm/src/components/SelectTokenTextField/types.ts
+++ b/apps/evm/src/components/SelectTokenTextField/types.ts
@@ -1,0 +1,5 @@
+import type { TokenBalance } from 'types';
+
+export interface OptionalTokenBalance extends Omit<TokenBalance, 'balanceMantissa'> {
+  balanceMantissa?: BigNumber;
+}


### PR DESCRIPTION
## Jira ticket(s)

VPD-211

## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- update `SelectTokenTextField` component so that token balances can be `undefined`, in which case they won't be displayed