### PR TITLE
Test: use blue/white color tokens for account overview net APY (VPD-1879)

### DIFF
--- a/apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx
+++ b/apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx
@@ -47,6 +47,18 @@ describe('AccountOverview net APY color', () => {
   });
 
   it('displays a positive net APY in blue', async () => {
+    const poolWithPositiveYearlyEarnings = {
+      ...poolData[0],
+      userYearlyEarningsCents: new BigNumber(36500),
+    } satisfies Pool;
+
+    mockUseGetPool.mockReturnValue({
+      isLoading: false,
+      data: {
+        pool: poolWithPositiveYearlyEarnings,
+      },
+    });
+
     await renderExpandedAccountOverview();
 
     expect(getNetApyCell()).toHaveClass('text-blue');

--- a/apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx
+++ b/apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx
@@ -1,0 +1,90 @@
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import BigNumber from 'bignumber.js';
+import type { Mock } from 'vitest';
+
+import fakeAccountAddress from '__mocks__/models/address';
+import { poolData } from '__mocks__/models/pools';
+import { useGetPool, useGetVaults } from 'clients/api';
+import { en } from 'libs/translations';
+import { renderComponent } from 'testUtils/render';
+import type { Pool } from 'types';
+import { AccountOverview } from '..';
+import { testIds } from '../testIds';
+
+const getNetApyCell = () => {
+  const labelElement = screen.getByText(en.dashboard.overview.summary.cellGroup.netApy);
+  const cell = labelElement.parentElement?.parentElement;
+
+  expect(cell).toBeInTheDocument();
+
+  return cell as HTMLElement;
+};
+
+const renderExpandedAccountOverview = async () => {
+  const result = renderComponent(<AccountOverview accountAddress={fakeAccountAddress} />, {
+    accountAddress: fakeAccountAddress,
+  });
+
+  await waitFor(() =>
+    expect(result.queryByTestId(testIds.performanceChartPreview)).toBeInTheDocument(),
+  );
+
+  // Expand accordion to reveal the summary cells
+  fireEvent.click(screen.getByText(en.dashboard.overview.absolutePerformance).closest('button')!);
+
+  return result;
+};
+
+describe('AccountOverview net APY color', () => {
+  const mockUseGetPool = useGetPool as Mock;
+  const mockUseGetVaults = useGetVaults as Mock;
+
+  beforeEach(() => {
+    mockUseGetVaults.mockReturnValue({
+      isLoading: false,
+      data: [],
+    });
+  });
+
+  it('displays a positive net APY in blue', async () => {
+    await renderExpandedAccountOverview();
+
+    expect(getNetApyCell()).toHaveClass('text-blue');
+  });
+
+  it('displays a negative net APY in white', async () => {
+    const poolWithNegativeYearlyEarnings = {
+      ...poolData[0],
+      userYearlyEarningsCents: new BigNumber(-36500),
+    } satisfies Pool;
+
+    mockUseGetPool.mockReturnValue({
+      isLoading: false,
+      data: {
+        pool: poolWithNegativeYearlyEarnings,
+      },
+    });
+
+    await renderExpandedAccountOverview();
+
+    expect(getNetApyCell()).toHaveClass('text-white');
+  });
+
+  it('displays a zero net APY in white', async () => {
+    const poolWithZeroYearlyEarnings = {
+      ...poolData[0],
+      userYearlyEarningsCents: new BigNumber(0),
+    } satisfies Pool;
+
+    mockUseGetPool.mockReturnValue({
+      isLoading: false,
+      data: {
+        pool: poolWithZeroYearlyEarnings,
+      },
+    });
+
+    await renderExpandedAccountOverview();
+
+    expect(getNetApyCell()).toHaveClass('text-white');
+  });
+});

--- a/apps/evm/src/containers/AccountOverview/index.tsx
+++ b/apps/evm/src/containers/AccountOverview/index.tsx
@@ -233,9 +233,9 @@ export const AccountOverview: React.FC<AccountOverviewProps> = ({
         ? t('dashboard.overview.summary.cellGroup.netApyWithVaultStakeTooltip')
         : t('dashboard.overview.summary.cellGroup.netApyTooltip'),
       className:
-        typeof userNetApyPercentage === 'number' && userNetApyPercentage < 0
-          ? 'text-red'
-          : 'text-green',
+        typeof userNetApyPercentage === 'number' && userNetApyPercentage > 0
+          ? 'text-blue'
+          : 'text-white',
     },
     {
       label: t('dashboard.overview.summary.cellGroup.dailyEarnings'),


### PR DESCRIPTION
## Summary

Fixes the Net APY colour logic in the account overview summary cells.

- Jira: [VPD-1879](https://venus-labs.atlassian.net/browse/VPD-1879)
- Multica sub-issue: VENUS-67 — `b8b9b969-369e-4952-b8b7-c6c46e747352`

### Bug confirmed

On `feat/test-qa-agent`, `apps/evm/src/containers/AccountOverview/index.tsx` rendered the `summaryCells`
Net APY cell as:

```ts
typeof userNetApyPercentage === 'number' && userNetApyPercentage < 0 ? 'text-red' : 'text-green'
```

Both colour tokens were wrong against the expected behaviour.

### Change

```ts
typeof userNetApyPercentage === 'number' && userNetApyPercentage > 0 ? 'text-blue' : 'text-white'
```

- `userNetApyPercentage > 0` → `text-blue`
- `userNetApyPercentage < 0` → `text-white`

Both are existing design tokens in `packages/ui/src/theme.css` (`--color-blue`, `--color-white`); no new
tokens or dependencies.

Scope is limited to the container the ticket names. `pages/Dashboard/Summary/index.tsx` holds a
structurally identical expression over `cells` / `netApyPercentage`, but the ticket names `summaryCells` /
`userNetApyPercentage`, so it is deliberately left untouched.

## Files

- `apps/evm/src/containers/AccountOverview/index.tsx` — modified (colour expression only)
- `apps/evm/src/containers/AccountOverview/__tests__/index.netApy.spec.tsx` — added (3 tests)

## Verification gates

| Gate | Result |
|---|---|
| `yarn tsc` | pass — 3/3 tasks, 23.6s |
| `yarn lint` | pass — 3/3 tasks; 16 pre-existing `useLiteralEnumMembers` warnings in `packages/chains` (unrelated, non-fatal) |
| `yarn extract-translations` | pass — 2172 files parsed, no translation-file changes (no new i18n keys) |
| `yarn test --coverage` | pass — 2/2 tasks, 4m21s |

Coverage after the change (`apps/evm`): statements **80.71%**, branches **86.04%**, functions **74.52%** —
no drop vs the recorded baseline (80.71 / 86.02 / 74.52). `AccountOverview/index.tsx` itself is at 97.65%
statements.

No `@ts-ignore`, `eslint-disable`, `skip`/`only`, threshold change, or test deletion was used.

## Notes

- The existing `__tests__/index.spec.tsx` snapshots assert `container.textContent` only, so a class change
  does not touch them.
- Zero and `undefined` net APY continue to fall into the same branch as negative (now `text-white`,
  previously `text-green`). The ticket specifies only `> 0` and `< 0`; the two-branch shape was preserved.
  Flagged as an open question on the ticket.
- PR #5785 (VPD-1870) changed the same line to `> 0 ? 'text-red' : 'text-green'` but is **closed** and was
  not merged, so this branch is based on the correct current state of `feat/test-qa-agent` (`8d7a6b4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Self-review triage (pr-reviewer)

The reviewer uses Sev 1–4; mapped onto P0–P3 as Sev1→P0, Sev2→P1, Sev3→P2, Sev4→P3. No P0.

| # | Sev | Finding | State |
|---|---|---|---|
| 2.1 | P1 | `pages/Dashboard/Markets/Positions/Summary/index.tsx:76` renders a second "Net APY" cell on the same Dashboard page, still `text-red`/`text-green` | **Escalated as open question** — verified real, but out of this ticket's named scope |
| 3.1 | P2 | Same colour expression now in 3 files; extract a shared `getNetApyClassName` helper | **Deferred as follow-up** — new utility + 3 call sites, 2 outside this ticket |
| 3.2 | P2 | Zero net APY shares `text-white` with negative | **Escalated as open question** — ticket defines only `>0` / `<0` |
| 3.3 | P2 | Test walks two `parentElement` hops into `Cell` internals instead of a `data-testid` | **Not applicable** — this is the repo's established `getCell` pattern (`pages/Dashboard/Summary/__tests__/index.spec.tsx`); the alternative adds a test id to production markup |
| 4.1 | P3 | Positive test case relied on the shared `poolData[0]` fixture | **Fixed** in `07cff32` |
| 4.2 | P3 | `tooltip: vaults ?` is always truthy, so `netApyTooltip` is dead copy (pre-existing, all 3 sites) | **Deferred as follow-up** — reviewer flagged it as explicitly not for this PR |

### Open question on 2.1 (needs a QA/design call)

`pages/Dashboard/index.tsx` mounts `AccountOverview` (line 112) and `<Markets>` → `Positions/Summary` (line 66), so a positive net APY would read **blue** in the account overview accordion and **green** in the Markets tab summary. That sibling uses different identifiers (`cells` / `netApyPercentage`, i18n `account.summary.*`) than the ones VPD-1879 names, so it was deliberately not changed. Confirm whether the sibling should follow.


[VPD-1879]: https://venus-labs.atlassian.net/browse/VPD-1879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ