### PR TITLE
fix: various fixes

### DIFF
--- a/.changeset/early-results-talk.md
+++ b/.changeset/early-results-talk.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": patch
+---
+
+various fixes

--- a/apps/evm/src/clients/api/index.ts
+++ b/apps/evm/src/clients/api/index.ts
@@ -284,12 +284,6 @@ export * from './queries/getBurnedWBnb/useGetBurnedWBnb';
 export * from './queries/getImportablePositions';
 export * from './queries/getImportablePositions/useGetImportablePositions';
 
-export * from './queries/getBurnedWBnb';
-export * from './queries/getBurnedWBnb/useGetBurnedWBnb';
-
-export * from './queries/getImportablePositions';
-export * from './queries/getImportablePositions/useGetImportablePositions';
-
 export * from './queries/getAccountPerformanceHistory';
 export * from './queries/getAccountPerformanceHistory/useGetAccountPerformanceHistory';
 

--- a/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
+++ b/apps/evm/src/clients/api/queries/getPendingRewards/useGetPendingRewards.ts
@@ -36,6 +36,7 @@ export type UseGetPendingRewardsQueryKey = [
   FunctionKey.GET_PENDING_REWARDS,
   TrimmedGetPendingRewardsInput & {
     chainId: ChainId;
+    isolatedPoolComptrollerAddresses: Address[];
   },
 ];
 
@@ -150,7 +151,7 @@ export const useGetPendingRewards = (
   // Get XVS vesting vault pool count
   const { data: getXvsVaultPoolCountData, isLoading: isGetXvsVaultPoolCountLoading } =
     useGetXvsVaultPoolCount({
-      enabled: !!options?.enabled,
+      enabled: options?.enabled === undefined || !!options.enabled,
     });
   const xvsVestingVaultPoolCount = getXvsVaultPoolCountData?.poolCount || 0;
 
@@ -159,7 +160,14 @@ export const useGetPendingRewards = (
   const sortedIsolatedPoolComptrollerAddresses = [...isolatedPoolComptrollerAddresses].sort();
 
   return useQuery({
-    queryKey: [FunctionKey.GET_PENDING_REWARDS, { ...input, chainId }],
+    queryKey: [
+      FunctionKey.GET_PENDING_REWARDS,
+      {
+        ...input,
+        chainId,
+        isolatedPoolComptrollerAddresses: sortedIsolatedPoolComptrollerAddresses,
+      },
+    ],
     queryFn: () =>
       callOrThrow(
         {

--- a/apps/evm/src/containers/EModeGroupList/formatEModeGroups/__tests__/index.spec.ts
+++ b/apps/evm/src/containers/EModeGroupList/formatEModeGroups/__tests__/index.spec.ts
@@ -1,0 +1,148 @@
+import BigNumber from 'bignumber.js';
+
+import { assetData } from '__mocks__/models/asset';
+import { poolData } from '__mocks__/models/pools';
+import type { Asset, EModeGroup, Pool } from 'types';
+import { formatEModeGroups } from '..';
+
+const createEModeGroup = ({
+  id,
+  name,
+  asset,
+  isBorrowable,
+  liquidationThresholdPercentage,
+}: {
+  id: number;
+  name: string;
+  asset: Asset;
+  isBorrowable: boolean;
+  liquidationThresholdPercentage: number;
+}): EModeGroup => ({
+  id,
+  name,
+  isActive: true,
+  isIsolated: false,
+  assetSettings: [
+    {
+      vToken: asset.vToken,
+      collateralFactor: 0.5,
+      liquidationThresholdPercentage,
+      liquidationPenaltyPercentage: 0,
+      isBorrowable,
+    },
+  ],
+});
+
+const createPool = ({
+  groups,
+  userEModeGroup,
+}: {
+  groups: EModeGroup[];
+  userEModeGroup?: EModeGroup;
+}): Pool => {
+  const asset: Asset = {
+    ...assetData[0],
+    userBorrowBalanceCents: new BigNumber(100),
+    userBorrowBalanceTokens: new BigNumber(1),
+    userSupplyBalanceCents: new BigNumber(1000),
+    userSupplyBalanceTokens: new BigNumber(10),
+    userWalletBalanceCents: new BigNumber(0),
+    isCollateralOfUser: true,
+  };
+
+  return {
+    ...poolData[0],
+    assets: [asset],
+    eModeGroups: groups,
+    userEModeGroup,
+    vai: undefined,
+  };
+};
+
+describe('formatEModeGroups', () => {
+  it('sorts enabled first, then enableable groups by descending health factor, then blocked groups', () => {
+    const asset = assetData[0];
+    const enabledGroup = createEModeGroup({
+      id: 1,
+      name: 'Enabled blocked group',
+      asset,
+      isBorrowable: false,
+      liquidationThresholdPercentage: 20,
+    });
+    const highHealthFactorGroup = createEModeGroup({
+      id: 2,
+      name: 'High health factor group',
+      asset,
+      isBorrowable: true,
+      liquidationThresholdPercentage: 80,
+    });
+    const blockedGroup = createEModeGroup({
+      id: 3,
+      name: 'Blocked group',
+      asset,
+      isBorrowable: false,
+      liquidationThresholdPercentage: 90,
+    });
+    const lowHealthFactorGroup = createEModeGroup({
+      id: 4,
+      name: 'Low health factor group',
+      asset,
+      isBorrowable: true,
+      liquidationThresholdPercentage: 50,
+    });
+    const pool = createPool({
+      groups: [enabledGroup, highHealthFactorGroup, blockedGroup, lowHealthFactorGroup],
+      userEModeGroup: enabledGroup,
+    });
+
+    const result = formatEModeGroups({
+      pool,
+      eModeGroups: pool.eModeGroups,
+      searchValue: '',
+      showUserAssetsOnly: false,
+      formatTo: vi.fn(({ to }) => to),
+    });
+
+    expect(result.map(group => group.name)).toEqual([
+      enabledGroup.name,
+      highHealthFactorGroup.name,
+      lowHealthFactorGroup.name,
+      blockedGroup.name,
+    ]);
+  });
+
+  it.each([
+    ['enableable group before blocked group', true],
+    ['blocked group before enableable group', false],
+  ])('sorts enableable groups before blocked groups when input has %s', (_, isEnableableFirst) => {
+    const asset = assetData[0];
+    const enableableGroup = createEModeGroup({
+      id: 1,
+      name: 'Enableable group',
+      asset,
+      isBorrowable: true,
+      liquidationThresholdPercentage: 80,
+    });
+    const blockedGroup = createEModeGroup({
+      id: 2,
+      name: 'Blocked group',
+      asset,
+      isBorrowable: false,
+      liquidationThresholdPercentage: 80,
+    });
+    const groups = isEnableableFirst
+      ? [enableableGroup, blockedGroup]
+      : [blockedGroup, enableableGroup];
+    const pool = createPool({ groups });
+
+    const result = formatEModeGroups({
+      pool,
+      eModeGroups: pool.eModeGroups,
+      searchValue: '',
+      showUserAssetsOnly: false,
+      formatTo: vi.fn(({ to }) => to),
+    });
+
+    expect(result.map(group => group.name)).toEqual([enableableGroup.name, blockedGroup.name]);
+  });
+});

--- a/apps/evm/src/containers/EModeGroupList/formatEModeGroups/index.ts
+++ b/apps/evm/src/containers/EModeGroupList/formatEModeGroups/index.ts
@@ -160,7 +160,7 @@ export const formatEModeGroups = ({
       }
 
       const aCanBeEnabled = a.userBlockingBorrowPositions.length === 0 && a.userHasEnoughCollateral;
-      const bCanBeEnabled = a.userBlockingBorrowPositions.length === 0 && a.userHasEnoughCollateral;
+      const bCanBeEnabled = b.userBlockingBorrowPositions.length === 0 && b.userHasEnoughCollateral;
 
       // Sort groups that can't be enabled last
       if (!aCanBeEnabled) {

--- a/apps/evm/src/containers/Layout/NavBar/__tests__/index.spec.tsx
+++ b/apps/evm/src/containers/Layout/NavBar/__tests__/index.spec.tsx
@@ -90,7 +90,10 @@ const seedSharedQueryData = ({
   });
 
   queryClient.setQueryData(
-    [FunctionKey.GET_PENDING_REWARDS, { accountAddress, chainId: defaultChainId }],
+    [
+      FunctionKey.GET_PENDING_REWARDS,
+      { accountAddress, chainId: defaultChainId, isolatedPoolComptrollerAddresses: [] },
+    ],
     {
       pendingRewardGroups: [],
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "generate": "turbo run generate",
     "lint": "turbo run lint",
     "lint:styles": "turbo run lint:styles",
-    "format": "npx biome check --apply .",
+    "format": "yarn biome check --apply .",
     "test": "turbo run test --",
     "tsc": "turbo run tsc",
     "clean": "turbo run clean && rm -rf node_modules",
@@ -25,6 +25,7 @@
     "postinstall": "turbo run generate"
   },
   "devDependencies": {
+    "@biomejs/biome": "1.6.4",
     "@changesets/cli": "^2.27.1",
     "@commitlint/config-conventional": "19.8.1",
     "@earendil-works/pi-coding-agent": "0.79.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -24363,6 +24363,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "venusprotocol@workspace:."
   dependencies:
+    "@biomejs/biome": "npm:1.6.4"
     "@changesets/cli": "npm:^2.27.1"
     "@commitlint/config-conventional": "npm:19.8.1"
     "@earendil-works/pi-coding-agent": "npm:0.79.0"


### PR DESCRIPTION
## Changes

 - Fixed E-Mode group sorting so blocked groups are correctly pushed after enableable groups
 - Added unit tests covering E-Mode sorting behavior
 - Updated pending rewards query key to include isolated pool comptroller addresses and fixed the XVS vault pool count query enablement logic
 - Removed duplicate API exports
 - Updated the format script to use the workspace Biome dependency and added Biome as a dev dependency
