### PR TITLE
fix: refetch account transaction history when pools resolve

### DIFF
--- a/apps/evm/src/clients/api/queries/getAccountTransactionHistory/__tests__/useGetAccountTransactionHistory.spec.ts
+++ b/apps/evm/src/clients/api/queries/getAccountTransactionHistory/__tests__/useGetAccountTransactionHistory.spec.ts
@@ -1,0 +1,177 @@
+import { waitFor } from '@testing-library/react';
+import fakeAddress from '__mocks__/models/address';
+import { poolData } from '__mocks__/models/pools';
+import { useGetPools } from 'clients/api/queries/useGetPools';
+import { renderHook } from 'testUtils/render';
+import { type Mock, vi } from 'vitest';
+import * as getAccountTransactionHistoryQueries from '..';
+import { useGetAccountTransactionHistory } from '../useGetAccountTransactionHistory';
+
+vi.mock('clients/api/queries/useGetPools', () => ({
+  useGetPools: vi.fn(),
+}));
+
+const fakeOutput = {
+  count: 0,
+  transactions: [],
+};
+
+const mockGetAccountTransactionHistory = () =>
+  vi
+    .spyOn(getAccountTransactionHistoryQueries, 'getAccountTransactionHistory')
+    .mockResolvedValue(fakeOutput);
+
+describe('useGetAccountTransactionHistory', () => {
+  it('does not fetch the transactions while the pools are loading', async () => {
+    const getAccountTransactionHistorySpy = mockGetAccountTransactionHistory();
+
+    (useGetPools as Mock).mockReturnValue({
+      data: undefined,
+      isError: false,
+    });
+
+    const { result } = renderHook(() =>
+      useGetAccountTransactionHistory({ accountAddress: fakeAddress }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    expect(getAccountTransactionHistorySpy).not.toHaveBeenCalled();
+  });
+
+  it('fetches the transactions with the pools once they have resolved', async () => {
+    const getAccountTransactionHistorySpy = mockGetAccountTransactionHistory();
+
+    (useGetPools as Mock).mockReturnValue({
+      data: { pools: poolData },
+      isError: false,
+    });
+
+    const { result } = renderHook(() =>
+      useGetAccountTransactionHistory({ accountAddress: fakeAddress }),
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getAccountTransactionHistorySpy).toHaveBeenCalledTimes(1);
+    expect(getAccountTransactionHistorySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ getPoolsData: { pools: poolData } }),
+    );
+  });
+
+  it('fetches the transactions once the pools resolve after an initial render without them', async () => {
+    const getAccountTransactionHistorySpy = mockGetAccountTransactionHistory();
+
+    // Simulate the pools not having been fetched yet on first render
+    (useGetPools as Mock).mockReturnValue({
+      data: undefined,
+      isError: false,
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useGetAccountTransactionHistory({ accountAddress: fakeAddress }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    expect(getAccountTransactionHistorySpy).not.toHaveBeenCalled();
+
+    (useGetPools as Mock).mockReturnValue({
+      data: { pools: poolData },
+      isError: false,
+    });
+
+    rerender();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getAccountTransactionHistorySpy).toHaveBeenCalledTimes(1);
+    expect(getAccountTransactionHistorySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ getPoolsData: { pools: poolData } }),
+    );
+  });
+
+  it('refetches the transactions when the assets of the pools change', async () => {
+    const getAccountTransactionHistorySpy = mockGetAccountTransactionHistory();
+
+    (useGetPools as Mock).mockReturnValue({
+      data: { pools: [poolData[0]] },
+      isError: false,
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useGetAccountTransactionHistory({ accountAddress: fakeAddress }),
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(getAccountTransactionHistorySpy).toHaveBeenCalledTimes(1);
+
+    (useGetPools as Mock).mockReturnValue({
+      data: { pools: poolData },
+      isError: false,
+    });
+
+    rerender();
+
+    await waitFor(() => expect(getAccountTransactionHistorySpy).toHaveBeenCalledTimes(2));
+  });
+
+  it('does not refetch the transactions when the assets are returned in a different order', async () => {
+    const getAccountTransactionHistorySpy = mockGetAccountTransactionHistory();
+
+    (useGetPools as Mock).mockReturnValue({
+      data: { pools: poolData },
+      isError: false,
+    });
+
+    const { result, rerender } = renderHook(() =>
+      useGetAccountTransactionHistory({ accountAddress: fakeAddress }),
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    (useGetPools as Mock).mockReturnValue({
+      data: { pools: poolData.map(pool => ({ ...pool, assets: [...pool.assets].reverse() })) },
+      isError: false,
+    });
+
+    rerender();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getAccountTransactionHistorySpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fetch the transactions when the pools could not be fetched', async () => {
+    const getAccountTransactionHistorySpy = mockGetAccountTransactionHistory();
+
+    (useGetPools as Mock).mockReturnValue({
+      data: undefined,
+      isError: true,
+    });
+
+    const { result } = renderHook(() =>
+      useGetAccountTransactionHistory({ accountAddress: fakeAddress }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getAccountTransactionHistorySpy).not.toHaveBeenCalled();
+  });
+
+  it('does not report a loading state when the query is disabled', async () => {
+    const getAccountTransactionHistorySpy = mockGetAccountTransactionHistory();
+
+    (useGetPools as Mock).mockReturnValue({
+      data: undefined,
+      isError: false,
+    });
+
+    const { result } = renderHook(() =>
+      useGetAccountTransactionHistory({ accountAddress: fakeAddress }, { enabled: false }),
+    );
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(getAccountTransactionHistorySpy).not.toHaveBeenCalled();
+  });
+});

--- a/apps/evm/src/clients/api/queries/getAccountTransactionHistory/useGetAccountTransactionHistory.ts
+++ b/apps/evm/src/clients/api/queries/getAccountTransactionHistory/useGetAccountTransactionHistory.ts
@@ -4,6 +4,7 @@ import { liquidityHubs } from '__mocks__/models/liquidityHubs';
 import FunctionKey from 'constants/functionKey';
 import { useChainId } from 'libs/wallet';
 import type { ChainId } from 'types';
+import type { Address } from 'viem';
 import {
   type GetAccountTransactionHistoryInput,
   type GetAccountTransactionHistoryOutput,
@@ -25,26 +26,61 @@ type Options = QueryObserverOptions<
     FunctionKey.GET_ACCOUNT_TRANSACTION_HISTORY,
     TrimmedGetAccountTransactionHistoryInput & {
       chainId: ChainId;
+      vTokenAddresses: Address[];
     },
   ]
 >;
 
+// The query is combined with the pools one below, which means knowing whether it is enabled.
+// "enabled" is therefore narrowed to a boolean, since the predicate form react-query also accepts
+// could not be resolved here.
+type UseGetAccountTransactionHistoryOptions = Partial<Omit<Options, 'enabled'>> & {
+  enabled?: boolean;
+};
+
 export const useGetAccountTransactionHistory = (
   params: TrimmedGetAccountTransactionHistoryInput,
-  options?: Partial<Options>,
+  options?: UseGetAccountTransactionHistoryOptions,
 ) => {
   const { chainId } = useChainId();
-  const { data: getPoolsData } = useGetPools({ includeIsolatedPools: true });
-  const extendedParams = {
-    ...params,
-    getPoolsData,
-    liquidityHubs, // TODO: fetch from API
-    chainId,
-  };
-
-  return useQuery({
-    queryKey: [FunctionKey.GET_ACCOUNT_TRANSACTION_HISTORY, { ...params, chainId }],
-    queryFn: () => getAccountTransactionHistory(extendedParams),
-    ...options,
+  const { data: getPoolsData, isError: isGetPoolsError } = useGetPools({
+    includeIsolatedPools: true,
   });
+
+  // Transactions are formatted against the assets of the fetched pools, and any transaction
+  // referencing a vToken that is missing from them is discarded. The vToken addresses are
+  // therefore part of the query key, so the history is refetched whenever the pools resolve or
+  // their assets change. They are lowercased to mirror the mapping the query builds out of them,
+  // and sorted to output the same key when the pools are returned in a different order, which
+  // prevents unnecessary queries.
+  const vTokenAddresses = (getPoolsData?.pools || [])
+    .flatMap(pool => pool.assets.map(asset => asset.vToken.address.toLowerCase() as Address))
+    .sort();
+
+  const isEnabled = options?.enabled === undefined || options.enabled;
+  const arePoolsPending = !getPoolsData && !isGetPoolsError;
+
+  const queryResult = useQuery({
+    queryKey: [
+      FunctionKey.GET_ACCOUNT_TRANSACTION_HISTORY,
+      { ...params, chainId, vTokenAddresses },
+    ],
+    queryFn: () =>
+      getAccountTransactionHistory({
+        ...params,
+        getPoolsData,
+        liquidityHubs, // TODO: fetch from API
+        chainId,
+      }),
+    ...options,
+    // Wait for the pools to have been fetched, otherwise every transaction gets discarded
+    enabled: isEnabled && !!getPoolsData,
+  });
+
+  return {
+    ...queryResult,
+    // Keep reporting a loading state while the pools are being fetched, otherwise consumers
+    // briefly render an empty history
+    isLoading: queryResult.isLoading || (isEnabled && arePoolsPending),
+  };
 };


### PR DESCRIPTION
## Problem

`useGetAccountTransactionHistory` built its react-query key from `[FunctionKey.GET_ACCOUNT_TRANSACTION_HISTORY, { ...params, chainId }]`, while its query function closed over `getPoolsData` coming from its own `useGetPools({ includeIsolatedPools: true })` call.

That pools call passes no `accountAddress`, so it is a cache entry nothing else on the page warms — `pages/Dashboard/Transactions` itself fetches `useGetPools({ accountAddress, includeIsolatedPools: true })`, a different key. The account-less entry is therefore cold at every first mount, by construction:

1. the query function runs with `getPoolsData === undefined`;
2. `vTokenAssetMapping` comes out `{}` (`getAccountTransactionHistory/index.ts:64`);
3. `formatToMarketTransaction` hits its only early exit and returns `undefined` for every row (`formatApiTransaction/formatToMarketTransaction/index.ts:31`);
4. the empty result is cached under a key that does not change when the pools resolve, so nothing ever refetches.

The API serves the rows; the dashboard Transactions tab renders "No transactions yet" for every wallet-connected account with history. It does not recover on reload or on a Markets↔Transactions tab round-trip — only a type-filter round-trip more than 10s later (a new key plus a stale entry) brings the rows back.

## Fix

In `useGetAccountTransactionHistory`:

- Derive the pools' vToken addresses (lowercased, to mirror the mapping the query builds out of them, and sorted so a reordered payload does not produce a new key) and include them in the query key. The history is now refetched whenever the pools resolve or the listed assets change.
- Only run the query once the pools are actually available (`enabled: isEnabled && !!getPoolsData`), so it never fetches against an empty mapping — including on the pools-error path, where `isLoading` is `false` but the data is still `undefined`.
- Keep reporting `isLoading` while the pools are pending, so consumers show their spinner instead of briefly flashing the empty-state placeholder. It is gated on the caller's `enabled`, so a disconnected wallet still gets the placeholder rather than an endless spinner, and on the pools error so a hard pools failure resolves instead of spinning.
- Narrow the hook's `enabled` option to `boolean`. react-query v5 also accepts a `(query) => boolean` predicate, which cannot be resolved here and would have been silently dropped by the `&&` above.

No change was needed in the API layer, the components, or the QA suite's mocks.

## Files

| File | Change |
|---|---|
| `apps/evm/src/clients/api/queries/getAccountTransactionHistory/useGetAccountTransactionHistory.ts` | modified — query key marker, `enabled` gate, `isLoading` composition, narrowed options type |
| `apps/evm/src/clients/api/queries/getAccountTransactionHistory/__tests__/useGetAccountTransactionHistory.spec.ts` | added — 7 specs |

## Tests

New hook spec covering both halves of the fix. Each was verified to fail against the unfixed code:

- does not fetch while the pools are loading, and reports a loading state
- fetches with the pools once they have resolved
- fetches once the pools resolve after an initial render without them
- refetches when the assets of the pools change (fails if the key marker is removed)
- does not refetch when the assets are returned in a different order (fails if the `.sort()` is removed)
- does not fetch when the pools request failed, and does not spin forever
- does not report a loading state, and does not fetch, when the caller disables the query

## Gates

All four run end to end on this branch:

| Gate | Result |
|---|---|
| `yarn tsc` | pass — 3/3 packages |
| `yarn lint` | pass — 3/3 packages (16 pre-existing `useLiteralEnumMembers` warnings in `@venusprotocol/chains`, non-fatal) |
| `yarn extract-translations` | pass — no translation-file changes (no new user-facing copy) |
| `yarn test --coverage` | pass — evm 434 files / 1849 tests, chains 9 / 16. Coverage: statements 80.76, branches 86.05, functions 74.54, lines 80.76 (baseline 80.75 / 86.03 / 74.59 / 80.75) |

Note: `src/App/Routes/__tests__/index.spec.tsx` flaked once on an intermediate coverage run (a `findByText` timeout on a route whose page component is mocked, so it cannot reach this change). It passes in isolation and the final full run is green at 1849/1849. This flake is pre-existing and was already recorded before this ticket.

## Ticket

Multica VENUS-177 — Jira VPD-1580 cluster, 19 sub-tasks: VPD-1694, VPD-1733, VPD-1849, VPD-1872, VPD-1873, VPD-1874, VPD-1875, VPD-1876, VPD-1877, VPD-1883, VPD-1884, VPD-1885, VPD-1886, VPD-1887, VPD-1888, VPD-1889, VPD-1890, VPD-1891, VPD-1892 (TC-TXN-007 / 010–027).

## Follow-ups (not in this PR)

- This hook fetches `useGetPools({ includeIsolatedPools: true })` while `pages/Dashboard/Transactions` fetches `useGetPools({ accountAddress, includeIsolatedPools: true })` — two cache entries for what is nearly the same data, so the tab waits on a second pools round-trip. Consolidating them touches how pools are cached across the app and is out of scope here.
- `liquidityHubs` is still imported into app code from `__mocks__/models/liquidityHubs` (pre-existing `// TODO: fetch from API`). Worth a ticket reference on that TODO.
