### PR TITLE
fix: only return cap errors for relevant balance mutations

### DIFF
--- a/.changeset/major-mangos-see.md
+++ b/.changeset/major-mangos-see.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+only return cap errors for relevant balance mutations

--- a/apps/evm/src/pages/Market/OperationForm/useCommonValidation/index.ts
+++ b/apps/evm/src/pages/Market/OperationForm/useCommonValidation/index.ts
@@ -1,5 +1,3 @@
-// TODO: add tests
-
 import {
   HEALTH_FACTOR_LIQUIDATION_THRESHOLD,
   HEALTH_FACTOR_MODERATE_THRESHOLD,
@@ -44,6 +42,7 @@ export const useCommonValidation = ({
     }
 
     if (
+      balanceMutation.action === 'supply' &&
       asset.supplyCapTokens &&
       asset.supplyBalanceTokens.isGreaterThanOrEqualTo(asset.supplyCapTokens)
     ) {
@@ -60,6 +59,7 @@ export const useCommonValidation = ({
     }
 
     if (
+      balanceMutation.action === 'borrow' &&
       asset.borrowCapTokens &&
       asset.borrowBalanceTokens.isGreaterThanOrEqualTo(asset.borrowCapTokens)
     ) {


### PR DESCRIPTION
## Changes

- only return cap errors for relevant balance mutations
