### PR TITLE
ci: worktrunk config

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -1,0 +1,43 @@
+# Runs once, blocking, when a new worktree is created, before wt switch returns. Pipeline of 3
+# sequential steps: env files -> install -> start
+
+# Step 1: shared .env files
+[[pre-start]]
+env = """
+# Shared directory, sibling to all worktrees, holding the single source-of-truth .env files.
+mkdir -p {{ primary_worktree_path | dirname }}/.venus-env
+
+# Seed evm.env only if it doesn't exist yet. The first worktree created after this hook was
+# added copies whatever apps/evm/.env currently exists in the primary worktree (or creates
+# an empty file if there isn't one). Every worktree after that reuses this same file.
+if [ ! -f {{ primary_worktree_path | dirname }}/.venus-env/evm.env ]; then
+  if [ -f {{ primary_worktree_path }}/apps/evm/.env ]; then
+    cp {{ primary_worktree_path }}/apps/evm/.env {{ primary_worktree_path | dirname }}/.venus-env/evm.env
+  else
+    touch {{ primary_worktree_path | dirname }}/.venus-env/evm.env
+  fi
+fi
+
+# Same seeding logic for packages/chains/.env.
+if [ ! -f {{ primary_worktree_path | dirname }}/.venus-env/chains.env ]; then
+  if [ -f {{ primary_worktree_path }}/packages/chains/.env ]; then
+    cp {{ primary_worktree_path }}/packages/chains/.env {{ primary_worktree_path | dirname }}/.venus-env/chains.env
+  else
+    touch {{ primary_worktree_path | dirname }}/.venus-env/chains.env
+  fi
+fi
+
+# Point this worktree's .env files at the shared files instead of real files, so edits
+# in any worktree are visible in all of them immediately (same inode).
+ln -sf {{ primary_worktree_path | dirname }}/.venus-env/evm.env {{ worktree_path }}/apps/evm/.env
+ln -sf {{ primary_worktree_path | dirname }}/.venus-env/chains.env {{ worktree_path }}/packages/chains/.env
+"""
+
+# Step 2: install deps. Runs after env symlinks are in place, before start
+[[pre-start]]
+install = "yarn install"
+
+# Step 3: start the dev server. Blocks wt switch until you kill it, since yarn start never exits on
+# its own
+[[pre-start]]
+start = "yarn start"

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -36,8 +36,3 @@ ln -sf {{ primary_worktree_path | dirname }}/.venus-env/chains.env {{ worktree_p
 # Step 2: install deps. Runs after env symlinks are in place, before start
 [[pre-start]]
 install = "yarn install"
-
-# Step 3: start the dev server. Blocks wt switch until you kill it, since yarn start never exits on
-# its own
-[[pre-start]]
-start = "yarn start"

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,9 @@ npm-debug.log
 testem.log
 typings
 .turbo
-.yarn
+.yarn/*
+!.yarn/plugins/
+!.yarn/plugins/**
 storybook-static
 yarn-error.log
 

--- a/.yarn/plugins/yarn-plugin-generate-after-install.cjs
+++ b/.yarn/plugins/yarn-plugin-generate-after-install.cjs
@@ -1,0 +1,30 @@
+module.exports = {
+  name: '@venusprotocol/yarn-plugin-generate-after-install',
+  factory: require => {
+    const { execFileSync } = require('node:child_process');
+    const { npath } = require('@yarnpkg/fslib');
+
+    return {
+      hooks: {
+        afterAllInstalled: project => {
+          if (process.env.VENUS_SKIP_GENERATE_AFTER_INSTALL === '1') {
+            return;
+          }
+
+          const yarnPath = process.env.npm_execpath || 'yarn';
+
+          console.log('➤ YN0000: Running yarn generate');
+
+          execFileSync(yarnPath, ['generate'], {
+            cwd: npath.fromPortablePath(project.cwd),
+            env: {
+              ...process.env,
+              VENUS_SKIP_GENERATE_AFTER_INSTALL: '1',
+            },
+            stdio: 'inherit',
+          });
+        },
+      },
+    };
+  },
+};

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,5 +1,9 @@
 enableScripts: true
 
+plugins:
+  - path: .yarn/plugins/yarn-plugin-generate-after-install.cjs
+    spec: "@venusprotocol/yarn-plugin-generate-after-install"
+
 nodeLinker: node-modules
 
 # In minutes.

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
     "build": "turbo run build",
     "extract-translations": "turbo run extract-translations",
     "changeset": "changeset",
-    "prepare": "husky",
-    "postinstall": "turbo run generate"
+    "prepare": "husky"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.1",

--- a/turbo.json
+++ b/turbo.json
@@ -7,10 +7,6 @@
       "cache": false,
       "dependsOn": ["^build"]
     },
-    "postinstall": {
-      "cache": false,
-      "dependsOn": ["^postinstall"]
-    },
     "start": {
       "cache": false,
       "persistent": true


### PR DESCRIPTION
## Changes

- added [Worktrunk](https://github.com/max-sixty/worktrunk) configuration to prepare new worktrees automatically. Upon creating a new worktree using Worktrunk (e.g.: `wt switch feat/my-new-feature --create`), `.env` files will be automatically generated from the main workspace and dependencies will be installed so that the new worktree is fully operational
- added a Yarn plugin to run yarn generate after installs