### PR TITLE
fix: block boost tab for users with no collateral

### DIFF
--- a/.changeset/late-pears-trade.md
+++ b/.changeset/late-pears-trade.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+only allow users with pre-existing collateral to open a leveraged position

--- a/apps/evm/src/pages/Market/OperationForm/BoostForm/useForm/useFormValidation.ts
+++ b/apps/evm/src/pages/Market/OperationForm/BoostForm/useForm/useFormValidation.ts
@@ -42,10 +42,7 @@ const useFormValidation = ({
   const { t } = useTranslation();
 
   const formError = useMemo<FormError<FormErrorCode> | undefined>(() => {
-    if (
-      (!pool?.userBorrowLimitCents || pool.userBorrowLimitCents.isEqualTo(0)) &&
-      asset.userSupplyBalanceCents.isEqualTo(0)
-    ) {
+    if (!pool?.userBorrowLimitCents || pool.userBorrowLimitCents.isEqualTo(0)) {
       return {
         code: 'NO_COLLATERALS',
         message: t('operationForm.error.noCollateral', {


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- only allow users with pre-existing collateral to open a leveraged position