### PR TITLE
fix: reset the vault filters when the chain changes

### DIFF
--- a/apps/evm/src/pages/Vaults/VaultList/hooks/useFilterOptions.tsx
+++ b/apps/evm/src/pages/Vaults/VaultList/hooks/useFilterOptions.tsx
@@ -5,11 +5,9 @@ import { useSearchParams } from 'react-router';
 import { VaultCategory, VaultStatus, VaultVenue } from 'types';
 import { getVaultCategoryName } from 'utilities/getVaultCategoryName';
 
+import { CATEGORY_PARAM_KEY, STATUS_PARAM_KEY, VENUE_PARAM_KEY } from '../../constants';
+import { deleteFilterSearchParams } from '../../utilities/deleteFilterSearchParams';
 import institutionIconSrc from '../asset/institution.svg';
-
-const CATEGORY_PARAM_KEY = 'category';
-const VENUE_PARAM_KEY = 'venue';
-const STATUS_PARAM_KEY = 'status';
 
 const PARAM_VALUE_SEPARATOR = ',';
 
@@ -194,19 +192,7 @@ export const useFilterOptions = () => {
   const setStatuses = (newValues: string[]) =>
     setParamValues(STATUS_PARAM_KEY, newValues, selectableStatuses);
 
-  const reset = () =>
-    setSearchParams(
-      currentSearchParams => {
-        const newSearchParams = new URLSearchParams(currentSearchParams);
-
-        newSearchParams.delete(CATEGORY_PARAM_KEY);
-        newSearchParams.delete(VENUE_PARAM_KEY);
-        newSearchParams.delete(STATUS_PARAM_KEY);
-
-        return newSearchParams;
-      },
-      { replace: true },
-    );
+  const reset = () => setSearchParams(deleteFilterSearchParams, { replace: true });
 
   return {
     categories,

--- a/apps/evm/src/pages/Vaults/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Vaults/__tests__/index.spec.tsx
@@ -24,7 +24,10 @@ describe('Vaults', () => {
   const getFilterOption = (label: string) => screen.getAllByRole('button', { name: label }).at(-1)!;
 
   // Mirrors useSwitchChain: the chain the app resolves changes, and the new chain is
-  // written to the url
+  // written to the url. The mock has to be overridden from inside the handler rather than
+  // from beforeEach, because renderComponent's wrapper re-applies its own implementation on
+  // every wrapper render; MemoryRouter lives inside that wrapper, so a navigation never
+  // re-renders it and the override sticks
   const ChainSwitcher: React.FC<{ chainId: ChainId }> = ({ chainId }) => {
     const [, setSearchParams] = useSearchParams();
 

--- a/apps/evm/src/pages/Vaults/__tests__/index.spec.tsx
+++ b/apps/evm/src/pages/Vaults/__tests__/index.spec.tsx
@@ -1,11 +1,13 @@
 import { fireEvent, screen, waitFor } from '@testing-library/react';
-import { useLocation, useNavigationType } from 'react-router';
+import { useLocation, useNavigate, useNavigationType, useSearchParams } from 'react-router';
 import type { Mock } from 'vitest';
 
 import { institutionalVault, pendleBnbVault, vaults as venusVaults } from '__mocks__/models/vaults';
 import { en, t } from 'libs/translations';
+import { useChainId } from 'libs/wallet';
+import { CHAIN_ID_SEARCH_PARAM } from 'libs/wallet/constants';
 import { renderComponent } from 'testUtils/render';
-import { type InstitutionalVault, VaultStatus } from 'types';
+import { ChainId, type InstitutionalVault, VaultStatus } from 'types';
 
 import { useGetVaults } from 'clients/api';
 
@@ -20,6 +22,29 @@ describe('Vaults', () => {
   // button carrying the label, and the modal copy of an option always the last one.
   const getFilterTrigger = (label: string) => screen.getAllByRole('button', { name: label })[0];
   const getFilterOption = (label: string) => screen.getAllByRole('button', { name: label }).at(-1)!;
+
+  // Mirrors useSwitchChain: the chain the app resolves changes, and the new chain is
+  // written to the url
+  const ChainSwitcher: React.FC<{ chainId: ChainId }> = ({ chainId }) => {
+    const [, setSearchParams] = useSearchParams();
+
+    const handleClick = () => {
+      (useChainId as Mock).mockReturnValue({ chainId });
+
+      setSearchParams(currentSearchParams => {
+        const newSearchParams = new URLSearchParams(currentSearchParams);
+        newSearchParams.set(CHAIN_ID_SEARCH_PARAM, String(chainId));
+
+        return newSearchParams;
+      });
+    };
+
+    return (
+      <button type="button" onClick={handleClick}>
+        switch chain
+      </button>
+    );
+  };
 
   beforeEach(() => {
     vi.useFakeTimers();
@@ -350,6 +375,149 @@ describe('Vaults', () => {
     expect(getByText('XVS', { selector: titleSelector })).toBeInTheDocument();
     expect(getByText('VAI', { selector: titleSelector })).toBeInTheDocument();
     expect(getByText(en.vault.modals.depositPeriodEnds)).toBeInTheDocument();
+  });
+
+  it('resets the filters and the search field when the chain changes', () => {
+    const { getByPlaceholderText, getByText } = renderComponent(
+      <>
+        <VaultsPage />
+
+        <ChainSwitcher chainId={ChainId.SEPOLIA} />
+      </>,
+      { routerInitialEntries: ['/?category=governance&venue=venus'] },
+    );
+
+    fireEvent.change(getByPlaceholderText(en.vault.filter.inputPlaceholder), {
+      target: { value: 'xvs' },
+    });
+
+    expect(getFilterTrigger(en.vault.category.governance)).toBeInTheDocument();
+
+    fireEvent.click(getByText('switch chain'));
+
+    expect(getByText(en.vault.filter.allCategories)).toBeInTheDocument();
+    expect(getByText(en.vault.filter.allVenues)).toBeInTheDocument();
+    expect(getByText(en.vault.filter.allStates)).toBeInTheDocument();
+    expect(getByPlaceholderText(en.vault.filter.inputPlaceholder)).toHaveValue('');
+    expect(getByText('XVS', { selector: titleSelector })).toBeInTheDocument();
+    expect(getByText('VAI', { selector: titleSelector })).toBeInTheDocument();
+    expect(getByText(en.vault.modals.depositPeriodEnds)).toBeInTheDocument();
+  });
+
+  it('clears the filter parameters from the url when the chain changes', () => {
+    const SearchDisplay = () => <div data-testid="search">{useLocation().search}</div>;
+
+    const { getByText } = renderComponent(
+      <>
+        <VaultsPage />
+
+        <ChainSwitcher chainId={ChainId.SEPOLIA} />
+
+        <SearchDisplay />
+      </>,
+      { routerInitialEntries: ['/?category=governance&venue=venus'] },
+    );
+
+    fireEvent.click(getByText('switch chain'));
+
+    const searchParams = new URLSearchParams(screen.getByTestId('search').textContent ?? '');
+
+    expect(searchParams.get('category')).toBeNull();
+    expect(searchParams.get('venue')).toBeNull();
+    // Only the filters are cleared, the chain the user switched to is kept
+    expect(searchParams.get(CHAIN_ID_SEARCH_PARAM)).toBe(String(ChainId.SEPOLIA));
+  });
+
+  it("resets the filters while the new chain's vaults are still loading", () => {
+    const SearchDisplay = () => <div data-testid="search">{useLocation().search}</div>;
+
+    const { getByText } = renderComponent(
+      <>
+        <VaultsPage />
+
+        <ChainSwitcher chainId={ChainId.SEPOLIA} />
+
+        <SearchDisplay />
+      </>,
+      { routerInitialEntries: ['/?category=governance&venue=venus'] },
+    );
+
+    // The page falls back to a spinner while the new chain's vaults load, which unmounts
+    // VaultList: the reset has to happen above it
+    (useGetVaults as Mock).mockImplementation(() => ({
+      data: [],
+      isLoading: true,
+    }));
+
+    fireEvent.click(getByText('switch chain'));
+
+    const searchParams = new URLSearchParams(screen.getByTestId('search').textContent ?? '');
+
+    expect(searchParams.get('category')).toBeNull();
+    expect(searchParams.get('venue')).toBeNull();
+  });
+
+  it('keeps the filters restored by a back navigation', () => {
+    const SearchDisplay = () => <div data-testid="search">{useLocation().search}</div>;
+
+    const BackButton = ({ chainId }: { chainId: ChainId }) => {
+      const navigate = useNavigate();
+
+      const handleClick = () => {
+        (useChainId as Mock).mockReturnValue({ chainId });
+        navigate(-1);
+      };
+
+      return (
+        <button type="button" onClick={handleClick}>
+          go back
+        </button>
+      );
+    };
+
+    const { getByText } = renderComponent(
+      <>
+        <VaultsPage />
+
+        <ChainSwitcher chainId={ChainId.SEPOLIA} />
+
+        <BackButton chainId={ChainId.BSC_TESTNET} />
+
+        <SearchDisplay />
+      </>,
+      {
+        routerInitialEntries: [
+          `/?${CHAIN_ID_SEARCH_PARAM}=${ChainId.BSC_TESTNET}&category=governance`,
+        ],
+      },
+    );
+
+    fireEvent.click(getByText('switch chain'));
+    fireEvent.click(getByText('go back'));
+
+    // Going back restores the entry the filters belonged to, so it must be left alone
+    // rather than rewritten in place
+    expect(
+      new URLSearchParams(screen.getByTestId('search').textContent ?? '').get('category'),
+    ).toBe('governance');
+    expect(getFilterTrigger(en.vault.category.governance)).toBeInTheDocument();
+  });
+
+  it('keeps the filters coming from the url when the chain does not change', () => {
+    const { getByText, queryByText } = renderComponent(
+      <>
+        <VaultsPage />
+
+        <ChainSwitcher chainId={ChainId.BSC_TESTNET} />
+      </>,
+      { routerInitialEntries: ['/?category=governance'] },
+    );
+
+    fireEvent.click(getByText('switch chain'));
+
+    expect(getFilterTrigger(en.vault.category.governance)).toBeInTheDocument();
+    expect(getByText('XVS', { selector: titleSelector })).toBeInTheDocument();
+    expect(queryByText('VAI', { selector: titleSelector })).not.toBeInTheDocument();
   });
 
   it.each([

--- a/apps/evm/src/pages/Vaults/constants.ts
+++ b/apps/evm/src/pages/Vaults/constants.ts
@@ -1,0 +1,6 @@
+export const CATEGORY_PARAM_KEY = 'category';
+export const VENUE_PARAM_KEY = 'venue';
+export const STATUS_PARAM_KEY = 'status';
+
+// Every group the user can filter on, so clearing all of them stays in one place
+export const FILTER_PARAM_KEYS = [CATEGORY_PARAM_KEY, VENUE_PARAM_KEY, STATUS_PARAM_KEY] as const;

--- a/apps/evm/src/pages/Vaults/hooks/useResetFiltersOnChainChange/index.ts
+++ b/apps/evm/src/pages/Vaults/hooks/useResetFiltersOnChainChange/index.ts
@@ -1,0 +1,53 @@
+import config from 'config';
+import { useAccountChainId, useChainId } from 'libs/wallet';
+import { useEffect, useRef } from 'react';
+import { NavigationType, useNavigationType, useSearchParams } from 'react-router';
+
+import { FILTER_PARAM_KEYS } from '../../constants';
+import { deleteFilterSearchParams } from '../../utilities/deleteFilterSearchParams';
+
+// Vaults are chain specific, so a selection made on one chain rarely matches anything on
+// the next one: clear the filters whenever the chain changes.
+//
+// This lives on the page rather than on VaultList because VaultList is unmounted while the
+// new chain's vaults load, which would lose track of the chain the filters were picked on.
+export const useResetFiltersOnChainChange = () => {
+  const { chainId } = useChainId();
+  const { chainId: accountChainId } = useAccountChainId();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const navigationType = useNavigationType();
+
+  // In the Safe app the active chain comes from the wallet and only resolves after the
+  // first render, until when useChainId falls back to the default chain: that fallback is
+  // not a chain the user picked. Seeded with the current chain rather than reusing
+  // usePrevious, whose ref starts undefined and would report a change on the first render
+  const previousChainIdRef = useRef(config.isSafeApp && !accountChainId ? undefined : chainId);
+
+  useEffect(() => {
+    if (previousChainIdRef.current === chainId) {
+      return;
+    }
+
+    const isFirstResolvedChainId = previousChainIdRef.current === undefined;
+    previousChainIdRef.current = chainId;
+
+    if (isFirstResolvedChainId) {
+      return;
+    }
+
+    // A back or forward navigation restores the filters that belong to the history entry it
+    // lands on, so there is nothing to reset. In the Safe app the chain comes from the
+    // wallet rather than from a navigation, so the navigation type says nothing about it
+    if (!config.isSafeApp && navigationType === NavigationType.Pop) {
+      return;
+    }
+
+    if (!FILTER_PARAM_KEYS.some(key => searchParams.has(key))) {
+      return;
+    }
+
+    // Consistent with the filter controls themselves, which replace the current history
+    // entry rather than pushing a new one
+    setSearchParams(deleteFilterSearchParams, { replace: true });
+  }, [chainId, navigationType, searchParams, setSearchParams]);
+};

--- a/apps/evm/src/pages/Vaults/index.tsx
+++ b/apps/evm/src/pages/Vaults/index.tsx
@@ -1,15 +1,19 @@
 import { useGetVaults } from 'clients/api';
 import { Page, Spinner } from 'components';
-import { useAccountAddress } from 'libs/wallet';
+import { useAccountAddress, useChainId } from 'libs/wallet';
 
 import { useSortVaults } from 'hooks/useSortVaults';
 import { VaultList } from './VaultList';
+import { useResetFiltersOnChainChange } from './hooks/useResetFiltersOnChainChange';
 
 const VaultsPage: React.FC = () => {
   const { accountAddress } = useAccountAddress();
+  const { chainId } = useChainId();
   const { data: vaults, isLoading: isGetVaultsLoading } = useGetVaults({
     accountAddress,
   });
+
+  useResetFiltersOnChainChange();
 
   // Sort vaults
   const sortedVaults = useSortVaults({
@@ -22,7 +26,8 @@ const VaultsPage: React.FC = () => {
 
   return (
     <Page>
-      <VaultList vaults={sortedVaults} />
+      {/* Remounting on chain change also clears the search field, which VaultList owns */}
+      <VaultList key={chainId} vaults={sortedVaults} />
     </Page>
   );
 };

--- a/apps/evm/src/pages/Vaults/utilities/deleteFilterSearchParams/index.ts
+++ b/apps/evm/src/pages/Vaults/utilities/deleteFilterSearchParams/index.ts
@@ -1,0 +1,8 @@
+import { FILTER_PARAM_KEYS } from '../../constants';
+
+export const deleteFilterSearchParams = (currentSearchParams: URLSearchParams) => {
+  const newSearchParams = new URLSearchParams(currentSearchParams);
+  FILTER_PARAM_KEYS.forEach(key => newSearchParams.delete(key));
+
+  return newSearchParams;
+};


### PR DESCRIPTION
## Jira ticket(s)

VPD-1956

## Changes

- Reset the vault category, venue and state filters, along with the search field, whenever the user switches chain, since a selection made on one chain rarely matches anything on the next one
