### PR TITLE
fix: invert net APY color logic in account overview (VPD-1870)

### DIFF
--- a/apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx
+++ b/apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
+import type { Mock } from 'vitest';
+
+import fakeAccountAddress from '__mocks__/models/address';
+import { poolData } from '__mocks__/models/pools';
+import { useGetPool, useGetVaults } from 'clients/api';
+import { en } from 'libs/translations';
+import { renderComponent } from 'testUtils/render';
+import type { Pool } from 'types';
+import { AccountOverview } from '..';
+import { testIds } from '../testIds';
+
+const getNetApyCell = () => {
+  const labelElement = screen.getByText(en.dashboard.overview.summary.cellGroup.netApy);
+  const cell = labelElement.parentElement?.parentElement;
+
+  expect(cell).toBeInTheDocument();
+
+  return cell as HTMLElement;
+};
+
+const renderExpandedAccountOverview = async () => {
+  const result = renderComponent(<AccountOverview accountAddress={fakeAccountAddress} />, {
+    accountAddress: fakeAccountAddress,
+  });
+
+  await waitFor(() =>
+    expect(result.queryByTestId(testIds.performanceChartPreview)).toBeInTheDocument(),
+  );
+
+  // Expand accordion
+  fireEvent.click(screen.getByText(en.dashboard.overview.absolutePerformance).closest('button')!);
+
+  return result;
+};
+
+describe('AccountOverview net APY color', () => {
+  const mockUseGetPool = useGetPool as Mock;
+  const mockUseGetVaults = useGetVaults as Mock;
+
+  beforeEach(() => {
+    mockUseGetVaults.mockReturnValue({
+      isLoading: false,
+      data: [],
+    });
+  });
+
+  it('displays a positive net APY in red', async () => {
+    await renderExpandedAccountOverview();
+
+    expect(getNetApyCell()).toHaveClass('text-red');
+  });
+
+  it('displays a negative net APY in green', async () => {
+    const poolWithNegativeYearlyEarnings = {
+      ...poolData[0],
+      userYearlyEarningsCents: new BigNumber(-36500),
+    } satisfies Pool;
+
+    mockUseGetPool.mockReturnValue({
+      isLoading: false,
+      data: {
+        pool: poolWithNegativeYearlyEarnings,
+      },
+    });
+
+    await renderExpandedAccountOverview();
+
+    expect(getNetApyCell()).toHaveClass('text-green');
+  });
+});

--- a/apps/evm/src/containers/AccountOverview/index.tsx
+++ b/apps/evm/src/containers/AccountOverview/index.tsx
@@ -233,7 +233,7 @@ export const AccountOverview: React.FC<AccountOverviewProps> = ({
         ? t('dashboard.overview.summary.cellGroup.netApyWithVaultStakeTooltip')
         : t('dashboard.overview.summary.cellGroup.netApyTooltip'),
       className:
-        typeof userNetApyPercentage === 'number' && userNetApyPercentage < 0
+        typeof userNetApyPercentage === 'number' && userNetApyPercentage > 0
           ? 'text-red'
           : 'text-green',
     },


### PR DESCRIPTION
## Summary

QA ticket [VPD-1870](https://venus-labs.atlassian.net/browse/VPD-1870) (Multica issue `VENUS-64`, id `fd88df7b-9ab3-41cd-90f9-ede77dfbd3f2`) reports that the Net APY cell in the account overview summary uses the wrong colour relative to the sign of `userNetApyPercentage`.

Confirmed against the code on `feat/test-qa-agent`: `containers/AccountOverview/index.tsx` rendered `text-red` for a **negative** net APY and `text-green` otherwise — the inverse of what the ticket expects.

Expected behaviour per the ticket:

- `text-red` when `userNetApyPercentage > 0`
- `text-green` when `userNetApyPercentage < 0`

## Changes

- `apps/evm/src/containers/AccountOverview/index.tsx` — the `summaryCells` Net APY entry now applies `text-red` when `userNetApyPercentage` is positive and `text-green` otherwise. The neutral cases (`0` and `undefined`) keep their existing `text-green` styling, since the ticket does not specify them.
- `apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx` — new spec asserting both colours on the Net APY cell (both cases fail against the pre-fix code).

## Verification gates

| Gate | Result |
|---|---|
| `yarn tsc` | pass (3 packages) |
| `yarn lint` | pass (biome + stylelint; only the 16 pre-existing `@venusprotocol/chains` warnings) |
| `yarn extract-translations` | pass, no translation-file changes (no new copy) |
| `yarn test --coverage` | pass; statements 80.71%, branches 86.04%, functions 74.52% — no drop vs. baseline |

## Open question

`apps/evm/src/pages/Dashboard/Summary/index.tsx` has the same Net APY colour expression for `netApyPercentage` and still uses the old convention (positive → green, negative → red), covered by an existing test. VPD-1870 names `summaryCells` / `userNetApyPercentage`, which matches only the account overview container, so that file is intentionally left untouched — but the two views now disagree visually. Please confirm whether the Dashboard summary should follow.


[VPD-1870]: https://venus-labs.atlassian.net/browse/VPD-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ