### PR TITLE
chore: remove engines settings from package files

### DIFF
--- a/.changeset/eleven-wolves-shake.md
+++ b/.changeset/eleven-wolves-shake.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+remove engines settings from package files so nvmrc file version is used instead

--- a/apps/evm/package.json
+++ b/apps/evm/package.json
@@ -2,9 +2,6 @@
   "name": "@venusprotocol/evm",
   "version": "3.76.0",
   "private": true,
-  "engines": {
-    "node": ">=20.x.x"
-  },
   "scripts": {
     "start": "vite",
     "build": "NODE_OPTIONS=\"--max-old-space-size=16384\" && vite build",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "venusprotocol",
   "version": "1.0.0",
   "private": true,
-  "engines": {
-    "node": ">=20.x.x"
-  },
   "packageManager": "yarn@1.22.21",
-  "workspaces": ["packages/*", "configs/*", "apps/*"],
+  "workspaces": [
+    "packages/*",
+    "configs/*",
+    "apps/*"
+  ],
   "scripts": {
     "start": "turbo run start",
     "generate": "turbo run generate",


### PR DESCRIPTION
## Changes

- remove engines settings from package files so .nvmrc file version is used instead