### PR TITLE
fix: prevent dividing by 0 when calculating max borrow power

### DIFF
--- a/.changeset/fast-readers-flash.md
+++ b/.changeset/fast-readers-flash.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+prevent dividing by 0 when calculating max borrow power

--- a/apps/evm/src/pages/Market/OperationForm/BoostForm/calculateUserMaxBorrowTokens/index.tsx
+++ b/apps/evm/src/pages/Market/OperationForm/BoostForm/calculateUserMaxBorrowTokens/index.tsx
@@ -8,9 +8,12 @@ export const calculateUserMaxBorrowTokens = ({
   suppliedAsset,
   userBorrowingPowerCents,
 }: { borrowedAsset: Asset; suppliedAsset: Asset; userBorrowingPowerCents: BigNumber }) => {
-  const userMaxBorrowCents = userBorrowingPowerCents.div(
-    new BigNumber(1).minus(suppliedAsset.userCollateralFactor),
-  );
+  const userMaxBorrowCents =
+    // If the collateral factor is 1, then it means the user can borrow up to 100% of their
+    // collateral value
+    suppliedAsset.userCollateralFactor === 1
+      ? userBorrowingPowerCents
+      : userBorrowingPowerCents.div(new BigNumber(1).minus(suppliedAsset.userCollateralFactor));
 
   const userMaxBorrowTokens = userMaxBorrowCents
     .div(borrowedAsset.tokenPriceCents)


### PR DESCRIPTION
## Changes

- prevent dividing by 0 when calculating max borrow power
