### PR TITLE
feat: promote the liquidity hub in the top bar and landing page

### DIFF
--- a/apps/evm/src/containers/Layout/NavBar/__tests__/index.spec.tsx
+++ b/apps/evm/src/containers/Layout/NavBar/__tests__/index.spec.tsx
@@ -20,6 +20,7 @@ import walletConfig from 'libs/wallet/Web3Wrapper/config';
 import type { ChainId } from 'types';
 
 import { useStore } from 'containers/Layout/store';
+import TEST_IDS from 'containers/Layout/testIds';
 import { NavBar } from '..';
 
 const defaultChainId = walletConfig.chains[0]?.id as ChainId;
@@ -166,10 +167,31 @@ describe('NavBar', () => {
     expect(screen.getByTestId('nav-bar')).toHaveClass('custom-nav');
     expect(screen.getAllByAltText('Venus logo')).toHaveLength(2);
     expect(screen.getAllByText('Dashboard')).toHaveLength(2);
-    expect(screen.getAllByText('Markets').length).toBeGreaterThan(1);
+    expect(screen.getAllByText('Borrow').length).toBeGreaterThan(1);
+    expect(screen.queryByText('Markets')).toBeNull();
     expect(screen.getAllByText('Earn').length).toBeGreaterThan(1);
     expect(screen.getByRole('button', { name: 'Connect wallet' })).toBeInTheDocument();
     expect(container.querySelector('button.hidden.lg\\:flex')).not.toBeNull();
+  });
+
+  it('renders the dashboard link on the right, ahead of the reward claim button', () => {
+    renderNavBar();
+
+    const menu = screen.getByTestId(TEST_IDS.navBarMenu);
+    const actions = screen.getByTestId(TEST_IDS.navBarActions);
+
+    // The dashboard has moved out of the left menu and into the right hand group
+    expect(menu.textContent).not.toContain('Dashboard');
+    expect(actions.textContent).toContain('Dashboard');
+
+    // Everything the right hand group renders after the dashboard - the reward claim button, the
+    // chain select and the connect button - comes later in the DOM, so the dashboard sits to its left
+    const dashboardLink = screen.getAllByText('Dashboard').find(el => actions.contains(el));
+    expect(actions.firstElementChild?.contains(dashboardLink as HTMLElement)).toBe(true);
+
+    // It is still reachable from the mobile menu
+    const mobileMenu = screen.getByText('Menu').closest('div')?.parentElement as HTMLDivElement;
+    expect(mobileMenu.textContent).toContain('Dashboard');
   });
 
   it('hides the desktop settings button when the user is connected', () => {

--- a/apps/evm/src/containers/Layout/NavBar/index.tsx
+++ b/apps/evm/src/containers/Layout/NavBar/index.tsx
@@ -10,6 +10,7 @@ import { useTranslation } from 'libs/translations';
 import { useAccountAddress } from 'libs/wallet';
 import { useEffect } from 'react';
 import { useStore } from '../store';
+import TEST_IDS from '../testIds';
 import { ChainSelect } from './ChainSelect';
 import { ClaimRewardsButton } from './ClaimRewardsButton';
 import { ConnectButton } from './ConnectButton';
@@ -17,7 +18,7 @@ import { MenuItem } from './MenuItem';
 import { NavButtonWrapper } from './NavButtonWrapper';
 import { Settings } from './Settings';
 import { SettingsButton } from './SettingsButton';
-import { useMenuItems } from './useMenuItems';
+import { useDashboardMenuItem, useMenuItems } from './useMenuItems';
 
 export type NavBarProps = React.HTMLAttributes<HTMLDivElement>;
 
@@ -57,6 +58,7 @@ export const NavBar: React.FC<NavBarProps> = ({ className, ...containerProps }) 
   }, [isMobileMenuOpen]);
 
   const menuItems = useMenuItems();
+  const dashboardMenuItem = useDashboardMenuItem();
 
   return (
     <nav className="relative">
@@ -83,14 +85,20 @@ export const NavBar: React.FC<NavBarProps> = ({ className, ...containerProps }) 
           </Link>
 
           {/* LG and up menu */}
-          <div className="hidden items-center lg:flex xl:gap-x-3">
+          <div className="hidden items-center lg:flex xl:gap-x-3" data-testid={TEST_IDS.navBarMenu}>
             {menuItems.map(item => (
               <MenuItem key={item.label} item={item} onClick={closeMobileMenu} />
             ))}
           </div>
         </div>
 
-        <div className="flex items-center gap-x-3 h-9 sm:h-12">
+        <div className="flex items-center gap-x-3 h-9 sm:h-12" data-testid={TEST_IDS.navBarActions}>
+          {/* Sits to the left of the reward claim button, and only from the breakpoint the desktop
+              menu appears at: below that, the dashboard is reachable from the mobile menu */}
+          <div className="hidden items-center lg:flex">
+            <MenuItem item={dashboardMenuItem} onClick={closeMobileMenu} />
+          </div>
+
           <ClaimRewardsButton className="h-full hidden sm:flex" data-rewards-button="true" />
 
           <ChainSelect buttonClassName="h-10 px-3 py-0 bg-dark-blue border-dark-blue-disabled/50 hover:bg-dark-blue-hover hover:border-dark-blue-disabled/50 hover:no-underline active:bg-dark-blue-hover sm:h-12" />
@@ -123,7 +131,7 @@ export const NavBar: React.FC<NavBarProps> = ({ className, ...containerProps }) 
         </div>
 
         <div className="mb-2">
-          {menuItems.map(item => (
+          {[dashboardMenuItem, ...menuItems].map(item => (
             <MenuItem key={item.label} item={item} onClick={closeMobileMenu} />
           ))}
         </div>

--- a/apps/evm/src/containers/Layout/NavBar/useMenuItems/index.tsx
+++ b/apps/evm/src/containers/Layout/NavBar/useMenuItems/index.tsx
@@ -11,6 +11,15 @@ import { useGetMarketsPagePath } from 'hooks/useGetMarketsPagePath';
 import { useTranslation } from 'libs/translations';
 import type { MenuItem, SubMenu } from '../types';
 
+export const useDashboardMenuItem = (): MenuItem => {
+  const { t } = useTranslation();
+
+  return {
+    to: routes.dashboard.path,
+    label: t('layout.menu.dashboard.label'),
+  };
+};
+
 export const useMenuItems = () => {
   const { t } = useTranslation();
   const { accountAddress } = useAccountAddress();
@@ -25,13 +34,8 @@ export const useMenuItems = () => {
 
   const menu: Array<MenuItem | SubMenu> = [];
 
-  menu.push({
-    to: routes.dashboard.path,
-    label: t('layout.menu.dashboard.label'),
-  });
-
-  const marketsSubMenu: SubMenu = {
-    label: t('layout.menu.markets.label'),
+  const borrowSubMenu: SubMenu = {
+    label: t('layout.menu.borrow.label'),
     variant: 'secondary',
     items: [
       {
@@ -71,10 +75,10 @@ export const useMenuItems = () => {
           },
         ],
       },
-      marketsSubMenu,
+      borrowSubMenu,
     );
   } else {
-    menu.push(marketsSubMenu, {
+    menu.push(borrowSubMenu, {
       to: routes.vaults.path,
       label: t('layout.menu.vaults.label'),
     });

--- a/apps/evm/src/containers/Layout/testIds.ts
+++ b/apps/evm/src/containers/Layout/testIds.ts
@@ -5,4 +5,6 @@ export default {
   claimExternalRewardBreakdown: 'layout-claim-external-reward-breakdown',
   claimRewardSubmitButton: 'layout-claim-reward-submit-button',
   claimRewardExternalRewards: 'layout-claim-reward-external-rewards',
+  navBarMenu: 'layout-nav-bar-menu',
+  navBarActions: 'layout-nav-bar-actions',
 };

--- a/apps/evm/src/libs/translations/translations/en.json
+++ b/apps/evm/src/libs/translations/translations/en.json
@@ -748,6 +748,7 @@
       "borrow": "Borrow",
       "earned": "Earned",
       "earnedAmount": "Earned {{amount}}",
+      "earnNow": "Earn now",
       "from": "From {{percentage}}",
       "highestApy": "Highest APY",
       "monthNo": "Month {{number}}",
@@ -821,6 +822,9 @@
     },
     "menu": {
       "beta": "beta",
+      "borrow": {
+        "label": "Borrow"
+      },
       "dashboard": {
         "label": "Dashboard"
       },
@@ -828,9 +832,6 @@
         "label": "Earn"
       },
       "label": "Menu",
-      "markets": {
-        "label": "Markets"
-      },
       "new": "New",
       "others": {
         "bridge": {

--- a/apps/evm/src/libs/translations/translations/ja.json
+++ b/apps/evm/src/libs/translations/translations/ja.json
@@ -747,7 +747,7 @@
       "borrow": "借入",
       "earned": "獲得済み",
       "earnedAmount": "獲得済み {{amount}}",
-      "earnNow": "TRANSLATION NEEDED",
+      "earnNow": "今すぐ運用する",
       "from": "{{percentage}}から",
       "highestApy": "最高APY",
       "monthNo": "第{{number}}月",
@@ -822,7 +822,7 @@
     "menu": {
       "beta": "beta",
       "borrow": {
-        "label": "TRANSLATION NEEDED"
+        "label": "借入"
       },
       "dashboard": {
         "label": "ダッシュボード"

--- a/apps/evm/src/libs/translations/translations/ja.json
+++ b/apps/evm/src/libs/translations/translations/ja.json
@@ -747,6 +747,7 @@
       "borrow": "借入",
       "earned": "獲得済み",
       "earnedAmount": "獲得済み {{amount}}",
+      "earnNow": "TRANSLATION NEEDED",
       "from": "{{percentage}}から",
       "highestApy": "最高APY",
       "monthNo": "第{{number}}月",
@@ -820,6 +821,9 @@
     },
     "menu": {
       "beta": "beta",
+      "borrow": {
+        "label": "TRANSLATION NEEDED"
+      },
       "dashboard": {
         "label": "ダッシュボード"
       },
@@ -827,9 +831,6 @@
         "label": "獲得"
       },
       "label": "メニュー",
-      "markets": {
-        "label": "マーケット"
-      },
       "new": "新規",
       "others": {
         "bridge": {

--- a/apps/evm/src/libs/translations/translations/th.json
+++ b/apps/evm/src/libs/translations/translations/th.json
@@ -747,6 +747,7 @@
       "borrow": "ยืม",
       "earned": "ได้รับ",
       "earnedAmount": "ได้รับ {{amount}}",
+      "earnNow": "TRANSLATION NEEDED",
       "from": "จาก {{percentage}}",
       "highestApy": "APY สูงสุด",
       "monthNo": "เดือน {{number}}",
@@ -820,6 +821,9 @@
     },
     "menu": {
       "beta": "beta",
+      "borrow": {
+        "label": "TRANSLATION NEEDED"
+      },
       "dashboard": {
         "label": "แดชบอร์ด"
       },
@@ -827,9 +831,6 @@
         "label": "รับผลตอบแทน"
       },
       "label": "เมนู",
-      "markets": {
-        "label": "ตลาด"
-      },
       "new": "ใหม่",
       "others": {
         "bridge": {

--- a/apps/evm/src/libs/translations/translations/th.json
+++ b/apps/evm/src/libs/translations/translations/th.json
@@ -747,7 +747,7 @@
       "borrow": "ยืม",
       "earned": "ได้รับ",
       "earnedAmount": "ได้รับ {{amount}}",
-      "earnNow": "TRANSLATION NEEDED",
+      "earnNow": "รับผลตอบแทนตอนนี้",
       "from": "จาก {{percentage}}",
       "highestApy": "APY สูงสุด",
       "monthNo": "เดือน {{number}}",
@@ -822,7 +822,7 @@
     "menu": {
       "beta": "beta",
       "borrow": {
-        "label": "TRANSLATION NEEDED"
+        "label": "ยืม"
       },
       "dashboard": {
         "label": "แดชบอร์ด"

--- a/apps/evm/src/libs/translations/translations/tr.json
+++ b/apps/evm/src/libs/translations/translations/tr.json
@@ -748,7 +748,7 @@
       "borrow": "Borç al",
       "earned": "Kazanılan",
       "earnedAmount": "Kazanılan {{amount}}",
-      "earnNow": "TRANSLATION NEEDED",
+      "earnNow": "Şimdi kazan",
       "from": "{{percentage}}'den",
       "highestApy": "En yüksek APY",
       "monthNo": "{{number}}. ay",
@@ -823,7 +823,7 @@
     "menu": {
       "beta": "beta",
       "borrow": {
-        "label": "TRANSLATION NEEDED"
+        "label": "Borç al"
       },
       "dashboard": {
         "label": "Gösterge paneli"

--- a/apps/evm/src/libs/translations/translations/tr.json
+++ b/apps/evm/src/libs/translations/translations/tr.json
@@ -748,6 +748,7 @@
       "borrow": "Borç al",
       "earned": "Kazanılan",
       "earnedAmount": "Kazanılan {{amount}}",
+      "earnNow": "TRANSLATION NEEDED",
       "from": "{{percentage}}'den",
       "highestApy": "En yüksek APY",
       "monthNo": "{{number}}. ay",
@@ -821,6 +822,9 @@
     },
     "menu": {
       "beta": "beta",
+      "borrow": {
+        "label": "TRANSLATION NEEDED"
+      },
       "dashboard": {
         "label": "Gösterge paneli"
       },
@@ -828,9 +832,6 @@
         "label": "Kazan"
       },
       "label": "Menü",
-      "markets": {
-        "label": "Piyasalar"
-      },
       "new": "Yeni",
       "others": {
         "bridge": {

--- a/apps/evm/src/libs/translations/translations/vi.json
+++ b/apps/evm/src/libs/translations/translations/vi.json
@@ -747,7 +747,7 @@
       "borrow": "Vay",
       "earned": "Đã kiếm",
       "earnedAmount": "Đã kiếm {{amount}}",
-      "earnNow": "TRANSLATION NEEDED",
+      "earnNow": "Kiếm lợi nhuận ngay",
       "from": "Từ {{percentage}}",
       "highestApy": "APY cao nhất",
       "monthNo": "Tháng {{number}}",
@@ -822,7 +822,7 @@
     "menu": {
       "beta": "beta",
       "borrow": {
-        "label": "TRANSLATION NEEDED"
+        "label": "Vay"
       },
       "dashboard": {
         "label": "Bảng điều khiển"

--- a/apps/evm/src/libs/translations/translations/vi.json
+++ b/apps/evm/src/libs/translations/translations/vi.json
@@ -747,6 +747,7 @@
       "borrow": "Vay",
       "earned": "Đã kiếm",
       "earnedAmount": "Đã kiếm {{amount}}",
+      "earnNow": "TRANSLATION NEEDED",
       "from": "Từ {{percentage}}",
       "highestApy": "APY cao nhất",
       "monthNo": "Tháng {{number}}",
@@ -820,6 +821,9 @@
     },
     "menu": {
       "beta": "beta",
+      "borrow": {
+        "label": "TRANSLATION NEEDED"
+      },
       "dashboard": {
         "label": "Bảng điều khiển"
       },
@@ -827,9 +831,6 @@
         "label": "Kiếm lợi nhuận"
       },
       "label": "Trình đơn",
-      "markets": {
-        "label": "Thị trường"
-      },
       "new": "Mới",
       "others": {
         "bridge": {

--- a/apps/evm/src/libs/translations/translations/zh-Hans.json
+++ b/apps/evm/src/libs/translations/translations/zh-Hans.json
@@ -747,7 +747,7 @@
       "borrow": "借款",
       "earned": "已赚取",
       "earnedAmount": "已赚取 {{amount}}",
-      "earnNow": "TRANSLATION NEEDED",
+      "earnNow": "立即赚取",
       "from": "来自 {{percentage}}",
       "highestApy": "最高 APY",
       "monthNo": "第 {{number}} 个月",
@@ -822,7 +822,7 @@
     "menu": {
       "beta": "beta",
       "borrow": {
-        "label": "TRANSLATION NEEDED"
+        "label": "借款"
       },
       "dashboard": {
         "label": "仪表盘"

--- a/apps/evm/src/libs/translations/translations/zh-Hans.json
+++ b/apps/evm/src/libs/translations/translations/zh-Hans.json
@@ -747,6 +747,7 @@
       "borrow": "借款",
       "earned": "已赚取",
       "earnedAmount": "已赚取 {{amount}}",
+      "earnNow": "TRANSLATION NEEDED",
       "from": "来自 {{percentage}}",
       "highestApy": "最高 APY",
       "monthNo": "第 {{number}} 个月",
@@ -820,6 +821,9 @@
     },
     "menu": {
       "beta": "beta",
+      "borrow": {
+        "label": "TRANSLATION NEEDED"
+      },
       "dashboard": {
         "label": "仪表盘"
       },
@@ -827,9 +831,6 @@
         "label": "赚取"
       },
       "label": "菜单",
-      "markets": {
-        "label": "市场"
-      },
       "new": "新",
       "others": {
         "bridge": {

--- a/apps/evm/src/libs/translations/translations/zh-Hant.json
+++ b/apps/evm/src/libs/translations/translations/zh-Hant.json
@@ -747,7 +747,7 @@
       "borrow": "借款",
       "earned": "已賺取",
       "earnedAmount": "已賺取 {{amount}}",
-      "earnNow": "TRANSLATION NEEDED",
+      "earnNow": "立即賺取",
       "from": "來自 {{percentage}}",
       "highestApy": "最高 APY",
       "monthNo": "第 {{number}} 個月",
@@ -822,7 +822,7 @@
     "menu": {
       "beta": "beta",
       "borrow": {
-        "label": "TRANSLATION NEEDED"
+        "label": "借款"
       },
       "dashboard": {
         "label": "儀表盤"

--- a/apps/evm/src/libs/translations/translations/zh-Hant.json
+++ b/apps/evm/src/libs/translations/translations/zh-Hant.json
@@ -747,6 +747,7 @@
       "borrow": "借款",
       "earned": "已賺取",
       "earnedAmount": "已賺取 {{amount}}",
+      "earnNow": "TRANSLATION NEEDED",
       "from": "來自 {{percentage}}",
       "highestApy": "最高 APY",
       "monthNo": "第 {{number}} 個月",
@@ -820,6 +821,9 @@
     },
     "menu": {
       "beta": "beta",
+      "borrow": {
+        "label": "TRANSLATION NEEDED"
+      },
       "dashboard": {
         "label": "儀表盤"
       },
@@ -827,9 +831,6 @@
         "label": "賺取"
       },
       "label": "菜單",
-      "markets": {
-        "label": "市場"
-      },
       "new": "新",
       "others": {
         "bridge": {

--- a/apps/evm/src/pages/Landing/Hero/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Landing/Hero/__tests__/index.spec.tsx
@@ -1,7 +1,10 @@
 import { renderComponent } from 'testUtils/render';
 
 import { fireEvent } from '@testing-library/react';
+import { routes } from 'constants/routing';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { en } from 'libs/translations';
+import type { Mock } from 'vitest';
 import { Hero } from '..';
 
 vi.mock('../Galaxy', () => ({
@@ -22,5 +25,27 @@ describe('Hero', () => {
     fireEvent.click(getByText(en.landing.hero.borrow));
 
     expect(container.textContent).toMatchSnapshot();
+  });
+
+  it('sends the call to action to the liquidity hub when it is enabled', () => {
+    (useIsFeatureEnabled as Mock).mockImplementation(
+      ({ name }: { name: string }) => name === 'liquidityHub',
+    );
+
+    const { getByText, queryByText } = renderComponent(<Hero />);
+
+    expect(queryByText(en.landing.hero.startNow)).toBeNull();
+    expect(getByText(en.landing.hero.earnNow).getAttribute('href')).toContain(
+      routes.liquidityHubs.path,
+    );
+  });
+
+  it('sends the call to action to the core markets when the liquidity hub is disabled', () => {
+    const { getByText, queryByText } = renderComponent(<Hero />);
+
+    expect(queryByText(en.landing.hero.earnNow)).toBeNull();
+    expect(getByText(en.landing.hero.startNow).getAttribute('href')).toContain(
+      routes.markets.path.replace(':poolComptrollerAddress', ''),
+    );
   });
 });

--- a/apps/evm/src/pages/Landing/Hero/index.tsx
+++ b/apps/evm/src/pages/Landing/Hero/index.tsx
@@ -1,8 +1,10 @@
 import { useGetMarketsTvl } from 'clients/api/queries/getMarketsTvl/useGetMarketsTvl';
 import { ButtonWrapper, Wrapper } from 'components';
+import { routes } from 'constants/routing';
 import { Link } from 'containers/Link';
 import { useBreakpointUp } from 'hooks/responsive';
 import { useGetMarketsPagePath } from 'hooks/useGetMarketsPagePath';
+import { useIsFeatureEnabled } from 'hooks/useIsFeatureEnabled';
 import { useTranslation } from 'libs/translations';
 import { formatCentsToReadableValue } from 'utilities';
 import { Galaxy } from './Galaxy';
@@ -20,6 +22,10 @@ export const Hero: React.FC = () => {
   });
 
   const { marketsPagePath } = useGetMarketsPagePath();
+
+  // The liquidity hub gets top billing where it exists. It is not deployed on every chain, and the
+  // same flag gates its route, so elsewhere the call to action still points at the core markets
+  const liquidityHubEnabled = useIsFeatureEnabled({ name: 'liquidityHub' });
 
   const isMdOrUp = useBreakpointUp('md');
 
@@ -58,8 +64,11 @@ export const Hero: React.FC = () => {
               <div className="text-h5 sm:text-h3">{readableMarketsTvl}</div>
 
               <ButtonWrapper asChild variant="primary" className="mt-6 py-2 px-20">
-                <Link to={marketsPagePath} noStyle>
-                  {t('landing.hero.startNow')}
+                <Link
+                  to={liquidityHubEnabled ? routes.liquidityHubs.path : marketsPagePath}
+                  noStyle
+                >
+                  {liquidityHubEnabled ? t('landing.hero.earnNow') : t('landing.hero.startNow')}
                 </Link>
               </ButtonWrapper>
             </div>


### PR DESCRIPTION
## Jira ticket(s)

VPD-1912

## Changes

- Moved the `Dashboard` entry from the left of the top bar to the right, just ahead of the reward claim button, and renamed the `Markets` menu to `Borrow`.
- Pointed the landing page call to action at the liquidity hub as "Earn now", keeping the previous "Start now" link to the core markets on chains where the hub is not deployed.
