### PR TITLE
Test: point isolated pools deprecation notice Learn more link to isolated E-mode guide

### DIFF
--- a/apps/evm/src/constants/production.ts
+++ b/apps/evm/src/constants/production.ts
@@ -3,7 +3,7 @@ export const VENUS_FLUX_URL = 'https://flux.venus.io';
 export const VENUS_DOC_URL = 'https://docs-v4.venus.io';
 export const VENUS_PRIME_DOC_URL = `${VENUS_DOC_URL}/whats-new/prime-yield`;
 export const VENUS_PROTECTION_MODE_DOC_URL = `${VENUS_DOC_URL}/risk/protection-mode`;
-export const VENUS_ISOLATED_E_MODE_DOC_URL = `${VENUS_DOC_URL}/guides/isolated-e-mode`;
+export const VENUS_ISOLATED_E_MODE_GUIDE_URL = `${VENUS_DOC_URL}/guides/isolated-e-mode`;
 
 export const DISCORD_SERVER_URL = 'https://discord.com/servers/venus-protocol-912811548651708448';
 export const VENUS_COMMUNITY_URL = 'https://community.venus.io/';

--- a/apps/evm/src/constants/production.ts
+++ b/apps/evm/src/constants/production.ts
@@ -3,7 +3,7 @@ export const VENUS_FLUX_URL = 'https://flux.venus.io';
 export const VENUS_DOC_URL = 'https://docs-v4.venus.io';
 export const VENUS_PRIME_DOC_URL = `${VENUS_DOC_URL}/whats-new/prime-yield`;
 export const VENUS_PROTECTION_MODE_DOC_URL = `${VENUS_DOC_URL}/risk/protection-mode`;
-export const VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL = `${VENUS_DOC_URL}/guides/isolated-pools-deprecation`;
+export const VENUS_ISOLATED_E_MODE_DOC_URL = `${VENUS_DOC_URL}/guides/isolated-e-mode`;
 
 export const DISCORD_SERVER_URL = 'https://discord.com/servers/venus-protocol-912811548651708448';
 export const VENUS_COMMUNITY_URL = 'https://community.venus.io/';

--- a/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx
@@ -1,7 +1,7 @@
 import type { Mock } from 'vitest';
 
 import { useGetChainIdsWithIsolatedPoolPosition } from 'clients/api';
-import { VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL } from 'constants/production';
+import { VENUS_ISOLATED_E_MODE_DOC_URL } from 'constants/production';
 import { renderComponent } from 'testUtils/render';
 import { ChainId } from 'types';
 import { IsolatedPoolsDeprecationNotice } from '..';
@@ -25,18 +25,16 @@ describe('IsolatedPoolsDeprecationNotice', () => {
     expect(container.textContent).toContain('Learn more');
   });
 
-  it('points the "Learn more" link to the isolated pools deprecation guide', () => {
+  it('points the "Learn more" link to the isolated E-mode guide', () => {
     mockOutput({ chainIds: [ChainId.BSC_MAINNET] });
 
     const { getByText } = renderComponent(<IsolatedPoolsDeprecationNotice />);
 
     expect(getByText('Learn more')).toHaveAttribute(
       'href',
-      'https://docs-v4.venus.io/guides/isolated-pools-deprecation',
+      'https://docs-v4.venus.io/guides/isolated-e-mode',
     );
-    expect(VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL).toBe(
-      'https://docs-v4.venus.io/guides/isolated-pools-deprecation',
-    );
+    expect(VENUS_ISOLATED_E_MODE_DOC_URL).toBe('https://docs-v4.venus.io/guides/isolated-e-mode');
   });
 
   it('formats the chain list with the locale separator', () => {

--- a/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx
@@ -1,7 +1,6 @@
 import type { Mock } from 'vitest';
 
 import { useGetChainIdsWithIsolatedPoolPosition } from 'clients/api';
-import { VENUS_ISOLATED_E_MODE_DOC_URL } from 'constants/production';
 import { renderComponent } from 'testUtils/render';
 import { ChainId } from 'types';
 import { IsolatedPoolsDeprecationNotice } from '..';
@@ -34,7 +33,6 @@ describe('IsolatedPoolsDeprecationNotice', () => {
       'href',
       'https://docs-v4.venus.io/guides/isolated-e-mode',
     );
-    expect(VENUS_ISOLATED_E_MODE_DOC_URL).toBe('https://docs-v4.venus.io/guides/isolated-e-mode');
   });
 
   it('formats the chain list with the locale separator', () => {

--- a/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/index.tsx
+++ b/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/index.tsx
@@ -2,7 +2,7 @@ import { chains } from '@venusprotocol/chains';
 
 import { useGetChainIdsWithIsolatedPoolPosition } from 'clients/api';
 import { NoticeWarning } from 'components';
-import { VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL } from 'constants/production';
+import { VENUS_ISOLATED_E_MODE_DOC_URL } from 'constants/production';
 import { Link } from 'containers/Link';
 import { useTranslation } from 'libs/translations';
 
@@ -32,9 +32,7 @@ export const IsolatedPoolsDeprecationNotice: React.FC<IsolatedPoolsDeprecationNo
           i18nKey="account.isolatedPoolsDeprecationNotice.description"
           values={{ chainNames }}
           components={{
-            LearnMore: (
-              <Link className="underline" href={VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL} />
-            ),
+            LearnMore: <Link className="underline" href={VENUS_ISOLATED_E_MODE_DOC_URL} />,
           }}
         />
       }

--- a/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/index.tsx
+++ b/apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/index.tsx
@@ -2,7 +2,7 @@ import { chains } from '@venusprotocol/chains';
 
 import { useGetChainIdsWithIsolatedPoolPosition } from 'clients/api';
 import { NoticeWarning } from 'components';
-import { VENUS_ISOLATED_E_MODE_DOC_URL } from 'constants/production';
+import { VENUS_ISOLATED_E_MODE_GUIDE_URL } from 'constants/production';
 import { Link } from 'containers/Link';
 import { useTranslation } from 'libs/translations';
 
@@ -32,7 +32,7 @@ export const IsolatedPoolsDeprecationNotice: React.FC<IsolatedPoolsDeprecationNo
           i18nKey="account.isolatedPoolsDeprecationNotice.description"
           values={{ chainNames }}
           components={{
-            LearnMore: <Link className="underline" href={VENUS_ISOLATED_E_MODE_DOC_URL} />,
+            LearnMore: <Link className="underline" href={VENUS_ISOLATED_E_MODE_GUIDE_URL} />,
           }}
         />
       }


### PR DESCRIPTION
## Summary

The "Learn more" link on the isolated pools deprecation notice (Dashboard → Markets) pointed at
`https://docs-v4.venus.io/guides/isolated-pools-deprecation`. Per **VPD-1869** it should point at
`https://docs-v4.venus.io/guides/isolated-e-mode`.

The constant was renamed `VENUS_ISOLATED_POOLS_DEPRECATION_DOC_URL` → `VENUS_ISOLATED_E_MODE_GUIDE_URL`
so the name describes what it actually points at, and so it stays distinguishable from the existing
`ISOLATION_MODE_DOC_URL` in `pages/Markets/Tabs` (which points at `/whats-new/isolated-e-mode`, a
different page). The rename touches only the same three files as the URL change.

## Changes

| File | Change |
|---|---|
| `apps/evm/src/constants/production.ts` | Doc URL repointed to `/guides/isolated-e-mode`; constant renamed |
| `apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/index.tsx` | Uses the renamed constant |
| `apps/evm/src/pages/Dashboard/Markets/IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx` | Updated expected URL + test name; dropped a tautological assertion |

No copy changed, so `yarn extract-translations` produced no diff. All 7 locales already carry the
translated `<LearnMore>` string.

## Verification gates

All four run end to end on the final commit:

| Gate | Result |
|---|---|
| `yarn tsc` | pass — 3/3 tasks |
| `yarn lint` | pass — 3/3 tasks, 0 errors |
| `yarn extract-translations` | pass — 2171 files parsed, no translation diff |
| `yarn test --coverage` | pass — evm 432 files / 1840 tests, chains 9 files / 16 tests; evm statements 80.71% (unchanged) |

The target spec `IsolatedPoolsDeprecationNotice/__tests__/index.spec.tsx` passes all 6 tests.

## ⚠️ Open question — please confirm before merging

Both doc pages exist, but they cover different topics. Verified against the published docs navigation
and page content on `https://docs-v4.venus.io`:

- `/guides/isolated-pools-deprecation` → **"Withdrawing from deprecated isolated pools"** — explains how
  to exit a position via a block explorer, and names the same BNB Chain / Ethereum / Arbitrum set that
  `chainNames` interpolates into this notice.
- `/guides/isolated-e-mode` → **"Isolated E-mode"** — a concept page about isolation mode as a risk
  safeguard. It contains no withdrawal instructions.

The notice copy reads *"Isolated pools have been fully deprecated. You still have positions on
{chainNames}. Repay any borrows and withdraw your assets. Learn more"*. Repointing the link therefore
removes the actionable recovery instructions for a user who currently has funds stranded in a
deprecated isolated pool.

This PR implements VPD-1869 verbatim — the ticket's "expected" and "now" values both match the live FE,
so the wording is not reversed. Raising it because the new target may not be the doc a user reading
this notice actually needs. Reverting is a one-line change if QA/product confirms the original URL was
correct.

## Ticket

- Jira: https://venus-labs.atlassian.net/browse/VPD-1869
- Multica: VENUS-58 (`fbac0e4f-544a-4c12-a2da-9c81e85517cf`)
