### PR TITLE
chore: make Dependabot ignore major version upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,7 @@ updates:
     versioning-strategy: 'widen'
     schedule:
       interval: 'daily'
+    ignore:
+      # Ignore all major updates
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Changes

- make Dependabot ignore major version upgrades