### PR TITLE
feat: update LiquidityHub object to support token distributions

### DIFF
--- a/.changeset/long-masks-cheer.md
+++ b/.changeset/long-masks-cheer.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+update LiquidityHub object to support token distributions

--- a/apps/evm/src/components/Apy/__tests__/index.spec.tsx
+++ b/apps/evm/src/components/Apy/__tests__/index.spec.tsx
@@ -1,0 +1,166 @@
+import BigNumber from 'bignumber.js';
+
+import { assetData } from '__mocks__/models/asset';
+import { en } from 'libs/translations';
+import { renderComponent } from 'testUtils/render';
+import type { TokenDistribution } from 'types';
+import { Apy } from '..';
+
+const token = assetData[0].vToken.underlyingToken;
+
+const venusDistribution: TokenDistribution = {
+  type: 'venus',
+  token,
+  apyPercentage: new BigNumber(1),
+  dailyDistributedTokens: new BigNumber(1),
+  isActive: true,
+};
+
+describe('Apy', () => {
+  it('renders a base APY without a boost', () => {
+    const { getByText, queryByAltText } = renderComponent(
+      <Apy
+        type="supply"
+        token={token}
+        baseApyPercentage={new BigNumber(2)}
+        tokenDistributions={[]}
+      />,
+    );
+
+    expect(getByText('2%')).toBeInTheDocument();
+    expect(queryByAltText(en.apy.boost.iconAlt)).not.toBeInTheDocument();
+  });
+
+  it.each([
+    {
+      type: 'supply',
+      baseApyPercentage: new BigNumber(2),
+      expectedApy: '3%',
+    },
+    {
+      type: 'borrow',
+      baseApyPercentage: new BigNumber(-2),
+      expectedApy: '-3%',
+    },
+  ] as const)('renders a boosted $type APY', ({ type, baseApyPercentage, expectedApy }) => {
+    const { getByAltText, getByText } = renderComponent(
+      <Apy
+        type={type}
+        token={token}
+        baseApyPercentage={baseApyPercentage}
+        tokenDistributions={[venusDistribution]}
+      />,
+    );
+
+    expect(getByText(expectedApy)).toBeInTheDocument();
+    expect(getByAltText(en.apy.boost.iconAlt)).toBeInTheDocument();
+  });
+
+  it('ignores inactive and zero token distributions', () => {
+    const { getByText, queryByAltText } = renderComponent(
+      <Apy
+        type="supply"
+        token={token}
+        baseApyPercentage={new BigNumber(2)}
+        tokenDistributions={[
+          {
+            ...venusDistribution,
+            apyPercentage: new BigNumber(10),
+            isActive: false,
+          },
+          {
+            ...venusDistribution,
+            apyPercentage: new BigNumber(0),
+          },
+        ]}
+      />,
+    );
+
+    expect(getByText('2%')).toBeInTheDocument();
+    expect(queryByAltText(en.apy.boost.iconAlt)).not.toBeInTheDocument();
+  });
+
+  it('shows the boost tooltip trigger for point distributions', () => {
+    const { getByAltText, getByText } = renderComponent(
+      <Apy
+        type="supply"
+        token={token}
+        baseApyPercentage={new BigNumber(2)}
+        tokenDistributions={[]}
+        pointDistributions={[
+          {
+            title: 'Points',
+            incentive: '2x',
+          },
+        ]}
+      />,
+    );
+
+    expect(getByText('2%')).toBeInTheDocument();
+    expect(getByAltText(en.apy.boost.iconAlt)).toBeInTheDocument();
+  });
+
+  it('applies muted styling', () => {
+    const { container } = renderComponent(
+      <Apy
+        type="borrow"
+        token={token}
+        baseApyPercentage={new BigNumber(-2)}
+        tokenDistributions={[]}
+        isMuted
+      />,
+    );
+
+    expect(container.firstElementChild).toHaveClass('opacity-50');
+    expect(container.querySelector('p')).toHaveClass('text-grey');
+  });
+
+  it('renders an active Prime boost', () => {
+    const { getByAltText, getByText } = renderComponent(
+      <Apy
+        type="supply"
+        token={token}
+        baseApyPercentage={new BigNumber(2)}
+        tokenDistributions={[
+          {
+            type: 'prime',
+            token,
+            apyPercentage: new BigNumber(1),
+            isActive: true,
+          },
+        ]}
+        userBalanceTokens={new BigNumber(1)}
+      />,
+    );
+
+    expect(getByText('3%')).toBeInTheDocument();
+    expect(getByAltText(en.apy.primeBadge.logoAlt)).toBeInTheDocument();
+  });
+
+  it('renders a Prime APY simulation', () => {
+    const { getByAltText, getByText } = renderComponent(
+      <Apy
+        type="supply"
+        token={token}
+        baseApyPercentage={new BigNumber(2)}
+        tokenDistributions={[
+          {
+            type: 'primeSimulation',
+            token,
+            apyPercentage: new BigNumber(1),
+            isActive: true,
+            referenceValues: {
+              userSupplyBalanceTokens: new BigNumber(0),
+              userBorrowBalanceTokens: new BigNumber(0),
+              userXvsStakedTokens: new BigNumber(0),
+            },
+          },
+        ]}
+      />,
+    );
+
+    expect(getByText('2%')).toBeInTheDocument();
+    expect(getByText('3%')).toBeInTheDocument();
+    expect(getByAltText(en.apy.primeBadge.logoAlt)).toBeInTheDocument();
+  });
+});

--- a/apps/evm/src/components/ApyBreakdown/__tests__/index.spec.tsx
+++ b/apps/evm/src/components/ApyBreakdown/__tests__/index.spec.tsx
@@ -1,0 +1,127 @@
+import BigNumber from 'bignumber.js';
+
+import { poolData } from '__mocks__/models/pools';
+import { renderComponent } from 'testUtils/render';
+import type { TokenDistribution } from 'types';
+import { ApyBreakdown, type ApyBreakdownItem } from '..';
+
+const bumpTokenDistributions = ({
+  tokenDistributions,
+}: { tokenDistributions: TokenDistribution[] }) =>
+  tokenDistributions.map(distribution => ({
+    ...distribution,
+    apyPercentage: distribution.apyPercentage.plus(1),
+  }));
+
+const fakeAssets = poolData[0].assets;
+
+const supplyItem: ApyBreakdownItem = {
+  type: 'supply',
+  token: fakeAssets[0].vToken.underlyingToken,
+  baseApyPercentage: fakeAssets[0].supplyApyPercentage,
+  tokenDistributions: fakeAssets[0].supplyTokenDistributions,
+  simulatedTokenDistributions: bumpTokenDistributions({
+    tokenDistributions: fakeAssets[0].supplyTokenDistributions,
+  }),
+};
+
+const borrowItem: ApyBreakdownItem = {
+  type: 'borrow',
+  token: fakeAssets[2].vToken.underlyingToken,
+  baseApyPercentage: fakeAssets[2].borrowApyPercentage,
+  tokenDistributions: fakeAssets[2].borrowTokenDistributions,
+  simulatedTokenDistributions: bumpTokenDistributions({
+    tokenDistributions: fakeAssets[2].borrowTokenDistributions,
+  }),
+};
+
+describe('ApyBreakdown', () => {
+  it('renders a zero borrow total when no items are provided', () => {
+    const { container } = renderComponent(<ApyBreakdown />);
+
+    expect(container.textContent).toBe('Total borrow APY0%');
+  });
+
+  it('renders a supply APY breakdown', () => {
+    const { container } = renderComponent(<ApyBreakdown items={[supplyItem]} />);
+
+    expect(container.textContent).toBe('Supply APY0.05%Distribution APY0.11%Total supply APY1.16%');
+  });
+
+  it('renders a borrow APY breakdown', () => {
+    const { container } = renderComponent(<ApyBreakdown items={[borrowItem]} />);
+
+    expect(container.textContent).toBe(
+      'Borrow APY-4.97%Distribution APY0.52%Total borrow APY-6.49%',
+    );
+  });
+
+  it('offsets borrow APY against supply APY when calculating net APY', () => {
+    const { container } = renderComponent(<ApyBreakdown items={[supplyItem, borrowItem]} />);
+
+    expect(container.textContent).toBe(
+      'Supply APY0.05%Distribution APY0.11%Borrow APY-4.97%Distribution APY0.52%Net APY7.66%',
+    );
+  });
+
+  it('renders simulated base and Prime APYs', () => {
+    const asset = fakeAssets[1];
+    const item: ApyBreakdownItem = {
+      type: 'supply',
+      token: asset.vToken.underlyingToken,
+      baseApyPercentage: asset.supplyApyPercentage,
+      tokenDistributions: asset.supplyTokenDistributions,
+      simulatedBaseApyPercentage: asset.supplyApyPercentage.plus(1),
+      simulatedTokenDistributions: bumpTokenDistributions({
+        tokenDistributions: asset.supplyTokenDistributions,
+      }),
+    };
+    const { container } = renderComponent(<ApyBreakdown items={[item]} />);
+
+    expect(container.textContent).toBe(
+      'Supply APY4.88%Distribution APY1.35%Prime APY0.75%1.75%Total supply APY8.99%',
+    );
+  });
+
+  it('excludes inactive, zero, and Prime simulation distributions', () => {
+    const distribution = fakeAssets[0].supplyTokenDistributions[0];
+    const item: ApyBreakdownItem = {
+      type: 'supply',
+      token: fakeAssets[0].vToken.underlyingToken,
+      baseApyPercentage: new BigNumber(2),
+      tokenDistributions: [
+        {
+          ...distribution,
+          apyPercentage: new BigNumber(5),
+          isActive: false,
+        },
+        {
+          ...distribution,
+          apyPercentage: new BigNumber(0),
+        },
+        {
+          type: 'primeSimulation',
+          token: fakeAssets[0].vToken.underlyingToken,
+          apyPercentage: new BigNumber(3),
+          isActive: true,
+          referenceValues: {
+            userSupplyBalanceTokens: new BigNumber(0),
+            userBorrowBalanceTokens: new BigNumber(0),
+            userXvsStakedTokens: new BigNumber(0),
+          },
+        },
+      ],
+    };
+    const { container } = renderComponent(<ApyBreakdown items={[item]} />);
+
+    expect(container.textContent).toBe('Supply APY2%Total supply APY2%');
+  });
+
+  it('renders the total as an accordion title', () => {
+    const { getByRole } = renderComponent(
+      <ApyBreakdown items={[supplyItem]} renderType="accordion" />,
+    );
+
+    expect(getByRole('button')).toHaveTextContent('Total supply APY1.16%');
+  });
+});

--- a/apps/evm/src/components/ApyBreakdown/formatRows/index.tsx
+++ b/apps/evm/src/components/ApyBreakdown/formatRows/index.tsx
@@ -1,0 +1,106 @@
+import type { TFunction } from 'i18next';
+
+import { formatPercentageToReadableValue } from 'utilities';
+import type { ApyBreakdownItem } from '..';
+import type { LabeledInlineContentProps } from '../../LabeledInlineContent';
+import { ValueUpdate } from '../../ValueUpdate';
+
+export const formatRows = ({
+  item,
+  t,
+}: {
+  item: ApyBreakdownItem;
+  t: TFunction<'translation', undefined>;
+}) => {
+  const rows: LabeledInlineContentProps[] = [
+    {
+      label: item.type === 'borrow' ? t('apyBreakdown.borrowApy') : t('apyBreakdown.supplyApy'),
+      iconSrc: item.token,
+      children: formatPercentageToReadableValue(
+        item.simulatedBaseApyPercentage ?? item.baseApyPercentage,
+      ),
+    },
+  ];
+
+  const distributionRows = item.tokenDistributions
+    .filter(distribution => distribution.type !== 'primeSimulation' && distribution.isActive)
+    .reduce<LabeledInlineContentProps[]>((acc, distribution) => {
+      if (distribution.type !== 'prime' && distribution.apyPercentage.isEqualTo(0)) {
+        return acc;
+      }
+
+      let label = t('apyBreakdown.distributionApy');
+
+      if (distribution.type === 'prime') {
+        label = t('apyBreakdown.primeApy');
+      }
+
+      if (distribution.type === 'merkl') {
+        label = t('apyBreakdown.externalDistributionApy', {
+          description: distribution.rewardDetails.description,
+          tokenSymbol: distribution.token.symbol,
+        });
+      }
+
+      if (distribution.type === 'intrinsic') {
+        label = t('apyBreakdown.intrinsicApy');
+      }
+
+      if (distribution.type === 'off-chain') {
+        label = t('apyBreakdown.offChainApy');
+      }
+
+      if (distribution.type === 'yield-to-maturity') {
+        label = t('apyBreakdown.yieldToMaturityApy');
+      }
+
+      let children: React.ReactNode;
+
+      if (distribution.type === 'prime') {
+        const simulatedPrimeDistribution = item.simulatedTokenDistributions?.find(
+          simulatedDistribution => simulatedDistribution.type === 'prime',
+        );
+
+        children = (
+          <ValueUpdate
+            original={formatPercentageToReadableValue(distribution.apyPercentage)}
+            update={
+              simulatedPrimeDistribution &&
+              formatPercentageToReadableValue(simulatedPrimeDistribution.apyPercentage)
+            }
+          />
+        );
+      } else {
+        children = formatPercentageToReadableValue(distribution.apyPercentage);
+      }
+
+      let tooltip = undefined;
+
+      if (distribution.type === 'venus') {
+        tooltip = t('apyBreakdown.distributionTooltip');
+      }
+
+      if (distribution.type === 'intrinsic') {
+        tooltip = t('apyBreakdown.intrinsicApyTooltip');
+      }
+
+      if (distribution.type === 'off-chain') {
+        tooltip = t('apyBreakdown.offChainApyTooltip');
+      }
+
+      if (distribution.type === 'yield-to-maturity') {
+        tooltip = t('apyBreakdown.yieldToMaturityApyTooltip');
+      }
+
+      const row: LabeledInlineContentProps = {
+        label,
+        iconSrc: distribution.token,
+        tooltip,
+        children,
+      };
+
+      return [...acc, row];
+    }, []);
+
+  return rows.concat(distributionRows);
+};

--- a/apps/evm/src/components/ApyBreakdown/index.tsx
+++ b/apps/evm/src/components/ApyBreakdown/index.tsx
@@ -1,0 +1,112 @@
+import BigNumber from 'bignumber.js';
+
+import { useTranslation } from 'libs/translations';
+import type { Token, TokenDistribution } from 'types';
+import { formatPercentageToReadableValue } from 'utilities';
+import { Accordion } from '../Accordion';
+import { InfoIcon } from '../InfoIcon';
+import { LabeledInlineContent, type LabeledInlineContentProps } from '../LabeledInlineContent';
+import { formatRows } from './formatRows';
+
+export interface ApyBreakdownItem {
+  type: 'supply' | 'borrow';
+  token: Token;
+  baseApyPercentage: BigNumber;
+  tokenDistributions: TokenDistribution[];
+  simulatedBaseApyPercentage?: BigNumber;
+  simulatedTokenDistributions?: TokenDistribution[];
+}
+
+export interface ApyBreakdownProps {
+  items?: ApyBreakdownItem[];
+  renderType?: 'block' | 'accordion';
+}
+
+export const ApyBreakdown: React.FC<ApyBreakdownProps> = ({ items = [], renderType = 'block' }) => {
+  const { t } = useTranslation();
+  const shouldShowNetApy = items.length > 1;
+
+  const { rows, totalApyPercentage } = items.reduce<{
+    rows: LabeledInlineContentProps[];
+    totalApyPercentage: BigNumber;
+  }>(
+    (acc, item) => {
+      const baseApyPercentage = item.simulatedBaseApyPercentage ?? item.baseApyPercentage;
+      const tokenDistributions = item.simulatedTokenDistributions ?? item.tokenDistributions;
+
+      const distributionApyPercentage = tokenDistributions.reduce((total, distribution) => {
+        if (!distribution.isActive || distribution.type === 'primeSimulation') {
+          return total;
+        }
+
+        return total.plus(distribution.apyPercentage);
+      }, new BigNumber(0));
+
+      const itemTotalApyPercentage =
+        item.type === 'supply'
+          ? baseApyPercentage.plus(distributionApyPercentage)
+          : baseApyPercentage.minus(distributionApyPercentage);
+
+      const totalApyPercentage =
+        shouldShowNetApy && item.type === 'borrow'
+          ? acc.totalApyPercentage.minus(itemTotalApyPercentage)
+          : acc.totalApyPercentage.plus(itemTotalApyPercentage);
+
+      return {
+        rows: acc.rows.concat(formatRows({ item, t })),
+        totalApyPercentage,
+      };
+    },
+    {
+      rows: [],
+      totalApyPercentage: new BigNumber(0),
+    },
+  );
+
+  const readableTotalApy = formatPercentageToReadableValue(totalApyPercentage);
+
+  let label: string;
+  let tooltip: string;
+
+  if (shouldShowNetApy) {
+    label = t('apyBreakdown.netApy.label');
+    tooltip = t('apyBreakdown.netApy.tooltip');
+  } else if (items[0]?.type === 'supply') {
+    label = t('apyBreakdown.totalApy.supplyApyLabel');
+    tooltip = t('apyBreakdown.totalApy.supplyApyTooltip');
+  } else {
+    label = t('apyBreakdown.totalApy.borrowApyLabel');
+    tooltip = t('apyBreakdown.totalApy.borrowApyTooltip');
+  }
+
+  const rowsDom = rows.map((row, index) => (
+    <LabeledInlineContent {...row} key={`${row.label}-${index}`} />
+  ));
+
+  if (renderType === 'block') {
+    return (
+      <div className="space-y-2">
+        {rowsDom}
+
+        <LabeledInlineContent tooltip={tooltip} label={label}>
+          {readableTotalApy}
+        </LabeledInlineContent>
+      </div>
+    );
+  }
+
+  return (
+    <Accordion
+      title={
+        <div className="flex items-center gap-x-2">
+          <p className="text-b1r">{label}</p>
+
+          <InfoIcon className="inline-flex items-center" tooltip={tooltip} />
+        </div>
+      }
+      rightLabel={readableTotalApy}
+    >
+      <div className="space-y-2">{rowsDom}</div>
+    </Accordion>
+  );
+};

--- a/apps/evm/src/components/AssetApy/index.tsx
+++ b/apps/evm/src/components/AssetApy/index.tsx
@@ -1,0 +1,36 @@
+import type { Asset } from 'types';
+import { Apy, type ApyProps } from '../Apy';
+
+export interface AssetApyProps {
+  asset: Asset;
+  type: ApyProps['type'];
+  showPrimeSimulation?: boolean;
+  className?: string;
+}
+
+export const AssetApy: React.FC<AssetApyProps> = ({
+  asset,
+  type,
+  showPrimeSimulation,
+  className,
+}) => {
+  const isBorrow = type === 'borrow';
+
+  return (
+    <Apy
+      type={type}
+      token={asset.vToken.underlyingToken}
+      baseApyPercentage={isBorrow ? asset.borrowApyPercentage : asset.supplyApyPercentage}
+      tokenDistributions={
+        isBorrow ? asset.borrowTokenDistributions : asset.supplyTokenDistributions
+      }
+      pointDistributions={
+        isBorrow ? asset.borrowPointDistributions : asset.supplyPointDistributions
+      }
+      userBalanceTokens={isBorrow ? asset.userBorrowBalanceTokens : asset.userSupplyBalanceTokens}
+      isMuted={isBorrow && !asset.isBorrowableByUser}
+      showPrimeSimulation={showPrimeSimulation}
+      className={className}
+    />
+  );
+};

--- a/apps/evm/src/utilities/getCombinedApy/__tests__/index.spec.ts
+++ b/apps/evm/src/utilities/getCombinedApy/__tests__/index.spec.ts
@@ -1,0 +1,66 @@
+import BigNumber from 'bignumber.js';
+
+import { assetData } from '__mocks__/models/asset';
+import type { TokenDistribution } from 'types';
+import getCombinedApy from '..';
+
+const token = assetData[0].vToken.underlyingToken;
+
+const tokenDistributions: TokenDistribution[] = [
+  {
+    type: 'venus',
+    token,
+    apyPercentage: new BigNumber(1),
+    dailyDistributedTokens: new BigNumber(1),
+    isActive: true,
+  },
+  {
+    type: 'prime',
+    token,
+    apyPercentage: new BigNumber(2),
+    isActive: true,
+  },
+  {
+    type: 'primeSimulation',
+    token,
+    apyPercentage: new BigNumber(3),
+    isActive: true,
+    referenceValues: {
+      userSupplyBalanceTokens: new BigNumber(0),
+      userBorrowBalanceTokens: new BigNumber(0),
+      userXvsStakedTokens: new BigNumber(0),
+    },
+  },
+  {
+    type: 'venus',
+    token,
+    apyPercentage: new BigNumber(100),
+    dailyDistributedTokens: new BigNumber(1),
+    isActive: false,
+  },
+];
+
+describe('getCombinedApy', () => {
+  it.each([
+    {
+      type: 'supply',
+      expectedTotalApyPercentage: '5',
+    },
+    {
+      type: 'borrow',
+      expectedTotalApyPercentage: '-5',
+    },
+  ] as const)('calculates the combined $type APY', ({ type, expectedTotalApyPercentage }) => {
+    const result = getCombinedApy({
+      type,
+      baseApyPercentage: new BigNumber(type === 'supply' ? 2 : -2),
+      tokenDistributions,
+    });
+
+    expect(result.apyRewardsPercentage.toFixed()).toBe('1');
+    expect(result.apyPrimePercentage.toFixed()).toBe('2');
+    expect(result.apyPrimeSimulationPercentage.toFixed()).toBe('3');
+    expect(result.totalApyBoostPercentage.toFixed()).toBe('3');
+    expect(result.totalApyPercentage.toFixed()).toBe(expectedTotalApyPercentage);
+  });
+});

--- a/apps/evm/src/utilities/getCombinedApy/index.ts
+++ b/apps/evm/src/utilities/getCombinedApy/index.ts
@@ -1,0 +1,72 @@
+import BigNumber from 'bignumber.js';
+
+import type { TokenDistribution } from 'types';
+
+export interface GetCombinedApyInput {
+  type: 'supply' | 'borrow';
+  baseApyPercentage: BigNumber;
+  tokenDistributions: TokenDistribution[];
+}
+
+const getCombinedApy = ({ type, baseApyPercentage, tokenDistributions }: GetCombinedApyInput) => {
+  const { apyRewardsPercentage, apyPrimePercentage, apyPrimeSimulationPercentage } =
+    tokenDistributions.reduce<{
+      apyRewardsPercentage: BigNumber;
+      apyPrimePercentage: BigNumber;
+      apyPrimeSimulationPercentage: BigNumber;
+    }>(
+      (acc, distribution) => {
+        if (!distribution.isActive) {
+          return acc;
+        }
+
+        if (
+          distribution.type === 'venus' ||
+          distribution.type === 'merkl' ||
+          distribution.type === 'intrinsic' ||
+          distribution.type === 'off-chain' ||
+          distribution.type === 'yield-to-maturity'
+        ) {
+          return {
+            ...acc,
+            apyRewardsPercentage: acc.apyRewardsPercentage.plus(distribution.apyPercentage),
+          };
+        }
+
+        if (distribution.type === 'prime') {
+          return {
+            ...acc,
+            apyPrimePercentage: acc.apyPrimePercentage.plus(distribution.apyPercentage),
+          };
+        }
+
+        return {
+          ...acc,
+          apyPrimeSimulationPercentage: acc.apyPrimeSimulationPercentage.plus(
+            distribution.apyPercentage,
+          ),
+        };
+      },
+      {
+        apyRewardsPercentage: new BigNumber(0),
+        apyPrimePercentage: new BigNumber(0),
+        apyPrimeSimulationPercentage: new BigNumber(0),
+      },
+    );
+
+  const totalApyBoostPercentage = apyRewardsPercentage.plus(apyPrimePercentage);
+  const totalApyPercentage =
+    type === 'supply'
+      ? baseApyPercentage.plus(totalApyBoostPercentage)
+      : baseApyPercentage.minus(totalApyBoostPercentage);
+
+  return {
+    apyRewardsPercentage,
+    apyPrimePercentage,
+    apyPrimeSimulationPercentage,
+    totalApyBoostPercentage,
+    totalApyPercentage,
+  };
+};
+
+export default getCombinedApy;


### PR DESCRIPTION
## Jira ticket(s)

VPD-1642

## Changes

- add token distribution support to Liquidity Hubs and their mock data
- make `Apy` and `ApyBreakdown` generic across assets and Liquidity Hubs, with shared APY calculations and an asset adapter
- display distribution-inclusive APYs in Liquidity Hub forms and tables, including consistent table sorting
