### PR TITLE
ci: only allow prerelease upgrades of @venusprotocol packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,10 @@ updates:
     schedule:
       interval: 'daily'
     ignore:
+      # Ignore non-slim @venusprotocol package upgrades
+      - dependency-name: "@venusprotocol/*"
+        versions: [">=0.0.0"]
+
       # Ignore all major updates
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Changes

- only allow Dependabot to propose prerelease upgrades of `@venusprotocol` packages, so that it doesn't override `-slim` pacakges
