### PR TITLE
feat: add singular Liquidity Hub page skeleton

### DIFF
--- a/.changeset/red-moles-agree.md
+++ b/.changeset/red-moles-agree.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+add singular Liquidity Hub page skeleton

--- a/apps/evm/src/__mocks__/utilities/getTokenIconSrc/index.ts
+++ b/apps/evm/src/__mocks__/utilities/getTokenIconSrc/index.ts
@@ -1,0 +1,7 @@
+import { tokens } from '@venusprotocol/chains';
+
+export const getTokenIconSrc = ({ symbol }: { symbol: string }) =>
+  Object.values(tokens)
+    .flat()
+    .find(candidateToken => candidateToken.symbol.toLowerCase() === symbol.toLowerCase())
+    ?.iconSrc || '';

--- a/apps/evm/src/clients/api/queries/getLiquidityHub/index.ts
+++ b/apps/evm/src/clients/api/queries/getLiquidityHub/index.ts
@@ -1,0 +1,24 @@
+import { liquidityHubs } from '__mocks__/models/liquidityHubs';
+import type { LiquidityHub } from 'types';
+import { areAddressesEqual } from 'utilities';
+import type { Address } from 'viem';
+
+export interface GetLiquidityHubInput {
+  vhTokenAddress: Address;
+}
+
+export interface GetLiquidityHubOutput {
+  liquidityHub?: LiquidityHub;
+}
+
+export const getLiquidityHub = async ({
+  vhTokenAddress,
+}: GetLiquidityHubInput): Promise<GetLiquidityHubOutput> => {
+  const liquidityHub = liquidityHubs.find(currLiquidityHub =>
+    areAddressesEqual(currLiquidityHub.vhToken.address, vhTokenAddress),
+  );
+
+  return {
+    liquidityHub,
+  };
+};

--- a/apps/evm/src/clients/api/queries/getLiquidityHub/useGetLiquidityHub/index.ts
+++ b/apps/evm/src/clients/api/queries/getLiquidityHub/useGetLiquidityHub/index.ts
@@ -1,0 +1,21 @@
+import { type QueryObserverOptions, useQuery } from '@tanstack/react-query';
+
+import FunctionKey from 'constants/functionKey';
+import { type GetLiquidityHubInput, type GetLiquidityHubOutput, getLiquidityHub } from '..';
+
+export type UseGetLiquidityHubQueryKey = [FunctionKey.GET_LIQUIDITY_HUB, GetLiquidityHubInput];
+
+type Options = QueryObserverOptions<
+  GetLiquidityHubOutput,
+  Error,
+  GetLiquidityHubOutput,
+  GetLiquidityHubOutput,
+  UseGetLiquidityHubQueryKey
+>;
+
+export const useGetLiquidityHub = (input: GetLiquidityHubInput, options?: Partial<Options>) =>
+  useQuery({
+    queryKey: [FunctionKey.GET_LIQUIDITY_HUB, input],
+    queryFn: () => getLiquidityHub(input),
+    ...options,
+  });

--- a/apps/evm/src/components/MarketPageGrid/index.tsx
+++ b/apps/evm/src/components/MarketPageGrid/index.tsx
@@ -1,0 +1,14 @@
+export interface MarketPageGridProps {
+  form: React.ReactElement;
+  content: React.ReactElement;
+}
+
+export const MarketPageGrid: React.FC<MarketPageGridProps> = ({ form, content }) => (
+  <div className="space-y-6 lg:space-y-0 lg:gap-x-6 lg:grid lg:grid-cols-2 xl:grid-cols-[7fr_5fr]">
+    <div className="w-auto self-start shrink-0 overflow-x-auto sm:p-6 sm:rounded-lg sm:border sm:border-blue sm:bg-dark-blue lg:order-2 lg:sticky lg:-top-4 lg:max-h-[calc(100vh-128px)]">
+      {form}
+    </div>
+
+    <div className="lg:order-1">{content}</div>
+  </div>
+);

--- a/apps/evm/src/containers/Layout/Header/AssetInfo/UtilizationRate/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/AssetInfo/UtilizationRate/index.tsx
@@ -1,0 +1,21 @@
+import { useGetVTokenUtilizationRate } from 'clients/api';
+import type { Asset } from 'types';
+import { formatPercentageToReadableValue } from 'utilities';
+
+export interface UtilizationRateProps {
+  asset: Asset;
+  isIsolatedPoolMarket: boolean;
+}
+
+export const UtilizationRate: React.FC<UtilizationRateProps> = ({
+  asset,
+  isIsolatedPoolMarket,
+}) => {
+  const { data: getUtilizationRateData } = useGetVTokenUtilizationRate({
+    asset,
+    isIsolatedPoolMarket,
+  });
+  const utilizationRatePercentage = getUtilizationRateData?.utilizationRatePercentage;
+
+  return formatPercentageToReadableValue(utilizationRatePercentage);
+};

--- a/apps/evm/src/containers/Layout/Header/AssetInfo/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/AssetInfo/index.tsx
@@ -1,0 +1,163 @@
+import BigNumber from 'bignumber.js';
+import { useParams } from 'react-router';
+import type { Address } from 'viem';
+
+import { useGetAsset, useGetPool } from 'clients/api';
+import { type CellProps, ProtectionModeIndicator } from 'components';
+import { NULL_ADDRESS } from 'constants/address';
+import { PLACEHOLDER_KEY } from 'constants/placeholders';
+import { useTranslation } from 'libs/translations';
+import { useAccountAddress } from 'libs/wallet';
+import {
+  areTokensEqual,
+  formatCentsToReadableValue,
+  formatPercentageToReadableValue,
+  scrollToElement,
+} from 'utilities';
+import { TokenInfo } from '../TokenInfo';
+import { UtilizationRate } from './UtilizationRate';
+
+export const AssetInfo = () => {
+  const { poolComptrollerAddress = NULL_ADDRESS, vTokenAddress = NULL_ADDRESS } = useParams<{
+    poolComptrollerAddress: Address;
+    vTokenAddress: Address;
+  }>();
+
+  const { t, Trans } = useTranslation();
+
+  const { accountAddress } = useAccountAddress();
+
+  const { data: getAssetData } = useGetAsset({
+    vTokenAddress,
+    accountAddress,
+  });
+  const asset = getAssetData?.asset;
+  const isUserConnected = !!accountAddress;
+
+  const { data: getPools } = useGetPool({
+    poolComptrollerAddress,
+    accountAddress,
+  });
+  const pool = getPools?.pool;
+
+  const hasModeInfo =
+    !!asset &&
+    !!pool?.eModeGroups.some(group =>
+      group.assetSettings.some(s =>
+        areTokensEqual(asset.vToken.underlyingToken, s.vToken.underlyingToken),
+      ),
+    );
+
+  const scrollToLtvOptions = () => scrollToElement('mode-info');
+
+  const effectiveCollateralFactor = isUserConnected
+    ? asset?.userCollateralFactor
+    : asset?.collateralFactor;
+
+  const readableMaxLtvPercentage = asset
+    ? formatPercentageToReadableValue(
+        effectiveCollateralFactor !== undefined
+          ? // We use BigNumber to prevent issues with floating-point numbers
+            new BigNumber(effectiveCollateralFactor)
+              .multipliedBy(100)
+              .toNumber()
+          : undefined,
+      )
+    : undefined;
+
+  const readablePrice = formatCentsToReadableValue({
+    value: asset?.tokenPriceCents,
+    shorten: false,
+    maxDecimalPlaces: 6,
+  });
+
+  const cells: CellProps[] = [
+    {
+      label: t('layout.header.supply'),
+      value: formatCentsToReadableValue({
+        value: asset?.supplyBalanceCents,
+      }),
+    },
+    {
+      label: t('layout.header.liquidity'),
+      value: formatCentsToReadableValue({
+        value: asset?.liquidityCents,
+      }),
+    },
+    {
+      label: t('layout.header.maxLtv.label'),
+      value: readableMaxLtvPercentage,
+      tooltip: (
+        <div>
+          <p>
+            {t('layout.header.maxLtv.tooltip', {
+              maxLtv: readableMaxLtvPercentage,
+              userCollateralFactor: effectiveCollateralFactor,
+              tokenSymbol: asset?.vToken.underlyingToken.symbol,
+            })}
+          </p>
+          {hasModeInfo && (
+            <p className="mt-2">
+              <Trans
+                i18nKey="layout.header.maxLtv.modeInfoHint"
+                components={{
+                  Link: (
+                    <button
+                      type="button"
+                      className="text-blue underline cursor-pointer"
+                      onClick={scrollToLtvOptions}
+                    />
+                  ),
+                }}
+              />
+            </p>
+          )}
+        </div>
+      ),
+    },
+    {
+      label: t('layout.header.utilizationRate'),
+      value:
+        asset && pool ? (
+          <UtilizationRate asset={asset} isIsolatedPoolMarket={pool.isIsolated} />
+        ) : (
+          PLACEHOLDER_KEY
+        ),
+    },
+    {
+      label: t('layout.header.price'),
+      value: (
+        <span className="inline-flex items-center gap-x-2">
+          {asset?.isProtectionModeEnabled && (
+            <ProtectionModeIndicator
+              variant="icon"
+              tokenName={asset.vToken.underlyingToken.symbol}
+              tokenSupplyPriceCents={asset.tokenSupplyPriceCents}
+              tokenBorrowPriceCents={asset.tokenBorrowPriceCents}
+            />
+          )}
+          {readablePrice}
+        </span>
+      ),
+    },
+  ];
+
+  const relatedTokens = asset && [asset.vToken.underlyingToken, asset.vToken];
+
+  const protectionModeIndicator = asset?.isProtectionModeEnabled
+    ? {
+        tokenSupplyPriceCents: asset.tokenSupplyPriceCents,
+        tokenBorrowPriceCents: asset.tokenBorrowPriceCents,
+      }
+    : undefined;
+
+  return (
+    <TokenInfo
+      token={asset?.vToken.underlyingToken}
+      tokenPriceOracleAddress={asset?.tokenPriceOracleAddress}
+      relatedTokens={relatedTokens}
+      protectionModeIndicator={protectionModeIndicator}
+      cells={cells}
+    />
+  );
+};

--- a/apps/evm/src/containers/Layout/Header/LiquidityHubInfo/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/LiquidityHubInfo/index.tsx
@@ -1,0 +1,73 @@
+import { useParams } from 'react-router';
+import type { Address } from 'viem';
+
+import { useGetLiquidityHub } from 'clients/api';
+import { type CellProps, TokenGroup } from 'components';
+import { NULL_ADDRESS } from 'constants/address';
+import { useTranslation } from 'libs/translations';
+import type { Token } from 'types';
+import { formatCentsToReadableValue } from 'utilities';
+import { TokenInfo } from '../TokenInfo';
+
+export const LiquidityHubInfo = () => {
+  const { t } = useTranslation();
+
+  const { vhTokenAddress = NULL_ADDRESS } = useParams<{
+    vhTokenAddress: Address;
+  }>();
+
+  const { data: getLiquidityHubData } = useGetLiquidityHub({
+    vhTokenAddress,
+  });
+  const liquidityHub = getLiquidityHubData?.liquidityHub;
+
+  const collateralTokens = (liquidityHub?.sources ?? []).reduce<Token[]>(
+    (acc, source) => acc.concat(source.collateralTokens),
+    [],
+  );
+
+  const cells: CellProps[] = [
+    {
+      label: t('layout.header.supply'),
+      value: formatCentsToReadableValue({
+        value: liquidityHub?.supplyBalanceCents,
+      }),
+    },
+    {
+      label: t('layout.header.liquidity'),
+      value: formatCentsToReadableValue({
+        value: liquidityHub?.liquidityCents,
+      }),
+    },
+    {
+      label: t('layout.header.suppliers'),
+      value: liquidityHub?.supplierCount,
+    },
+    {
+      label: t('layout.header.price'),
+      value: formatCentsToReadableValue({
+        value: liquidityHub?.tokenPriceCents,
+        shorten: false,
+        maxDecimalPlaces: 6,
+      }),
+    },
+    {
+      label: t('layout.header.exposures'),
+      value: <TokenGroup tokens={collateralTokens} removeDuplicates limit={6} className="h-6.5" />,
+    },
+  ];
+
+  const relatedTokens = liquidityHub && [
+    liquidityHub.vhToken.underlyingToken,
+    liquidityHub.vhToken,
+  ];
+
+  return (
+    <TokenInfo
+      token={liquidityHub?.vhToken.underlyingToken}
+      tokenPriceOracleAddress={liquidityHub?.tokenPriceOracleAddress}
+      relatedTokens={relatedTokens}
+      cells={cells}
+    />
+  );
+};

--- a/apps/evm/src/containers/Layout/Header/TokenInfo/AddTokenToWalletDropdown/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TokenInfo/AddTokenToWalletDropdown/index.tsx
@@ -1,0 +1,73 @@
+import { cn } from '@venusprotocol/ui';
+import { type ButtonProps, Dropdown, Icon } from 'components';
+import useCopyToClipboard from 'hooks/useCopyToClipboard';
+import { useTranslation } from 'libs/translations';
+import { useAddTokenToWallet } from 'libs/wallet';
+import type { Token, VToken, VhToken } from 'types';
+import { DropdownToggleButton } from '../DropdownToggleButton';
+import { TokenDropdownOption } from '../TokenDropdownOption';
+
+export interface AddTokenToWalletDropdownProps extends Omit<ButtonProps, 'onClick' | 'variant'> {
+  isUserConnected: boolean;
+  tokens: Array<Token | VToken | VhToken>;
+}
+
+export const AddTokenToWalletDropdown: React.FC<AddTokenToWalletDropdownProps> = ({
+  className,
+  isUserConnected,
+  tokens,
+}) => {
+  const { addTokenToWallet } = useAddTokenToWallet();
+  const { t } = useTranslation();
+  const copyToClipboard = useCopyToClipboard(t('interactive.copy.address.name'));
+
+  const optionsDom = ({ setIsDropdownOpen }: { setIsDropdownOpen: (v: boolean) => void }) => {
+    const addOrCopyTokenAction = (token: Token | VToken | VhToken) => () => {
+      if (isUserConnected) {
+        addTokenToWallet(token);
+      } else {
+        copyToClipboard(token.address);
+      }
+      setIsDropdownOpen(false);
+    };
+
+    return (
+      <>
+        {tokens.map(token => (
+          <TokenDropdownOption
+            key={token.address}
+            type="button"
+            onClick={addOrCopyTokenAction(token)}
+            token={token}
+            label={token.symbol}
+          />
+        ))}
+      </>
+    );
+  };
+
+  return (
+    <Dropdown
+      className={className}
+      optionsDom={optionsDom}
+      menuTitle={
+        isUserConnected
+          ? t('interactive.addToWallet.modalTitle')
+          : t('interactive.copy.address.modalTitle')
+      }
+    >
+      {({ isDropdownOpen, handleToggleDropdown }) => (
+        <DropdownToggleButton handleToggleDropdown={handleToggleDropdown}>
+          <Icon
+            name={isUserConnected ? 'wallet' : 'copy'}
+            className={cn(
+              'justify-center h-5 w-5',
+              isUserConnected && 'ml-0.5',
+              isDropdownOpen && 'text-blue',
+            )}
+          />
+        </DropdownToggleButton>
+      )}
+    </Dropdown>
+  );
+};

--- a/apps/evm/src/containers/Layout/Header/TokenInfo/DropdownToggleButton/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TokenInfo/DropdownToggleButton/index.tsx
@@ -1,0 +1,24 @@
+import { cn } from '@venusprotocol/ui';
+import { Button } from 'components';
+
+interface DropdownToggleButtonProps {
+  className?: string;
+  handleToggleDropdown: () => void;
+  children: React.ReactNode;
+}
+
+export const DropdownToggleButton = ({
+  className,
+  handleToggleDropdown,
+  children,
+}: DropdownToggleButtonProps) => (
+  <Button
+    onClick={handleToggleDropdown}
+    className={cn(
+      'p-0 border-transparent hover:border-transparent h-8 w-8 bg-background/40 hover:bg-background',
+      className,
+    )}
+  >
+    {children}
+  </Button>
+);

--- a/apps/evm/src/containers/Layout/Header/TokenInfo/GoToTokenContractDropdown/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TokenInfo/GoToTokenContractDropdown/index.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@venusprotocol/ui';
+import { Dropdown, Icon } from 'components';
+import { useTranslation } from 'libs/translations';
+import { useChainId } from 'libs/wallet';
+import type { Token, VToken, VhToken } from 'types';
+import { DropdownToggleButton } from '../DropdownToggleButton';
+import { TokenDropdownOption } from '../TokenDropdownOption';
+
+export interface GoToTokenContractProps
+  extends Omit<React.HTMLAttributes<HTMLButtonElement>, 'onClick'> {
+  tokens: Array<Token | VToken | VhToken>;
+}
+
+export const GoToTokenContractDropdown: React.FC<GoToTokenContractProps> = ({
+  tokens,
+  className,
+}) => {
+  const { chainId } = useChainId();
+  const { t } = useTranslation();
+
+  const optionsDom = ({ setIsDropdownOpen }: { setIsDropdownOpen: (v: boolean) => void }) => (
+    <>
+      {tokens.map(token => (
+        <TokenDropdownOption
+          key={token.address}
+          type="link"
+          onClick={() => setIsDropdownOpen(false)}
+          chainId={chainId}
+          token={token}
+          label={token.symbol}
+        />
+      ))}
+    </>
+  );
+
+  return (
+    <Dropdown
+      className={className}
+      optionsDom={optionsDom}
+      menuTitle={t('interactive.goTo.modalTitle')}
+    >
+      {({ isDropdownOpen, handleToggleDropdown }) => (
+        <DropdownToggleButton handleToggleDropdown={handleToggleDropdown}>
+          <Icon name="link" className={cn('h-5 w-5 border-none', isDropdownOpen && 'text-blue')} />
+        </DropdownToggleButton>
+      )}
+    </Dropdown>
+  );
+};

--- a/apps/evm/src/containers/Layout/Header/TokenInfo/TokenDropdownOption/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TokenInfo/TokenDropdownOption/index.tsx
@@ -1,0 +1,62 @@
+import { cn } from '@venusprotocol/ui';
+import type { ChainId, Token, VToken, VhToken } from 'types';
+import { generateExplorerUrl } from 'utilities';
+
+type ConditionalTokenDropdownOptionProps =
+  | {
+      onClick: () => void;
+      chainId?: never;
+      type: 'button';
+    }
+  | {
+      onClick?: () => void;
+      chainId: ChainId;
+      type: 'link';
+    };
+
+type TokenDropdownOptionProps = {
+  buttonClassName?: string;
+  className?: string;
+  token: Token | VToken | VhToken;
+  label: string;
+} & ConditionalTokenDropdownOptionProps;
+
+export const TokenDropdownOption = ({
+  chainId,
+  className,
+  onClick,
+  token,
+  label,
+  type,
+}: TokenDropdownOptionProps) => {
+  const wrapperClassName = cn(
+    'flex items-center justify-start py-3 px-4 text-left text-sm font-semibold flex-row gap-2 grow min-w-[180px] cursor-pointer hover:bg-lightGrey active:bg-lightGrey',
+    className,
+  );
+  const contentsDom = (
+    <>
+      {'iconSrc' in token ? (
+        <img className="w-5 max-w-none flex-none" src={token.iconSrc} alt={token.symbol} />
+      ) : undefined}
+      {label}
+    </>
+  );
+  const dom =
+    type === 'button' ? (
+      <span onClick={onClick} className={wrapperClassName}>
+        {contentsDom}
+      </span>
+    ) : (
+      <a
+        className={wrapperClassName}
+        href={generateExplorerUrl({ hash: token.address, chainId })}
+        target="_blank"
+        rel="noreferrer"
+        onClick={onClick}
+      >
+        {contentsDom}
+      </a>
+    );
+
+  return dom;
+};

--- a/apps/evm/src/containers/Layout/Header/TokenInfo/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/TokenInfo/index.tsx
@@ -1,0 +1,111 @@
+import type BigNumber from 'bignumber.js';
+
+import {
+  CellGroup,
+  type CellProps,
+  Icon,
+  ProtectionModeIndicator,
+  Spinner,
+  TokenIcon,
+  Wrapper,
+} from 'components';
+import { Link } from 'containers/Link';
+import { useTranslation } from 'libs/translations';
+import { useAccountAddress, useChainId } from 'libs/wallet';
+import type { Token, VToken, VhToken } from 'types';
+import { generateExplorerUrl } from 'utilities';
+import type { Address } from 'viem';
+import { AddTokenToWalletDropdown } from './AddTokenToWalletDropdown';
+import { GoToTokenContractDropdown } from './GoToTokenContractDropdown';
+
+export interface TokenInfoProps {
+  token?: Token;
+  tokenPriceOracleAddress?: Address;
+  relatedTokens?: Array<Token | VToken | VhToken>;
+  protectionModeIndicator?: {
+    tokenSupplyPriceCents: BigNumber;
+    tokenBorrowPriceCents: BigNumber;
+  };
+  cells: CellProps[];
+}
+
+export const TokenInfo: React.FC<TokenInfoProps> = ({
+  cells,
+  token,
+  relatedTokens = [],
+  protectionModeIndicator,
+  tokenPriceOracleAddress,
+}) => {
+  const { t } = useTranslation();
+
+  const { chainId } = useChainId();
+
+  const { accountAddress } = useAccountAddress();
+  const isUserConnected = !!accountAddress;
+
+  const oracleContractHref =
+    tokenPriceOracleAddress &&
+    generateExplorerUrl({
+      hash: tokenPriceOracleAddress,
+      chainId,
+    });
+
+  return (
+    <div className="pb-6 sm:pb-5 md:pb-12 border-b-dark-blue-hover border-b">
+      <Wrapper className="space-y-6 pt-6 sm:space-y-8">
+        <div className="flex items-center min-h-8">
+          {token ? (
+            <div className="flex flex-col gap-y-3 sm:items-center sm:flex-row sm:justify-between sm:w-full md:w-auto md:gap-x-3">
+              <div className="flex items-center gap-3">
+                <TokenIcon token={token} className="h-full w-8 shrink-0" />
+
+                <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+                  <span className="font-bold text-lg">{token.symbol}</span>
+                </div>
+
+                <AddTokenToWalletDropdown
+                  isUserConnected={isUserConnected}
+                  tokens={relatedTokens}
+                />
+
+                <GoToTokenContractDropdown tokens={relatedTokens} />
+              </div>
+
+              {oracleContractHref && (
+                <Link
+                  noStyle
+                  href={oracleContractHref}
+                  className="inline-flex items-center gap-x-2 self-start shrink-0 rounded-full bg-background/40 px-5 h-8 text-light-grey text-sm transition-colors duration-250 hover:bg-background"
+                >
+                  <span>{t('layout.header.resilientOracle')}</span>
+
+                  <Icon name="resilientOracle" className="h-5 w-5 text-inherit" />
+                </Link>
+              )}
+
+              {protectionModeIndicator && (
+                <ProtectionModeIndicator
+                  variant="label"
+                  tokenName={token.symbol}
+                  tokenSupplyPriceCents={protectionModeIndicator.tokenSupplyPriceCents}
+                  tokenBorrowPriceCents={protectionModeIndicator.tokenBorrowPriceCents}
+                />
+              )}
+            </div>
+          ) : (
+            <Spinner className="h-full w-auto" />
+          )}
+        </div>
+
+        <CellGroup
+          cells={cells.map(cell => ({
+            ...cell,
+            className: 'p-0 bg-transparent',
+          }))}
+          grid
+          className="md:gap-x-15 xl:p-0 xl:bg-transparent"
+        />
+      </Wrapper>
+    </div>
+  );
+};

--- a/apps/evm/src/containers/Layout/Header/TokenInfo/types.ts
+++ b/apps/evm/src/containers/Layout/Header/TokenInfo/types.ts
@@ -1,0 +1,8 @@
+import type { Asset, Pool } from 'types';
+
+export interface TokenInfoHeaderProps {
+  asset: Asset | undefined;
+  pool: Pool | undefined;
+  isUserConnected: boolean;
+  handleGoBack: () => void;
+}

--- a/apps/evm/src/containers/Layout/Header/usePathNodes/LiquidityHubName/index.tsx
+++ b/apps/evm/src/containers/Layout/Header/usePathNodes/LiquidityHubName/index.tsx
@@ -1,0 +1,29 @@
+import type { Address } from 'viem';
+
+import { useGetLiquidityHub } from 'clients/api';
+import { NULL_ADDRESS } from 'constants/address';
+import { PLACEHOLDER_KEY } from 'constants/placeholders';
+
+export interface LiquidityHubNameProps {
+  vhTokenAddress?: Address;
+}
+
+const LiquidityHubName: React.FC<LiquidityHubNameProps> = ({ vhTokenAddress }) => {
+  const { data: getLiquidityHubData } = useGetLiquidityHub(
+    {
+      vhTokenAddress: vhTokenAddress || NULL_ADDRESS,
+    },
+    {
+      enabled: !!vhTokenAddress,
+    },
+  );
+  const liquidityHub = getLiquidityHubData?.liquidityHub;
+
+  return (
+    <div className="inline-flex items-center">
+      <span>{liquidityHub?.vhToken.underlyingToken.symbol || PLACEHOLDER_KEY}</span>
+    </div>
+  );
+};
+
+export default LiquidityHubName;

--- a/apps/evm/src/containers/LiquidityHubLoader/index.tsx
+++ b/apps/evm/src/containers/LiquidityHubLoader/index.tsx
@@ -1,0 +1,44 @@
+import { useGetLiquidityHub } from 'clients/api';
+import { Spinner } from 'components';
+import { NULL_ADDRESS } from 'constants/address';
+import { routes } from 'constants/routing';
+import { Redirect } from 'containers/Redirect';
+import type { LiquidityHub } from 'types';
+import type { Address } from 'viem';
+
+export interface LiquidityHubLoaderProps {
+  children: (props: {
+    liquidityHub: LiquidityHub;
+  }) => React.ReactNode;
+  vhTokenAddress?: Address;
+}
+
+export const LiquidityHubLoader: React.FC<LiquidityHubLoaderProps> = ({
+  vhTokenAddress,
+  children,
+}) => {
+  const { data: getLiquidityHubData, isLoading } = useGetLiquidityHub(
+    {
+      vhTokenAddress: vhTokenAddress || NULL_ADDRESS,
+    },
+    {
+      enabled: !!vhTokenAddress,
+    },
+  );
+  const liquidityHub = getLiquidityHubData?.liquidityHub;
+
+  const isVhTokenAddressInvalid = !isLoading && !liquidityHub;
+
+  // Redirect to home page if params are invalid
+  if (isVhTokenAddressInvalid) {
+    return <Redirect to={routes.liquidityHubs.path} />;
+  }
+
+  if (!liquidityHub) {
+    return <Spinner />;
+  }
+
+  return <>{children({ liquidityHub })}</>;
+};
+
+export default LiquidityHubLoader;


### PR DESCRIPTION
## Jira ticket(s)

VPD-1561

## Changes

- scaffold the singular Liquidity Hub page at `/liquidity-hubs/:vhTokenAddress` and link table rows to it
- add Liquidity Hub lookup, loading, and invalid-address redirect handling
- extend the shared header with hub-specific token details, metrics, exposures, breadcrumbs, and accent styling
- add supporting token-icon handling, translations, mocks, and targeted tests
