### PR TITLE
fix: translation comments

### DIFF
--- a/.changeset/odd-cooks-punch.md
+++ b/.changeset/odd-cooks-punch.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+Added helper comments for extract-translations

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -93,13 +93,13 @@
         },
         "txType": {
           "all": "All transactions",
-          "mint": "Supply",
-          "borrow": "Borrow",
-          "redeem": "Withdraw",
-          "repay": "Repayment",
           "approve": "Approval",
+          "borrow": "Borrow",
           "enterMarket": "Enabled collateral",
-          "exitMarket": "Disabled collateral"
+          "exitMarket": "Disabled collateral",
+          "mint": "Supply",
+          "redeem": "Withdraw",
+          "repay": "Repayment"
         }
       },
       "today": "Today",
@@ -976,12 +976,12 @@
       "label": "Price impact",
       "tooltip": "Difference between the market price and estimated price due to trade size."
     },
+    "slippageTolerance": {
+      "label": "Slippage tolerance"
+    },
     "slippageToleranceModal": {
       "description": "Setting a high slippage tolerance can help transactions succeed, but you may not get such a good price. Use with caution.",
       "title": "Slippage tolerance"
-    },
-    "slippageTolerance": {
-      "label": "Slippage tolerance"
     }
   },
   "swapPage": {

--- a/apps/evm/src/pages/Account/Transactions/index.tsx
+++ b/apps/evm/src/pages/Account/Transactions/index.tsx
@@ -15,6 +15,15 @@ const PAGE_PARAM_KEY = 'page';
 const TX_TYPE_PARAM_KEY = 'txType';
 const CONTRACT_ADDRESS_PARAM_KEY = 'contractAddress';
 
+// DO NOT REMOVE COMMENT: needed by i18next to extract translation key
+// t('account.transactions.selects.txType.mint')
+// t('account.transactions.selects.txType.repay')
+// t('account.transactions.selects.txType.borrow')
+// t('account.transactions.selects.txType.redeem')
+// t('account.transactions.selects.txType.approve')
+// t('account.transactions.selects.txType.exitMarket')
+// t('account.transactions.selects.txType.enterMarket')
+
 const getTxTypeOptionTranslationKey = (txType: TxType) => {
   switch (txType) {
     case TxType.Mint:


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- Added helper comments to avoid removing by accident the transaction types text when running `yarn extract-transalations`
