### PR TITLE
chore: do not block build pipeline when vToken is missing

### DIFF
--- a/.changeset/fair-lizards-tell.md
+++ b/.changeset/fair-lizards-tell.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/chains": patch
+---
+
+do not block build pipeline when vToken is missing

--- a/packages/chains/src/scripts/generateVTokens/writeVTokens/index.ts
+++ b/packages/chains/src/scripts/generateVTokens/writeVTokens/index.ts
@@ -73,15 +73,17 @@ export const writeVTokens = async ({
     const vTokenAddress = vTokenAddresses[i / 2];
 
     if (!symbol) {
-      throw new Error(
+      process.emitWarning(
         `Failed to fetch vToken symbol. Chain ID: ${chainId} Address: ${vTokenAddress}`,
       );
+      continue;
     }
 
     if (underlyingTokenIndex < 0) {
-      throw new Error(
+      process.emitWarning(
         `Could not find underlying token for vToken ${symbol}. Chain ID: ${chainId} Address: ${vTokenAddress}`,
       );
+      continue;
     }
 
     vTokens.push({


### PR DESCRIPTION
### [chains package](https://github.com/VenusProtocol/venus-protocol-interface/tree/main/apps/chains/)
- emit warning instead of throwing error when a VToken record is missing
