### PR TITLE
fix: point isolated pools deprecation notice to the deprecation guide

### DIFF
--- a/apps/evm/src/constants/production.ts
+++ b/apps/evm/src/constants/production.ts
@@ -3,7 +3,7 @@ export const VENUS_FLUX_URL = 'https://flux.venus.io';
 export const VENUS_DOC_URL = 'https://docs-v4.venus.io';
 export const VENUS_PRIME_DOC_URL = `${VENUS_DOC_URL}/whats-new/prime-yield`;
 export const VENUS_PROTECTION_MODE_DOC_URL = `${VENUS_DOC_URL}/risk/protection-mode`;
-export const VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL = VENUS_DOC_URL;
+export const VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL = `${VENUS_DOC_URL}/guides/isolated-pools-deprecation`;
 
 export const DISCORD_SERVER_URL = 'https://discord.com/servers/venus-protocol-912811548651708448';
 export const VENUS_COMMUNITY_URL = 'https://community.venus.io/';

--- a/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx
@@ -2,6 +2,7 @@ import { fireEvent } from '@testing-library/react';
 import type { Mock } from 'vitest';
 
 import { useGetChainIdsWithIsolatedPoolPosition } from 'clients/api';
+import { VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL } from 'constants/production';
 import { renderComponent } from 'testUtils/render';
 import { ChainId } from 'types';
 import { IsolatedPoolsDeprecationNotice } from '..';
@@ -23,6 +24,20 @@ describe('IsolatedPoolsDeprecationNotice', () => {
 
     expect(container.textContent).toContain('BNB Chain and Ethereum');
     expect(container.textContent).toContain('Learn more');
+  });
+
+  it('points the "Learn more" link to the isolated pools deprecation guide', () => {
+    mockOutput({ chainIds: [ChainId.BSC_MAINNET] });
+
+    const { getByText } = renderComponent(<IsolatedPoolsDeprecationNotice />);
+
+    expect(getByText('Learn more')).toHaveAttribute(
+      'href',
+      'https://docs-v4.venus.io/guides/isolated-pools-deprecation',
+    );
+    expect(VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL).toBe(
+      'https://docs-v4.venus.io/guides/isolated-pools-deprecation',
+    );
   });
 
   it('formats the chain list with the locale separator', () => {


### PR DESCRIPTION
## Summary

Fixes [VPD-1840](https://venus-labs.atlassian.net/browse/VPD-1840). The "Learn more" link in the isolated pools deprecation notice on the Dashboard resolved to the docs root (`https://docs-v4.venus.io/`) because `VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL` was still a placeholder aliasing `VENUS_DOC_URL`.

It now points at the deprecation guide confirmed on the ticket: `https://docs-v4.venus.io/guides/isolated-pools-deprecation`.

## Changes

- `apps/evm/src/constants/production.ts` — `VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL` now appends `/guides/isolated-pools-deprecation`.
- `apps/evm/src/pages/.../IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx` — regression test asserting the rendered "Learn more" anchor's `href`.

## Testing

`yarn tsc`, `yarn lint`, `yarn extract-translations` (no translation diff — no copy changed) and `yarn test --coverage` all pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[VPD-1840]: https://venus-labs.atlassian.net/browse/VPD-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ