### PR TITLE
fix: exclude WBNB from token select list on native BNB market

### DIFF
--- a/apps/evm/src/pages/Market/OperationForm/Repay/RepayWithWalletBalanceForm/index.tsx
+++ b/apps/evm/src/pages/Market/OperationForm/Repay/RepayWithWalletBalanceForm/index.tsx
@@ -574,6 +574,14 @@ const RepayWithWalletBalanceForm: React.FC<RepayWithWalletBalanceFormProps> = ({
           value: asset.userWalletBalanceTokens,
         }),
       };
+
+      // Don't offer WBNB as an alternative when the market's underlying is the
+      // native token (e.g. BNB market). The SwapRouter treats WBNB and native
+      // BNB as identical for vBNB, so the swap path is broken for that pair.
+      if (asset.vToken.underlyingToken.isNative) {
+        return [marketTokenBalance];
+      }
+
       const nativeTokenBalance: TokenBalance = {
         token: asset.vToken.underlyingToken.tokenWrapped,
         balanceMantissa: userTokenWrappedBalanceMantissa,

--- a/apps/evm/src/pages/Market/OperationForm/SupplyForm/index.tsx
+++ b/apps/evm/src/pages/Market/OperationForm/SupplyForm/index.tsx
@@ -171,6 +171,14 @@ const SupplyForm: React.FC<SupplyFormProps> = ({
           value: asset.userWalletBalanceTokens,
         }),
       };
+
+      // Don't offer WBNB as an alternative when the market's underlying is the
+      // native token (e.g. BNB market). The SwapRouter treats WBNB and native
+      // BNB as identical for vBNB, so the swap path is broken for that pair.
+      if (asset.vToken.underlyingToken.isNative) {
+        return [marketTokenBalance];
+      }
+
       const nativeTokenBalance: TokenBalance = {
         token: asset.vToken.underlyingToken.tokenWrapped,
         balanceMantissa: userTokenWrappedBalanceMantissa,


### PR DESCRIPTION
## Summary

- In `SupplyForm` and `RepayWithWalletBalanceForm`, `nativeWrappedTokenBalances` was including WBNB as a selectable input token for the BNB market (vBNB)
- The Venus SwapRouter maps `vBNB → WBNB` via `_getUnderlyingToken`, so when a user selects WBNB as input, `tokenIn == tokenOut` and the swap is short-circuited — resulting in broken supply/repay transactions
- Guard added: when `underlyingToken.isNative === true`, skip adding `tokenWrapped` (WBNB) to the token list

## Test plan

- [ ] Open BNB market Supply form — WBNB should not appear in the token selector
- [ ] Open BNB market Repay form — WBNB should not appear in the token selector
- [ ] Open WBNB market Supply form — native BNB should still appear (unaffected)
- [ ] Open WBNB market Repay form — native BNB should still appear (unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)