### PR TITLE
fix: stop health bar marks painting over the token list dropdown

### DIFF
--- a/.changeset/cuddly-berries-mate.md
+++ b/.changeset/cuddly-berries-mate.md
@@ -1,0 +1,5 @@
+---
+"@venusprotocol/evm": minor
+---
+
+feat: update heathy bar z-index

--- a/.changeset/cuddly-berries-mate.md
+++ b/.changeset/cuddly-berries-mate.md
@@ -2,4 +2,4 @@
 "@venusprotocol/evm": minor
 ---
 
-feat: update heathy bar z-index
+feat: update health bar z-index

--- a/apps/evm/src/components/ProgressBar/__tests__/index.spec.tsx
+++ b/apps/evm/src/components/ProgressBar/__tests__/index.spec.tsx
@@ -20,7 +20,7 @@ describe('ProgressBar', () => {
     const rail = container.firstElementChild;
     const fill = rail?.querySelector('div');
 
-    expect(rail).toHaveClass('custom-class', 'bg-lightGrey');
+    expect(rail).toHaveClass('custom-class', 'bg-lightGrey', 'isolate');
     expect(fill).toHaveClass('bg-green');
     expect(fill).toHaveStyle({ width: '50%' });
   });
@@ -72,6 +72,29 @@ describe('ProgressBar', () => {
     expect(marks[0]).toHaveStyle({ left: '75%' });
     expect(marks[1]).toHaveClass('bg-white');
     expect(marks[1]).toHaveStyle({ left: '25%' });
+  });
+
+  it('renders marks after the fills in DOM order', () => {
+    const { container } = render(
+      <ProgressBar progressBars={[{ value: 90 }]} marks={[{ value: 75 }]} min={0} max={100} />,
+    );
+
+    const railChildren = Array.from(container.firstElementChild?.children ?? []);
+
+    expect(railChildren.map(child => child.tagName)).toEqual(['DIV', 'SPAN']);
+  });
+
+  it('does not apply a z-index to marks', () => {
+    const { container } = render(
+      <ProgressBar progressBars={[{ value: 90 }]} marks={[{ value: 75 }]} min={0} max={100} />,
+    );
+
+    // Marks paint above the fills through DOM order alone. A z-index on them used to escape the
+    // rail and render them on top of overlays sharing the rail's stacking context, such as the
+    // token list dropdown of a market form.
+    const mark = container.querySelector('span');
+
+    expect(Array.from(mark?.classList ?? []).some(name => /^-?z-/.test(name))).toBe(false);
   });
 
   it('wraps the rail in a tooltip when content is provided', () => {

--- a/apps/evm/src/components/ProgressBar/index.tsx
+++ b/apps/evm/src/components/ProgressBar/index.tsx
@@ -31,7 +31,14 @@ export const ProgressBar = ({
   className,
 }: ProgressBarProps) => {
   const dom = (
-    <div className={cn('relative h-2 w-full rounded-full overflow-hidden bg-lightGrey', className)}>
+    // isolate keeps the marks' stacking scoped to the rail, so they can never paint over overlays
+    // sharing the rail's stacking context, such as the token list dropdown of a market form
+    <div
+      className={cn(
+        'relative isolate h-2 w-full rounded-full overflow-hidden bg-lightGrey',
+        className,
+      )}
+    >
       {progressBars.map((progressBar, index) => {
         const valuePercentage = getProgressBarValuePercentage({
           value: progressBar.value,
@@ -55,7 +62,7 @@ export const ProgressBar = ({
           <span
             key={index}
             className={cn(
-              'absolute top-1/2 z-30 h-2 w-1 -translate-x-px -translate-y-1/2 rounded-sm bg-red',
+              'absolute top-1/2 h-2 w-1 -translate-x-px -translate-y-1/2 rounded-sm bg-red',
               mark.className,
             )}
             style={{ left: `${valuePercentage}%` }}


### PR DESCRIPTION
## Ticket

VENUS-269

## Changes

- Stop the account health bar marks from painting over overlays that share their stacking context, which made the two dots show through the asset selector dropdown in the Supply and Repay forms.
