### PR TITLE
fix: issue with incorrect decimals used in approximate-out swaps

### DIFF
--- a/.changeset/cold-bottles-sin.md
+++ b/.changeset/cold-bottles-sin.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+fix issue with incorrect decimals used in approximate-out swaps

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
   "editor.codeActionsOnSave": {
     "source.organizeImports.biome": "explicit"
-  }
+  },
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.formatOnSave": true
 }

--- a/apps/evm/src/clients/api/queries/getSwapQuote/__ tests__/index.spec.ts
+++ b/apps/evm/src/clients/api/queries/getSwapQuote/__ tests__/index.spec.ts
@@ -111,7 +111,7 @@ describe('getSwapQuote', () => {
         "params": {
           "chainId": 56,
           "deadlineTimestampSecs": 1747386407,
-          "exactAmountOutMantissa": "1000000",
+          "exactAmountOutMantissa": "1000000000000000000",
           "recipientAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
           "shouldTransferToReceiver": true,
           "slippagePercentage": 0.005,
@@ -163,7 +163,7 @@ describe('getSwapQuote', () => {
         "params": {
           "chainId": 56,
           "deadlineTimestampSecs": 1747386407,
-          "minAmountOutMantissa": "1000000",
+          "minAmountOutMantissa": "1000000000000000000",
           "recipientAddress": "0x3d759121234cd36F8124C21aFe1c6852d2bEd848",
           "shouldTransferToReceiver": true,
           "slippagePercentage": 0.005,
@@ -187,7 +187,7 @@ describe('getSwapQuote', () => {
             "symbol": "USDC",
           },
           "fromTokenAmountSoldMantissa": 1000000n,
-          "minimumToTokenAmountReceivedMantissa": 1000000n,
+          "minimumToTokenAmountReceivedMantissa": 1000000000000000000n,
           "priceImpactPercentage": 0.8,
           "toToken": {
             "address": "0x8301F2213c0eeD49a7E28Ae4c3e91722919B8B47",

--- a/apps/evm/src/clients/api/queries/getSwapQuote/index.ts
+++ b/apps/evm/src/clients/api/queries/getSwapQuote/index.ts
@@ -34,13 +34,13 @@ export const getSwapQuote = async ({
   } else if (swapSpecificProps.direction === 'exact-out') {
     params.exactAmountOutMantissa = convertTokensToMantissa({
       value: swapSpecificProps.toTokenAmountTokens,
-      token: fromToken,
+      token: toToken,
     }).toFixed();
   } else {
     // Approximate out swap
     params.minAmountOutMantissa = convertTokensToMantissa({
       value: swapSpecificProps.minToTokenAmountTokens,
-      token: fromToken,
+      token: toToken,
     }).toFixed();
   }
 


### PR DESCRIPTION
## Changes

### [evm app](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/evm/)
- fix issue with incorrect decimals used in approximate-out swaps