### PR TITLE
fix: keep the multi-select option highlight within the menu border

### DIFF
--- a/apps/evm/src/components/MultiSelect/__tests__/index.spec.tsx
+++ b/apps/evm/src/components/MultiSelect/__tests__/index.spec.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, screen } from '@testing-library/react';
+
+import { renderComponent } from 'testUtils/render';
+
+import { MultiSelect } from '..';
+
+describe('MultiSelect', () => {
+  const options = [
+    { value: 'first', label: 'First option' },
+    { value: 'last', label: 'Last option' },
+  ];
+
+  const renderMultiSelect = () =>
+    renderComponent(
+      <MultiSelect
+        options={options}
+        value={[]}
+        onChange={vi.fn()}
+        placeholder="All options"
+        renderCount={count => `${count} options`}
+        title="Select options"
+        resetLabel="Reset"
+      />,
+    );
+
+  it('clips the options to the menu edge, so the highlight of the last option stays within its border', () => {
+    renderMultiSelect();
+
+    fireEvent.click(screen.getByRole('button', { name: 'All options' }));
+
+    // An open dropdown renders its options in both the desktop menu and the mobile modal;
+    // the desktop menu comes first, and is the element the accent border is passed to
+    const menu = screen.getAllByText('Last option')[0].closest('.border-blue');
+
+    expect(menu).toHaveClass('overflow-hidden');
+    expect(menu).not.toHaveClass('overflow-visible');
+  });
+});

--- a/apps/evm/src/components/MultiSelect/index.tsx
+++ b/apps/evm/src/components/MultiSelect/index.tsx
@@ -45,7 +45,9 @@ export const MultiSelect: React.FC<MultiSelectProps> = ({
     <Dropdown
       className={className}
       menuPosition="right"
-      menuClassName="bg-background border-blue"
+      // Clip the options to the menu's rounded corners, so the hover highlight of the last
+      // option does not bleed past the border
+      menuClassName="bg-background border-blue overflow-hidden"
       optionsDom={() => (
         <div className="min-w-full">
           <div className="flex h-12 items-center justify-between gap-3 px-4 py-3">


### PR DESCRIPTION
## Jira ticket(s)

VPD-1958

## Changes

- Clip the multi-select filter menu to its rounded border, so hovering the last option no longer paints grey past the blue edge
